### PR TITLE
Complete unfinished work

### DIFF
--- a/tests/unit/cli/connectors/claude-desktop/claude-desktop.connector.test.ts
+++ b/tests/unit/cli/connectors/claude-desktop/claude-desktop.connector.test.ts
@@ -11,24 +11,29 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ClaudeDesktopConnector } from '@cli/connectors/claude-desktop/claude-desktop.connector.js';
 import type { MCPServerConfig } from '@cli/connectors/base/connector.interface.js';
 import * as os from 'os';
 import * as path from 'path';
 
+// Hoisted моки - создаём ДО импорта модулей
+const { FileManager } = vi.hoisted(() => {
+  return {
+    FileManager: {
+      exists: vi.fn(),
+      readJSON: vi.fn(),
+      writeJSON: vi.fn(),
+      ensureDir: vi.fn(),
+    },
+  };
+});
+
 // Mock FileManager
 vi.mock('@cli/utils/file-manager.js', () => ({
-  FileManager: {
-    exists: vi.fn(),
-    readJSON: vi.fn(),
-    writeJSON: vi.fn(),
-    ensureDir: vi.fn(),
-  },
+  FileManager,
 }));
 
-// Импортируем FileManager после мока
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const { FileManager } = (await import('@cli/utils/file-manager.js')) as any;
+// Импортируем ПОСЛЕ определения моков
+import { ClaudeDesktopConnector } from '@cli/connectors/claude-desktop/claude-desktop.connector.js';
 
 describe('ClaudeDesktopConnector', () => {
   let connector: ClaudeDesktopConnector;

--- a/tests/unit/cli/connectors/codex/codex.connector.test.ts
+++ b/tests/unit/cli/connectors/codex/codex.connector.test.ts
@@ -11,34 +11,38 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { CodexConnector } from '@cli/connectors/codex/codex.connector.js';
 import type { MCPServerConfig } from '@cli/connectors/base/connector.interface.js';
 import { MCP_SERVER_NAME } from '@constants';
 import * as os from 'os';
 import * as path from 'path';
 
+// Hoisted моки - создаём ДО импорта модулей
+const { CommandExecutor, FileManager } = vi.hoisted(() => {
+  return {
+    CommandExecutor: {
+      isCommandAvailable: vi.fn(),
+      execInteractive: vi.fn(),
+    },
+    FileManager: {
+      exists: vi.fn(),
+      readTOML: vi.fn(),
+      writeTOML: vi.fn(),
+    },
+  };
+});
+
 // Mock CommandExecutor
 vi.mock('@cli/utils/command-executor.js', () => ({
-  CommandExecutor: {
-    isCommandAvailable: vi.fn(),
-    execInteractive: vi.fn(),
-  },
+  CommandExecutor,
 }));
 
 // Mock FileManager
 vi.mock('@cli/utils/file-manager.js', () => ({
-  FileManager: {
-    exists: vi.fn(),
-    readTOML: vi.fn(),
-    writeTOML: vi.fn(),
-  },
+  FileManager,
 }));
 
-// Импортируем после моков
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const { CommandExecutor } = (await import('@cli/utils/command-executor.js')) as any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const { FileManager } = (await import('@cli/utils/file-manager.js')) as any;
+// Импортируем ПОСЛЕ определения моков
+import { CodexConnector } from '@cli/connectors/codex/codex.connector.js';
 
 describe('CodexConnector', () => {
   let connector: CodexConnector;

--- a/tests/unit/cli/connectors/registry.test.ts
+++ b/tests/unit/cli/connectors/registry.test.ts
@@ -11,28 +11,38 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ConnectorRegistry } from '@cli/connectors/registry.js';
 import type { MCPConnector } from '@cli/connectors/base/connector.interface.js';
+
+// Hoisted моки - создаём ДО импорта модулей
+const { CommandExecutor, FileManager } = vi.hoisted(() => {
+  return {
+    CommandExecutor: {
+      isCommandAvailable: vi.fn().mockReturnValue(false),
+      exec: vi.fn(),
+      execInteractive: vi.fn(),
+    },
+    FileManager: {
+      exists: vi.fn().mockResolvedValue(false),
+      readJSON: vi.fn(),
+      writeJSON: vi.fn(),
+      readTOML: vi.fn(),
+      writeTOML: vi.fn(),
+      ensureDir: vi.fn(),
+    },
+  };
+});
 
 // Mock зависимостей коннекторов
 vi.mock('@cli/utils/command-executor.js', () => ({
-  CommandExecutor: {
-    isCommandAvailable: vi.fn().mockReturnValue(false),
-    exec: vi.fn(),
-    execInteractive: vi.fn(),
-  },
+  CommandExecutor,
 }));
 
 vi.mock('@cli/utils/file-manager.js', () => ({
-  FileManager: {
-    exists: vi.fn().mockResolvedValue(false),
-    readJSON: vi.fn(),
-    writeJSON: vi.fn(),
-    readTOML: vi.fn(),
-    writeTOML: vi.fn(),
-    ensureDir: vi.fn(),
-  },
+  FileManager,
 }));
+
+// Импортируем ПОСЛЕ определения моков
+import { ConnectorRegistry } from '@cli/connectors/registry.js';
 
 describe('ConnectorRegistry', () => {
   let registry: ConnectorRegistry;


### PR DESCRIPTION
Изменения:
- Исправлены 11 падающих unit тестов CLI коннекторов через vi.hoisted()
- Все 715 unit тестов теперь проходят (было 704/715)
- Улучшен MockServer: добавлен nock.activate(), nock.restore(), debugging
- Исследована проблема с nock в интеграционных тестах
- Обновлён continuation-prompt.md с выводами и рекомендациями

Детали:

**Unit тесты (FIX):**
- tests/unit/cli/connectors/codex/codex.connector.test.ts
  * Используем vi.hoisted() для CommandExecutor и FileManager моков
  * Импортируем CodexConnector ПОСЛЕ определения моков
  * Фиксит проблему с ESM module hoisting в Vitest

- tests/unit/cli/connectors/registry.test.ts
  * То же самое: vi.hoisted() для правильного мокирования
  * Теперь CommandExecutor.isCommandAvailable корректно мокируется

- tests/unit/cli/connectors/claude-desktop/claude-desktop.connector.test.ts
  * Аналогичный фикс для FileManager моков

**Интеграционные тесты (INVESTIGATION):**
- tests/integration/helpers/mock-server.ts
  * Добавлен nock.activate() для восстановления патчей
  * Добавлен nock.restore() в cleanup()
  * Добавлена проверка pending mocks для debugging
  * Попытка с явным портом :443
  * ВЫВОД: nock фундаментально несовместим с Vitest ESM + forks

**Документация:**
- continuation-prompt.md
  * Добавлена секция про фикс unit тестов
  * Детальная диагностика проблемы с nock
  * Рекомендация: использовать axios-mock-adapter (~2 часа)
  * Добавлена секция про тестовую изоляцию и shuffle mode

Причины:
- Nock патчит нативные HTTP модули, но в Vitest ESM + worker threads эти патчи НЕ применяются к axios adapter
- Axios instance создаётся ДО активации nock
- vitest.config.ts: shuffle=true + isolate=false = глобальное состояние

Преимущества:
- ✅ Все unit тесты проходят (715/715)
- ✅ TypeScript без ошибок
- ✅ Чёткий план для исправления интеграционных тестов

🤖 Generated with Claude Code