### PR TITLE
Review MCP server logs

### DIFF
--- a/packages/framework/core/src/tool-registry.ts
+++ b/packages/framework/core/src/tool-registry.ts
@@ -80,6 +80,25 @@ export class ToolRegistry {
   }
 
   /**
+   * Добавить дополнительный инструмент из контейнера
+   *
+   * Используется для регистрации инструментов с нестандартными зависимостями
+   * (например, SearchToolsTool с зависимостью от SearchEngine)
+   *
+   * @param symbolKey - Строковый ключ для Symbol.for() или Symbol
+   */
+  public registerToolFromContainer(symbolKey: string | symbol): void {
+    // ВАЖНО: Сначала инициализируем все стандартные tools
+    // Иначе создание this.tools здесь заблокирует ensureInitialized()
+    this.ensureInitialized();
+
+    const symbol = typeof symbolKey === 'string' ? Symbol.for(symbolKey) : symbolKey;
+    const tool = this.container.get<BaseTool>(symbol);
+
+    this.registerTool(tool);
+  }
+
+  /**
    * Получить определения всех зарегистрированных инструментов
    */
   getDefinitions(): ToolDefinition[] {

--- a/packages/servers/yandex-tracker/tests/composition-root/container.test.ts
+++ b/packages/servers/yandex-tracker/tests/composition-root/container.test.ts
@@ -186,6 +186,21 @@ describe('Container', () => {
       expect(tool).toHaveProperty('getDefinition');
     });
 
+    it('SearchToolsTool должен быть зарегистрирован в ToolRegistry', () => {
+      const registry = container.get<ToolRegistry>(TYPES.ToolRegistry);
+      const definitions = registry.getDefinitions();
+
+      // Проверяем, что SearchToolsTool присутствует в списке
+      const searchToolDefinition = definitions.find((def) => def.name === 'search_tools');
+      expect(searchToolDefinition).toBeDefined();
+      expect(searchToolDefinition?.description).toContain('Поиск доступных MCP инструментов');
+
+      // Проверяем, что можно получить tool через getTool
+      const searchTool = registry.getTool('search_tools');
+      expect(searchTool).toBeDefined();
+      expect(searchTool?.getDefinition().name).toBe('search_tools');
+    });
+
     it('должен resolve ToolSearchEngine', () => {
       const searchEngine = container.get(TYPES.ToolSearchEngine);
       expect(searchEngine).toBeDefined();


### PR DESCRIPTION
Проблема:
- SearchToolsTool не регистрировался в ToolRegistry при запуске сервера
- Сервер падал с ошибкой "No bindings found for service: Symbol(_SearchToolsTool)"
- Причина: циклическая зависимость между ToolRegistry, SearchEngine и SearchToolsTool

Решение:
1. Разорвана циклическая зависимость:
   - ToolRegistry создаётся БЕЗ SearchToolsTool
   - SearchEngine создаётся с ToolRegistry
   - SearchToolsTool создаётся с SearchEngine
   - SearchToolsTool добавляется в ToolRegistry через registerToolFromContainer()

2. Исправлен ToolRegistry.registerToolFromContainer():
   - Теперь вызывает ensureInitialized() ПЕРЕД добавлением инструмента
   - Предотвращает блокировку инициализации стандартных tools

3. Использование строкового ключа вместо класса:
   - TypeScript/tsup переименовывает класс в _SearchToolsTool при компиляции
   - Используем жёстко закодированную строку "SearchToolsTool" для Symbol.for()

4. Улучшен smoke test:
   - Исправлен путь к бандлу (.cjs вместо .js)
   - Добавлена проверка минимального количества инструментов (>=10)
   - Добавлена проверка наличия критических инструментов (ping, search_tools)

5. Добавлен unit тест для проверки регистрации SearchToolsTool в ToolRegistry

Тесты:
- Все unit тесты проходят (529/529)
- Smoke test проходит успешно (11 инструментов найдено)
- TypeScript typecheck без ошибок

🤖 Generated with Claude Code