### PR TITLE
Add tool name prefixes to MCP server

### DIFF
--- a/packages/servers/yandex-tracker/README.md
+++ b/packages/servers/yandex-tracker/README.md
@@ -104,7 +104,7 @@ npm run build
 ```
 Найди все критичные баги в проекте MOBILE
 ```
-Claude использует `yandex_tracker_find_issues` с JQL: `project = MOBILE AND type = Bug AND priority = Critical`
+Claude использует `fr_yandex_tracker_find_issues` с JQL: `project = MOBILE AND type = Bug AND priority = Critical`
 
 ### Анализ задач
 ```
@@ -190,13 +190,13 @@ Claude использует `yandex_tracker_find_issues` с JQL: `project = MOBI
 
 ### Опасные операции
 Инструменты, которые **изменяют данные** (создание, обновление, удаление), требуют явного подтверждения от пользователя. Claude спросит разрешение перед выполнением:
-- `yandex_tracker_create_issue` — создание задачи
-- `yandex_tracker_update_issue` — обновление задачи
-- `yandex_tracker_link_issues` — связывание задач
-- `yandex_tracker_add_comment` — добавление комментария
+- `fr_yandex_tracker_create_issue` — создание задачи
+- `fr_yandex_tracker_update_issue` — обновление задачи
+- `fr_yandex_tracker_link_issues` — связывание задач
+- `fr_yandex_tracker_add_comment` — добавление комментария
 
 **Только чтение** (безопасно, без подтверждения):
-- `yandex_tracker_ping`, `yandex_tracker_get_issues`, `yandex_tracker_find_issues`, `yandex_tracker_get_issue_url`, `yandex_tracker_search_tools`
+- `fr_yandex_tracker_ping`, `fr_yandex_tracker_get_issues`, `fr_yandex_tracker_find_issues`, `fr_yandex_tracker_get_issue_url`, `fr_yandex_tracker_search_tools`
 
 ---
 

--- a/packages/servers/yandex-tracker/src/constants.ts
+++ b/packages/servers/yandex-tracker/src/constants.ts
@@ -17,9 +17,9 @@ export const MCP_SERVER_NAME = PROJECT_BASE_NAME;
 
 /**
  * Префикс для названий MCP инструментов
- * @example "fractalizer_mcp_yandex_tracker_get_issues"
+ * @example "fr_yandex_tracker_get_issues"
  */
-export const MCP_TOOL_PREFIX = `${PROJECT_BASE_NAME}_` as const;
+export const MCP_TOOL_PREFIX = 'fr_yandex_tracker_' as const;
 
 /**
  * Отображаемое название MCP сервера

--- a/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.definition.ts
@@ -9,7 +9,9 @@ import {
 } from '@mcp-framework/core';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 import { GetIssueChangelogTool } from './get-issue-changelog.tool.js';
+
 /**
  * Definition для GetIssueChangelogTool
  *
@@ -26,7 +28,7 @@ export class GetIssueChangelogDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('get_issue_changelog'),
+      name: buildToolName('get_issue_changelog', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.tool.ts
@@ -17,6 +17,8 @@ import { GetIssueChangelogDefinition } from '@tools/api/issues/changelog/get-iss
 import { GetIssueChangelogParamsSchema } from '@tools/api/issues/changelog/get-issue-changelog.schema.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
 /**
  * Инструмент для получения истории изменений задачи
  *
@@ -37,7 +39,7 @@ export class GetIssueChangelogTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('get_issue_changelog'),
+    name: buildToolName('get_issue_changelog', MCP_TOOL_PREFIX),
     description: 'Получить историю изменений задачи',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'changelog', 'history', 'read'],

--- a/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.definition.ts
@@ -9,6 +9,7 @@ import {
 } from '@mcp-framework/core';
 import { CreateIssueTool } from './create-issue.tool.js';
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 
 /**
  * Definition для CreateIssueTool
@@ -26,7 +27,7 @@ export class CreateIssueDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('create_issue'),
+      name: buildToolName('create_issue', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.tool.ts
@@ -17,6 +17,7 @@ import type { CreateIssueDto } from '@tracker_api/dto/index.js';
 import { CreateIssueDefinition } from '@tools/api/issues/create/create-issue.definition.js';
 import { CreateIssueParamsSchema } from '@tools/api/issues/create/create-issue.schema.js';
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 
 /**
  * Инструмент для создания новой задачи
@@ -35,7 +36,7 @@ export class CreateIssueTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('create_issue'),
+    name: buildToolName('create_issue', MCP_TOOL_PREFIX),
     description: 'Создать новую задачу в Яндекс.Трекере',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'create', 'write'],

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
@@ -10,6 +10,7 @@ import {
 
 import { buildToolName } from '@mcp-framework/core';
 import { FindIssuesTool } from './find-issues.tool.js';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 /**
  * Definition для FindIssuesTool
  *
@@ -26,7 +27,7 @@ export class FindIssuesDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('find_issues'),
+      name: buildToolName('find_issues', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.tool.ts
@@ -17,6 +17,7 @@ import { FindIssuesDefinition } from '@tools/api/issues/find/find-issues.definit
 import { FindIssuesParamsSchema } from '@tools/api/issues/find/find-issues.schema.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 /**
  * Инструмент для поиска задач
  *
@@ -36,7 +37,7 @@ export class FindIssuesTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('find_issues'),
+    name: buildToolName('find_issues', MCP_TOOL_PREFIX),
     description: 'Найти задачи по JQL запросу',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'find', 'search', 'jql', 'query'],

--- a/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.definition.ts
@@ -9,6 +9,7 @@ import {
 } from '@mcp-framework/core';
 import { buildToolName } from '@mcp-framework/core';
 import { GetIssuesTool } from './get-issues.tool.js';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 /**
  * Definition для GetIssuesTool
  *
@@ -25,7 +26,7 @@ export class GetIssuesDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('get_issues'),
+      name: buildToolName('get_issues', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.tool.ts
@@ -17,6 +17,7 @@ import { GetIssuesDefinition } from '@tools/api/issues/get/get-issues.definition
 import { GetIssuesParamsSchema } from '@tools/api/issues/get/get-issues.schema.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
 /**
  * Инструмент для получения информации о задачах
  *
@@ -37,7 +38,7 @@ export class GetIssuesTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('get_issues'),
+    name: buildToolName('get_issues', MCP_TOOL_PREFIX),
     description: 'Получить задачи по ключам (batch операция)',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'get', 'batch', 'read'],

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.definition.ts
@@ -9,6 +9,7 @@ import {
 } from '@mcp-framework/core';
 import { TransitionIssueTool } from './transition-issue.tool.js';
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
 
 /**
  * Definition для TransitionIssueTool
@@ -26,7 +27,7 @@ export class TransitionIssueDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('transition_issue'),
+      name: buildToolName('transition_issue', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.tool.ts
@@ -17,6 +17,7 @@ import type { ExecuteTransitionDto } from '@tracker_api/dto/index.js';
 import { TransitionIssueDefinition } from '@tools/api/issues/transitions/execute/transition-issue.definition.js';
 import { TransitionIssueParamsSchema } from '@tools/api/issues/transitions/execute/transition-issue.schema.js';
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
 
 /**
  * Инструмент для выполнения перехода задачи в другой статус
@@ -38,7 +39,7 @@ export class TransitionIssueTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('transition_issue'),
+    name: buildToolName('transition_issue', MCP_TOOL_PREFIX),
     description: 'Выполнить переход задачи в другой статус',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'transition', 'workflow', 'write'],

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.definition.ts
@@ -9,7 +9,9 @@ import {
 } from '@mcp-framework/core';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
 import { GetIssueTransitionsTool } from './get-issue-transitions.tool.js';
+
 /**
  * Definition для GetIssueTransitionsTool
  *
@@ -26,7 +28,7 @@ export class GetIssueTransitionsDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('get_issue_transitions'),
+      name: buildToolName('get_issue_transitions', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.tool.ts
@@ -17,6 +17,8 @@ import { GetIssueTransitionsDefinition } from '@tools/api/issues/transitions/get
 import { GetIssueTransitionsParamsSchema } from '@tools/api/issues/transitions/get/get-issue-transitions.schema.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
 /**
  * Инструмент для получения доступных переходов статусов задачи
  *
@@ -37,7 +39,7 @@ export class GetIssueTransitionsTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('get_issue_transitions'),
+    name: buildToolName('get_issue_transitions', MCP_TOOL_PREFIX),
     description: 'Получить доступные переходы статусов задачи',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'transitions', 'workflow', 'read'],

--- a/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.definition.ts
@@ -10,6 +10,8 @@ import {
 import { UpdateIssueTool } from './update-issue.tool.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
 /**
  * Definition для UpdateIssueTool
  *
@@ -26,7 +28,7 @@ export class UpdateIssueDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('update_issue'),
+      name: buildToolName('update_issue', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.tool.ts
@@ -18,6 +18,8 @@ import { UpdateIssueDefinition } from '@tools/api/issues/update/update-issue.def
 import { UpdateIssueParamsSchema } from '@tools/api/issues/update/update-issue.schema.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
 /**
  * Инструмент для обновления задачи
  *
@@ -37,7 +39,7 @@ export class UpdateIssueTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('update_issue'),
+    name: buildToolName('update_issue', MCP_TOOL_PREFIX),
     description: 'Обновить существующую задачу в Яндекс.Трекере',
     category: ToolCategory.ISSUES,
     tags: ['issue', 'update', 'write'],

--- a/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.definition.ts
@@ -5,8 +5,9 @@
  */
 
 import type { ToolDefinition, StaticToolMetadata } from '@mcp-framework/core';
-import { BaseToolDefinition } from '@mcp-framework/core';
+import { BaseToolDefinition, buildToolName } from '@mcp-framework/core';
 import { DemoTool } from './demo.tool.js';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
 
 export class DemoDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
@@ -15,7 +16,7 @@ export class DemoDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: 'demo',
+      name: buildToolName('demo', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(
         'Демонстрационный инструмент для проверки масштабируемости архитектуры'
       ),

--- a/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.tool.ts
@@ -16,12 +16,14 @@ import { DemoDefinition } from './demo.definition.js';
 import { DemoParamsSchema } from './demo.schema.js';
 
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
 export class DemoTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('demo'),
+    name: buildToolName('demo', MCP_TOOL_PREFIX),
     description: 'Демонстрационный инструмент для тестирования',
     category: ToolCategory.DEMO,
     tags: ['demo', 'example', 'test'],

--- a/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.definition.ts
@@ -8,6 +8,7 @@ import {
   type StaticToolMetadata,
 } from '@mcp-framework/core';
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
 import { IssueUrlTool } from './issue-url.tool.js';
 
 /**
@@ -25,7 +26,7 @@ export class IssueUrlDefinition extends BaseToolDefinition {
 
   build(): ToolDefinition {
     return {
-      name: buildToolName('get_issue_urls'),
+      name: buildToolName('get_issue_urls', MCP_TOOL_PREFIX),
       description: this.wrapWithSafetyWarning(this.buildDescription()),
       inputSchema: {
         type: 'object',

--- a/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.tool.ts
@@ -15,6 +15,7 @@ import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { IssueUrlDefinition } from '@tools/helpers/issue-url/issue-url.definition.js';
 import { IssueUrlParamsSchema } from '@tools/helpers/issue-url/issue-url.schema.js';
 import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
 
 /**
  * Инструмент для получения URL задач
@@ -31,7 +32,7 @@ export class IssueUrlTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('get_issue_urls'),
+    name: buildToolName('get_issue_urls', MCP_TOOL_PREFIX),
     description: 'Получить URL задач в Яндекс.Трекере',
     category: ToolCategory.URL_GENERATION,
     tags: ['url', 'link', 'helper', 'issue', 'batch'],

--- a/packages/servers/yandex-tracker/src/tools/ping.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/ping.tool.ts
@@ -11,6 +11,7 @@ import { BaseTool, ToolCategory, buildToolName } from '@mcp-framework/core';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
+import { MCP_TOOL_PREFIX } from '../constants.js';
 
 /**
  * Ping инструмент для диагностики подключения
@@ -20,7 +21,7 @@ export class PingTool extends BaseTool<YandexTrackerFacade> {
    * Статические метаданные для compile-time индексации
    */
   static override readonly METADATA = {
-    name: buildToolName('ping'),
+    name: buildToolName('ping', MCP_TOOL_PREFIX),
     description:
       'Проверка доступности API Яндекс.Трекера и валидности OAuth токена. Возвращает информацию о текущем пользователе. Не требует параметров.',
     category: ToolCategory.USERS,
@@ -33,7 +34,7 @@ export class PingTool extends BaseTool<YandexTrackerFacade> {
    */
   override getDefinition(): ToolDefinition {
     return {
-      name: buildToolName('ping'),
+      name: buildToolName('ping', MCP_TOOL_PREFIX),
       description:
         'Проверка доступности API Яндекс.Трекера и валидности OAuth токена. ' +
         'Возвращает информацию о текущем пользователе. ' +

--- a/packages/servers/yandex-tracker/tests/helpers/workflow-client.ts
+++ b/packages/servers/yandex-tracker/tests/helpers/workflow-client.ts
@@ -1,5 +1,7 @@
 // tests/e2e/helpers/workflow-client.ts
 import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 /**
  * Helper для E2E workflows с автоматическим извлечением данных
@@ -16,7 +18,10 @@ export class WorkflowClient {
     summary: string;
     description?: string;
   }): Promise<string> {
-    const result = await this.client.callTool('create_issue', params);
+    const result = await this.client.callTool(
+      buildToolName('create_issue', MCP_TOOL_PREFIX),
+      params
+    );
 
     if (result.isError) {
       throw new Error(`Failed to create issue: ${result.content[0]?.text}`);
@@ -30,7 +35,7 @@ export class WorkflowClient {
    * Получить задачу по ключу
    */
   async getIssue(issueKey: string): Promise<unknown> {
-    const result = await this.client.callTool('get_issues', {
+    const result = await this.client.callTool(buildToolName('get_issues', MCP_TOOL_PREFIX), {
       issueKeys: [issueKey],
     });
 
@@ -46,7 +51,7 @@ export class WorkflowClient {
    * Обновить задачу
    */
   async updateIssue(issueKey: string, updates: Record<string, unknown>): Promise<void> {
-    const result = await this.client.callTool('update_issue', {
+    const result = await this.client.callTool(buildToolName('update_issue', MCP_TOOL_PREFIX), {
       issueKey,
       ...updates,
     });
@@ -60,7 +65,7 @@ export class WorkflowClient {
    * Перевести задачу в новый статус
    */
   async transitionIssue(issueKey: string, transitionId: string): Promise<void> {
-    const result = await this.client.callTool('transition_issue', {
+    const result = await this.client.callTool(buildToolName('transition_issue', MCP_TOOL_PREFIX), {
       issueKey,
       transitionId,
     });
@@ -74,7 +79,7 @@ export class WorkflowClient {
    * Найти задачи по query
    */
   async findIssues(query: string): Promise<unknown[]> {
-    const result = await this.client.callTool('find_issues', {
+    const result = await this.client.callTool(buildToolName('find_issues', MCP_TOOL_PREFIX), {
       query,
     });
 
@@ -90,7 +95,12 @@ export class WorkflowClient {
    * Получить changelog задачи
    */
   async getChangelog(issueKey: string): Promise<unknown[]> {
-    const result = await this.client.callTool('get_issue_changelog', { issueKey });
+    const result = await this.client.callTool(
+      buildToolName('get_issue_changelog', MCP_TOOL_PREFIX),
+      {
+        issueKey,
+      }
+    );
 
     if (result.isError) {
       throw new Error(`Failed to get changelog: ${result.content[0]?.text}`);
@@ -104,7 +114,10 @@ export class WorkflowClient {
    * Получить доступные transitions для задачи
    */
   async getTransitions(issueKey: string): Promise<unknown[]> {
-    const result = await this.client.callTool('get_issue_transitions', { issueKey });
+    const result = await this.client.callTool(
+      buildToolName('get_issue_transitions', MCP_TOOL_PREFIX),
+      { issueKey }
+    );
 
     if (result.isError) {
       throw new Error(`Failed to get transitions: ${result.content[0]?.text}`);

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/changelog/get-issue-changelog.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/changelog/get-issue-changelog.tool.integration.test.ts
@@ -24,7 +24,7 @@ describe('get-issue-changelog integration tests', () => {
     mockServer.mockGetChangelogSuccess(issueKey);
 
     // Act
-    const result = await client.callTool('get_issue_changelog', {
+    const result = await client.callTool('fr_yandex_tracker_get_issue_changelog', {
       issueKey,
     });
 
@@ -47,7 +47,7 @@ describe('get-issue-changelog integration tests', () => {
     mockServer.mockGetChangelog404(issueKey);
 
     // Act
-    const result = await client.callTool('get_issue_changelog', {
+    const result = await client.callTool('fr_yandex_tracker_get_issue_changelog', {
       issueKey,
     });
 
@@ -62,7 +62,7 @@ describe('get-issue-changelog integration tests', () => {
     mockServer.mockGetChangelogSuccess(issueKey);
 
     // Act
-    const result = await client.callTool('get_issue_changelog', {
+    const result = await client.callTool('fr_yandex_tracker_get_issue_changelog', {
       issueKey,
       fields: ['id', 'updatedAt', 'updatedBy'],
     });

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/create/create-issue.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/create/create-issue.tool.integration.test.ts
@@ -27,7 +27,7 @@ describe('create-issue integration tests', () => {
     });
 
     // Act
-    const result = await client.callTool('create_issue', {
+    const result = await client.callTool('fr_yandex_tracker_create_issue', {
       queue: 'TEST',
       summary: 'Test issue',
     });
@@ -55,7 +55,7 @@ describe('create-issue integration tests', () => {
     mockServer.mockCreateIssueSuccess(issueData);
 
     // Act
-    const result = await client.callTool('create_issue', {
+    const result = await client.callTool('fr_yandex_tracker_create_issue', {
       queue: 'TEST',
       summary: 'Full issue',
       description: 'Detailed description',
@@ -76,7 +76,7 @@ describe('create-issue integration tests', () => {
     mockServer.mockCreateIssue403();
 
     // Act
-    const result = await client.callTool('create_issue', {
+    const result = await client.callTool('fr_yandex_tracker_create_issue', {
       queue: 'TEST',
       summary: 'Test',
     });
@@ -95,7 +95,7 @@ describe('create-issue integration tests', () => {
     });
 
     // Act
-    const result = await client.callTool('create_issue', {
+    const result = await client.callTool('fr_yandex_tracker_create_issue', {
       queue: 'TEST',
       summary: 'Filtered issue',
       fields: ['key', 'summary'],

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/find/find-issues.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/find/find-issues.tool.integration.test.ts
@@ -40,7 +40,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         keys: issueKeys,
       });
 
@@ -75,7 +75,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query,
       });
 
@@ -102,7 +102,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         queue,
       });
 
@@ -133,7 +133,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         filter,
       });
 
@@ -161,7 +161,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'Author: me()',
         perPage: 2,
         page: 1,
@@ -190,7 +190,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'Author: me()',
         order,
       });
@@ -216,7 +216,7 @@ describe('find-issues integration tests', () => {
       mockServer.mockFindIssuesSuccess(issueKeys);
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         keys: issueKeys,
         fields,
       });
@@ -253,7 +253,7 @@ describe('find-issues integration tests', () => {
       mockServer.mockFindIssuesSuccess(issueKeys);
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         keys: issueKeys,
         fields,
       });
@@ -284,7 +284,7 @@ describe('find-issues integration tests', () => {
       mockServer.mockFindIssuesError400();
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'invalid JQL syntax',
       });
 
@@ -302,7 +302,7 @@ describe('find-issues integration tests', () => {
       mockServer.mockFindIssuesEmpty();
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'nonexistent task',
       });
 
@@ -322,7 +322,7 @@ describe('find-issues integration tests', () => {
   describe('Validation', () => {
     it('должен вернуть ошибку если не указан ни один параметр поиска', async () => {
       // Act
-      const result = await client.callTool('find_issues', {});
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {});
 
       // Assert
       expect(result.isError).toBe(true);
@@ -334,7 +334,7 @@ describe('find-issues integration tests', () => {
 
     it('должен вернуть ошибку для невалидного perPage (отрицательное число)', async () => {
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'test',
         perPage: -1,
       });
@@ -346,7 +346,7 @@ describe('find-issues integration tests', () => {
 
     it('должен вернуть ошибку для невалидного page (не целое число)', async () => {
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'test',
         page: 1.5,
       });
@@ -366,7 +366,7 @@ describe('find-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('find_issues', {
+      const result = await client.callTool('fr_yandex_tracker_find_issues', {
         query: 'Author: me()',
         perPage: 10,
         page: 1,

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/get/get-issues.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/get/get-issues.tool.integration.test.ts
@@ -37,7 +37,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssueSuccess(issueKey);
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [issueKey],
       });
 
@@ -81,7 +81,7 @@ describe('get-issues integration tests', () => {
       });
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys,
       });
 
@@ -118,7 +118,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssueSuccess(issueKey);
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [issueKey],
         fields,
       });
@@ -156,7 +156,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssueSuccess(issueKey);
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [issueKey],
         fields,
       });
@@ -188,7 +188,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssue404(issueKey);
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [issueKey],
       });
 
@@ -221,7 +221,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssue401(issueKey);
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [issueKey],
       });
 
@@ -243,7 +243,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssue403(issueKey);
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [issueKey],
       });
 
@@ -272,7 +272,7 @@ describe('get-issues integration tests', () => {
       mockServer.mockGetIssueSuccess('QUEUE-3');
 
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: ['QUEUE-1', 'QUEUE-2', 'QUEUE-3'],
       });
 
@@ -305,7 +305,7 @@ describe('get-issues integration tests', () => {
   describe('Validation', () => {
     it('должен вернуть ошибку при пустом массиве issueKeys', async () => {
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: [],
       });
 
@@ -316,7 +316,7 @@ describe('get-issues integration tests', () => {
 
     it('должен вернуть ошибку при невалидном формате ключа', async () => {
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: ['invalid-key'], // нет дефиса или формат не соответствует QUEUE-123
       });
 
@@ -327,7 +327,7 @@ describe('get-issues integration tests', () => {
 
     it('должен вернуть ошибку если issueKeys не массив', async () => {
       // Act
-      const result = await client.callTool('get_issues', {
+      const result = await client.callTool('fr_yandex_tracker_get_issues', {
         issueKeys: 'QUEUE-1', // строка вместо массива
       });
 

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/transition/transition-issue.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/transition/transition-issue.tool.integration.test.ts
@@ -25,7 +25,7 @@ describe('transition-issue integration tests', () => {
     mockServer.mockTransitionIssueSuccess(issueKey, transitionId);
 
     // Act
-    const result = await client.callTool('transition_issue', {
+    const result = await client.callTool('fr_yandex_tracker_transition_issue', {
       issueKey,
       transitionId,
     });
@@ -44,7 +44,7 @@ describe('transition-issue integration tests', () => {
     mockServer.mockTransitionIssueSuccess(issueKey, transitionId);
 
     // Act
-    const result = await client.callTool('transition_issue', {
+    const result = await client.callTool('fr_yandex_tracker_transition_issue', {
       issueKey,
       transitionId,
       comment: 'Closing as completed',
@@ -62,7 +62,7 @@ describe('transition-issue integration tests', () => {
     mockServer.mockTransitionIssue404(issueKey, transitionId);
 
     // Act
-    const result = await client.callTool('transition_issue', {
+    const result = await client.callTool('fr_yandex_tracker_transition_issue', {
       issueKey,
       transitionId,
     });
@@ -79,7 +79,7 @@ describe('transition-issue integration tests', () => {
     mockServer.mockTransitionIssueSuccess(issueKey, transitionId);
 
     // Act
-    const result = await client.callTool('transition_issue', {
+    const result = await client.callTool('fr_yandex_tracker_transition_issue', {
       issueKey,
       transitionId,
       fields: ['key', 'status'],

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/transitions/get-issue-transitions.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/transitions/get-issue-transitions.tool.integration.test.ts
@@ -24,7 +24,7 @@ describe('get-issue-transitions integration tests', () => {
     mockServer.mockGetTransitionsSuccess(issueKey);
 
     // Act
-    const result = await client.callTool('get_issue_transitions', {
+    const result = await client.callTool('fr_yandex_tracker_get_issue_transitions', {
       issueKey,
     });
 
@@ -47,7 +47,7 @@ describe('get-issue-transitions integration tests', () => {
     mockServer.mockGetTransitions404(issueKey);
 
     // Act
-    const result = await client.callTool('get_issue_transitions', {
+    const result = await client.callTool('fr_yandex_tracker_get_issue_transitions', {
       issueKey,
     });
 
@@ -62,7 +62,7 @@ describe('get-issue-transitions integration tests', () => {
     mockServer.mockGetTransitionsSuccess(issueKey);
 
     // Act
-    const result = await client.callTool('get_issue_transitions', {
+    const result = await client.callTool('fr_yandex_tracker_get_issue_transitions', {
       issueKey,
       fields: ['id', 'to'],
     });

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/update/update-issue.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/update/update-issue.tool.integration.test.ts
@@ -26,7 +26,7 @@ describe('update-issue integration tests', () => {
     });
 
     // Act
-    const result = await client.callTool('update_issue', {
+    const result = await client.callTool('fr_yandex_tracker_update_issue', {
       issueKey,
       summary: 'Updated summary',
     });
@@ -49,7 +49,7 @@ describe('update-issue integration tests', () => {
     });
 
     // Act
-    const result = await client.callTool('update_issue', {
+    const result = await client.callTool('fr_yandex_tracker_update_issue', {
       issueKey,
       summary: 'New summary',
       description: 'New description',
@@ -69,7 +69,7 @@ describe('update-issue integration tests', () => {
     mockServer.mockUpdateIssue404(issueKey);
 
     // Act
-    const result = await client.callTool('update_issue', {
+    const result = await client.callTool('fr_yandex_tracker_update_issue', {
       issueKey,
       summary: 'Test',
     });
@@ -85,7 +85,7 @@ describe('update-issue integration tests', () => {
     mockServer.mockUpdateIssueSuccess(issueKey, { summary: 'Updated' });
 
     // Act
-    const result = await client.callTool('update_issue', {
+    const result = await client.callTool('fr_yandex_tracker_update_issue', {
       issueKey,
       summary: 'Updated',
       fields: ['key', 'summary'],

--- a/packages/servers/yandex-tracker/tests/integration/tools/helpers/search/search-tools.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/helpers/search/search-tools.tool.integration.test.ts
@@ -11,6 +11,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestClient } from '@integration/helpers/mcp-client.js';
 import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('search-tools integration tests', () => {
   let client: TestMCPClient;
@@ -29,7 +31,7 @@ describe('search-tools integration tests', () => {
   describe('Happy Path', () => {
     it('должен успешно найти инструменты по простому query', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
       });
 
@@ -59,7 +61,7 @@ describe('search-tools integration tests', () => {
 
     it('должен найти tools по специфичному названию', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'get_issues',
         detailLevel: 'full',
       });
@@ -72,12 +74,12 @@ describe('search-tools integration tests', () => {
         const parsed = JSON.parse(content.text);
         expect(parsed.data.tools).toBeInstanceOf(Array);
 
-        // Должен найти fractalizer_mcp_yandex_tracker_get_issues
+        // Должен найти fr_yandex_tracker_get_issues
         const getIssuesTool = parsed.data.tools.find(
-          (t: { name: string }) => t.name === 'fractalizer_mcp_yandex_tracker_get_issues'
+          (t: { name: string }) => t.name === buildToolName('get_issues', MCP_TOOL_PREFIX)
         );
         expect(getIssuesTool).toBeDefined();
-        expect(getIssuesTool.name).toBe('fractalizer_mcp_yandex_tracker_get_issues');
+        expect(getIssuesTool.name).toBe(buildToolName('get_issues', MCP_TOOL_PREFIX));
         // inputSchema может быть undefined в интеграционных тестах (несовпадение имен в registry vs search index)
         expect(getIssuesTool.tags).toBeDefined(); // full detail level includes tags
       }
@@ -85,7 +87,7 @@ describe('search-tools integration tests', () => {
 
     it('должен применить лимит к результатам', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'yandex',
         limit: 2,
       });
@@ -104,7 +106,7 @@ describe('search-tools integration tests', () => {
 
     it('должен использовать default limit (10)', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'tracker',
       });
 
@@ -122,7 +124,7 @@ describe('search-tools integration tests', () => {
   describe('Уровни детализации', () => {
     it('name_only: должен вернуть только имена', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         detailLevel: 'name_only',
       });
@@ -144,7 +146,7 @@ describe('search-tools integration tests', () => {
 
     it('name_and_description: должен вернуть имя, описание, категорию', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         detailLevel: 'name_and_description',
       });
@@ -167,7 +169,7 @@ describe('search-tools integration tests', () => {
 
     it('full: должен загрузить полные метаданные', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         detailLevel: 'full',
       });
@@ -191,7 +193,7 @@ describe('search-tools integration tests', () => {
 
     it('default detailLevel = name_and_description', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
       });
 
@@ -211,7 +213,7 @@ describe('search-tools integration tests', () => {
   describe('Фильтрация', () => {
     it('должен фильтровать по категории ISSUES', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'yandex',
         category: 'issues',
       });
@@ -230,7 +232,7 @@ describe('search-tools integration tests', () => {
 
     it('должен фильтровать по типу (helper)', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'search',
         isHelper: true,
       });
@@ -243,7 +245,7 @@ describe('search-tools integration tests', () => {
         const parsed = JSON.parse(content.text);
         // fractalizer_mcp_yandex_tracker_search_tools должен быть helper
         const searchToolsTool = parsed.data.tools.find(
-          (t: { name: string }) => t.name === 'fractalizer_mcp_yandex_tracker_search_tools'
+          (t: { name: string }) => t.name === buildToolName('search_tools', MCP_TOOL_PREFIX)
         );
         expect(searchToolsTool).toBeDefined();
       }
@@ -251,7 +253,7 @@ describe('search-tools integration tests', () => {
 
     it('должен фильтровать по типу (API)', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         isHelper: false,
       });
@@ -265,14 +267,14 @@ describe('search-tools integration tests', () => {
         // Все результаты должны быть API tools
         parsed.data.tools.forEach((toolData: { name: string }) => {
           // fractalizer_mcp_yandex_tracker_search_tools не должен быть в результатах (он helper)
-          expect(toolData.name).not.toBe('fractalizer_mcp_yandex_tracker_search_tools');
+          expect(toolData.name).not.toBe(buildToolName('search_tools', MCP_TOOL_PREFIX));
         });
       }
     });
 
     it('должен комбинировать фильтры', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'yandex',
         category: 'issues',
         isHelper: false,
@@ -296,7 +298,7 @@ describe('search-tools integration tests', () => {
   describe('Валидация параметров', () => {
     it('должен вернуть ошибку для пустого query', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: '',
       });
 
@@ -313,7 +315,7 @@ describe('search-tools integration tests', () => {
 
     it('должен вернуть ошибку для невалидного detailLevel', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         detailLevel: 'invalid',
       });
@@ -329,7 +331,7 @@ describe('search-tools integration tests', () => {
 
     it('должен вернуть ошибку для невалидной категории', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         category: 'INVALID_CATEGORY',
       });
@@ -345,7 +347,7 @@ describe('search-tools integration tests', () => {
 
     it('должен вернуть ошибку для невалидного limit (негативное число)', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         limit: -5,
       });
@@ -361,7 +363,7 @@ describe('search-tools integration tests', () => {
 
     it('должен вернуть ошибку для невалидного limit (не целое число)', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         limit: 3.14,
       });
@@ -377,7 +379,7 @@ describe('search-tools integration tests', () => {
 
     it('должен принять валидные параметры', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
         detailLevel: 'full',
         category: 'issues',
@@ -393,7 +395,7 @@ describe('search-tools integration tests', () => {
   describe('Edge cases', () => {
     it('должен обработать query без совпадений', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'xyzqwertynonexistent999',
       });
 
@@ -414,7 +416,7 @@ describe('search-tools integration tests', () => {
     it('должен обработать очень длинный query', async () => {
       // Act
       const longQuery = 'a'.repeat(1000);
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: longQuery,
       });
 
@@ -430,7 +432,7 @@ describe('search-tools integration tests', () => {
 
     it('должен обработать специальные символы в query', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'tracker_',
       });
 
@@ -446,7 +448,7 @@ describe('search-tools integration tests', () => {
 
     it('должен обработать query с пробелами', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: '  issue  ',
       });
 
@@ -465,7 +467,7 @@ describe('search-tools integration tests', () => {
   describe('JSON формат ответа', () => {
     it('должен вернуть валидный JSON', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
       });
 
@@ -480,7 +482,7 @@ describe('search-tools integration tests', () => {
 
     it('должен включить все обязательные поля в ответ', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'issue',
       });
 
@@ -505,7 +507,7 @@ describe('search-tools integration tests', () => {
 
     it('totalFound должен быть >= returned', async () => {
       // Act
-      const result = await client.callTool('search_tools', {
+      const result = await client.callTool(buildToolName('search_tools', MCP_TOOL_PREFIX), {
         query: 'yandex',
         limit: 1,
       });

--- a/packages/servers/yandex-tracker/tests/mcp/tools/search-tools.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/mcp/tools/search-tools.tool.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { SearchToolsTool } from '@mcp-framework/search';
+import { SearchToolsTool, buildToolName } from '@mcp-framework/search';
 import { ToolSearchEngine } from '@mcp-framework/search/engine';
 import {
   WeightedCombinedStrategy,
@@ -26,6 +26,7 @@ import type { StaticToolIndex, StrategyType } from '@mcp-framework/search/types.
 import type { ToolRegistry } from '@mcp-framework/core/tool-registry.js';
 import type { BaseTool } from '@mcp-framework/core/tools/base/base-tool.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('SearchToolsTool (E2E)', () => {
   // Mock ToolRegistry
@@ -74,7 +75,7 @@ describe('SearchToolsTool (E2E)', () => {
 
   const mockIndex: StaticToolIndex[] = [
     {
-      name: 'fractalizer_mcp_yandex_tracker_ping',
+      name: buildToolName('ping', MCP_TOOL_PREFIX),
       category: ToolCategory.USERS,
       tags: ['ping', 'health', 'check'],
       isHelper: false,
@@ -83,7 +84,7 @@ describe('SearchToolsTool (E2E)', () => {
       descriptionShort: 'Проверка доступности API',
     },
     {
-      name: 'get_issues',
+      name: buildToolName('get_issues', MCP_TOOL_PREFIX),
       category: ToolCategory.ISSUES,
       tags: ['issue', 'get', 'batch'],
       isHelper: false,
@@ -92,7 +93,7 @@ describe('SearchToolsTool (E2E)', () => {
       descriptionShort: 'Получить задачи по ключам',
     },
     {
-      name: 'find_issues',
+      name: buildToolName('find_issues', MCP_TOOL_PREFIX),
       category: ToolCategory.ISSUES,
       tags: ['issue', 'find', 'search', 'jql'],
       isHelper: false,
@@ -101,7 +102,7 @@ describe('SearchToolsTool (E2E)', () => {
       descriptionShort: 'Найти задачи по JQL запросу',
     },
     {
-      name: 'search_tools',
+      name: buildToolName('search_tools', MCP_TOOL_PREFIX),
       category: ToolCategory.SEARCH,
       tags: ['search', 'tools', 'discovery'],
       isHelper: true,
@@ -164,7 +165,7 @@ describe('SearchToolsTool (E2E)', () => {
         expect(parsed.data.totalFound).toBeGreaterThan(0);
         expect(parsed.data.returned).toBeGreaterThan(0);
         expect(parsed.data.tools).toBeInstanceOf(Array);
-        expect(parsed.data.tools[0].name).toBe('fractalizer_mcp_yandex_tracker_ping');
+        expect(parsed.data.tools[0].name).toBe(buildToolName('ping', MCP_TOOL_PREFIX));
       }
     });
 
@@ -498,7 +499,7 @@ describe('SearchToolsTool (E2E)', () => {
   describe('METADATA', () => {
     it('должен содержать корректные статические метаданные', () => {
       expect(SearchToolsTool.METADATA).toBeDefined();
-      expect(SearchToolsTool.METADATA.name).toBe('search_tools');
+      expect(SearchToolsTool.METADATA.name).toBe(buildToolName('search_tools', MCP_TOOL_PREFIX));
       expect(SearchToolsTool.METADATA.category).toBe(ToolCategory.SEARCH);
       expect(SearchToolsTool.METADATA.isHelper).toBe(true);
       expect(SearchToolsTool.METADATA.tags).toContain('search');

--- a/packages/servers/yandex-tracker/tests/test-constants.ts
+++ b/packages/servers/yandex-tracker/tests/test-constants.ts
@@ -9,17 +9,17 @@ import { MCP_TOOL_PREFIX } from '../src/constants.js';
 
 /**
  * Префикс для названий инструментов в тестах
- * @example "fractalizer_mcp_yandex_tracker_"
+ * @example "fr_yandex_tracker_"
  */
 export const TEST_TOOL_PREFIX = MCP_TOOL_PREFIX;
 
 /**
  * Короткий префикс (без underscore) для тестов поиска
- * @example "fyt_mcp" или "fyt"
+ * @example "fr_yandex_tracker"
  */
-export const TEST_TOOL_PREFIX_SHORT = MCP_TOOL_PREFIX.slice(0, -1); // "fyt_mcp"
-export const TEST_TOOL_BRAND = 'fyt'; // Первая часть префикса
-export const TEST_TOOL_CATEGORY = 'mcp'; // Вторая часть префикса
+export const TEST_TOOL_PREFIX_SHORT = MCP_TOOL_PREFIX.slice(0, -1); // "fr_yandex_tracker"
+export const TEST_TOOL_BRAND = 'fr'; // Первая часть префикса
+export const TEST_TOOL_CATEGORY = 'yandex_tracker'; // Вторая часть префикса
 
 /**
  * Полные имена инструментов для тестов
@@ -30,5 +30,5 @@ export const TEST_TOOL_NAMES = {
   FIND_ISSUES: `${TEST_TOOL_PREFIX}find_issues`,
   ISSUE_GET_URL: `${TEST_TOOL_PREFIX}issue_get_url`,
   SEARCH_TOOLS: `${TEST_TOOL_PREFIX}search_tools`,
-  DEMO: 'demo', // Специальный инструмент без префикса
+  DEMO: `${TEST_TOOL_PREFIX}demo`,
 } as const;

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/changelog/get-issue-changelog.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/changelog/get-issue-changelog.tool.test.ts
@@ -7,6 +7,8 @@ import { GetIssueChangelogTool } from '@tools/api/issues/changelog/index.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { ChangelogEntryWithUnknownFields } from '@tracker_api/entities/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('GetIssueChangelogTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
@@ -80,7 +82,7 @@ describe('GetIssueChangelogTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('get_issue_changelog');
+      expect(definition.name).toBe(buildToolName('get_issue_changelog', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('историю изменений');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toEqual(['issueKey']);

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/create/create-issue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/create/create-issue.tool.test.ts
@@ -7,6 +7,8 @@ import { CreateIssueTool } from '@tools/api/issues/create/index.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('CreateIssueTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
@@ -57,7 +59,7 @@ describe('CreateIssueTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('create_issue');
+      expect(definition.name).toBe(buildToolName('create_issue', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('Создать новую задачу');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toEqual(['queue', 'summary']);

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/find/find-issues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/find/find-issues.tool.test.ts
@@ -7,6 +7,8 @@ import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
 import { FindIssuesTool } from '@tools/api/issues/find/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('FindIssuesTool', () => {
   let tool: FindIssuesTool;
@@ -332,7 +334,7 @@ describe('FindIssuesTool', () => {
   describe('METADATA', () => {
     it('должен иметь корректные статические метаданные', () => {
       expect(FindIssuesTool.METADATA).toBeDefined();
-      expect(FindIssuesTool.METADATA.name).toBe('find_issues');
+      expect(FindIssuesTool.METADATA.name).toBe(buildToolName('find_issues', MCP_TOOL_PREFIX));
       expect(FindIssuesTool.METADATA.description).toContain('Найти задачи');
       expect(FindIssuesTool.METADATA.category).toBe('issues');
       expect(FindIssuesTool.METADATA.tags).toContain('issue');

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/get/get-issues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/get/get-issues.tool.test.ts
@@ -7,6 +7,8 @@ import { GetIssuesTool } from '@tools/api/issues/get/index.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('GetIssuesTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
@@ -89,7 +91,7 @@ describe('GetIssuesTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('get_issues');
+      expect(definition.name).toBe(buildToolName('get_issues', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('Получение информации о задачах');
       expect(definition.description).toContain('Batch-режим');
       expect(definition.inputSchema.type).toBe('object');

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/transitions/execute/transition-issue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/transitions/execute/transition-issue.tool.test.ts
@@ -7,6 +7,8 @@ import { TransitionIssueTool } from '@tools/api/issues/transitions/execute/index
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('TransitionIssueTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
@@ -56,7 +58,7 @@ describe('TransitionIssueTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('transition_issue');
+      expect(definition.name).toBe(buildToolName('transition_issue', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('переход');
       expect(definition.description).toContain('статус');
       expect(definition.inputSchema.type).toBe('object');

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/transitions/get/get-issue-transitions.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/transitions/get/get-issue-transitions.tool.test.ts
@@ -7,6 +7,8 @@ import { GetIssueTransitionsTool } from '@tools/api/issues/transitions/get/index
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { TransitionWithUnknownFields } from '@tracker_api/entities/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('GetIssueTransitionsTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
@@ -54,7 +56,7 @@ describe('GetIssueTransitionsTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('get_issue_transitions');
+      expect(definition.name).toBe(buildToolName('get_issue_transitions', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('переход');
       expect(definition.description).toContain('статус');
       expect(definition.inputSchema.type).toBe('object');

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/update/update-issue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/update/update-issue.tool.test.ts
@@ -7,6 +7,8 @@ import { UpdateIssueTool } from '@tools/api/issues/update/index.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('UpdateIssueTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
@@ -57,7 +59,7 @@ describe('UpdateIssueTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('update_issue');
+      expect(definition.name).toBe(buildToolName('update_issue', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('Обнов');
       expect(definition.description).toContain('задач');
       expect(definition.inputSchema.type).toBe('object');

--- a/packages/servers/yandex-tracker/tests/tools/helpers/demo/demo.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/helpers/demo/demo.tool.test.ts
@@ -4,9 +4,10 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DemoTool } from '@tools/helpers/demo/demo.tool.js';
-import { ToolCategory } from '@mcp-framework/core';
+import { ToolCategory, buildToolName } from '@mcp-framework/core';
 import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('DemoTool', () => {
   let tool: DemoTool;
@@ -30,7 +31,7 @@ describe('DemoTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('demo');
+      expect(definition.name).toBe(buildToolName('demo', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('Демонстрационный');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toEqual(['message']);
@@ -175,7 +176,7 @@ describe('DemoTool', () => {
   describe('METADATA', () => {
     it('должен иметь статические метаданные', () => {
       expect(DemoTool.METADATA).toBeDefined();
-      expect(DemoTool.METADATA.name).toBe('demo');
+      expect(DemoTool.METADATA.name).toBe(buildToolName('demo', MCP_TOOL_PREFIX));
       expect(DemoTool.METADATA.description).toBe('Демонстрационный инструмент для тестирования');
       expect(DemoTool.METADATA.category).toBe(ToolCategory.DEMO);
       expect(DemoTool.METADATA.tags).toContain('demo');

--- a/packages/servers/yandex-tracker/tests/tools/helpers/issue-url/issue-url.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/helpers/issue-url/issue-url.tool.test.ts
@@ -4,9 +4,10 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { IssueUrlTool } from '@tools/helpers/issue-url/issue-url.tool.js';
-import { ToolCategory } from '@mcp-framework/core';
+import { ToolCategory, buildToolName } from '@mcp-framework/core';
 import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
 import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('IssueUrlTool', () => {
   let tool: IssueUrlTool;
@@ -30,7 +31,7 @@ describe('IssueUrlTool', () => {
     it('должен вернуть корректное определение инструмента', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.name).toBe('get_issue_urls');
+      expect(definition.name).toBe(buildToolName('get_issue_urls', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('URL');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toEqual(['issueKeys']);
@@ -180,7 +181,7 @@ describe('IssueUrlTool', () => {
   describe('METADATA', () => {
     it('должен иметь статические метаданные', () => {
       expect(IssueUrlTool.METADATA).toBeDefined();
-      expect(IssueUrlTool.METADATA.name).toBe('get_issue_urls');
+      expect(IssueUrlTool.METADATA.name).toBe(buildToolName('get_issue_urls', MCP_TOOL_PREFIX));
       expect(IssueUrlTool.METADATA.description).toBe('Получить URL задач в Яндекс.Трекере');
       expect(IssueUrlTool.METADATA.category).toBe(ToolCategory.URL_GENERATION);
       expect(IssueUrlTool.METADATA.tags).toContain('url');

--- a/packages/servers/yandex-tracker/tests/tools/ping.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/ping.tool.test.ts
@@ -4,6 +4,8 @@ import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.fac
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
 import type { ToolCallParams } from '@mcp-framework/infrastructure/types.js';
 import type { PingResult } from '@tracker_api/api_operations/user/ping.operation.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
 
 describe('PingTool', () => {
   let tool: PingTool;
@@ -39,7 +41,7 @@ describe('PingTool', () => {
       const definition = tool.getDefinition();
 
       // Assert
-      expect(definition.name).toBe('ping');
+      expect(definition.name).toBe(buildToolName('ping', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('API Яндекс.Трекера');
       expect(definition.description).toContain('OAuth токена');
       expect(definition.inputSchema.type).toBe('object');


### PR DESCRIPTION
Изменения:
- Обновлена константа MCP_TOOL_PREFIX с 'fractalizer_mcp_yandex_tracker_' на 'fr_yandex_tracker_'
- Добавлен префикс во все вызовы buildToolName() для инструментов (21 файл)
- Обновлены тестовые константы и все unit/integration тесты (23 файла)
- Обновлена документация с новыми именами инструментов

Преимущества:
- Предотвращение конфликтов имён при использовании нескольких MCP серверов
- Экономия токенов контекста (короткий префикс вместо длинного)
- Улучшение читаемости в UI Claude Desktop
- Следование best practices MCP naming conventions

Новые имена инструментов:
- ping → fr_yandex_tracker_ping
- get_issues → fr_yandex_tracker_get_issues
- find_issues → fr_yandex_tracker_find_issues
- create_issue → fr_yandex_tracker_create_issue
- update_issue → fr_yandex_tracker_update_issue
- и другие (всего 13 инструментов)

🤖 Generated with Claude Code