### PR TITLE
Auto-increment build number handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ dependency-graph.html
 jscpd-report/
 *.mcpb
 .mcpb-build/
+
+# Динамически генерируемые файлы (build hash обновляется при каждой сборке)
+manifest.json

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -90,12 +90,5 @@
   },
   "privacy_policies": [
     "https://yandex.ru/legal/confidential/"
-  ],
-  "_meta": {
-    "build": {
-      "number": 2,
-      "generated_by": "mcpb-build",
-      "last_updated": "2025-11-17"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Изменения:
- Обновлен скрипт increment-build.ts для использования git hash вместо автоинкремента
- manifest.json теперь генерируется из manifest.template.json при сборке
- manifest.json добавлен в .gitignore, чтобы избежать постоянных коммитов
- Build hash теперь соответствует короткому git hash (7 символов) текущего коммита
- Формат версии: {version}+{gitHash} (например, 0.1.0+a841dde)

Преимущества:
- Не требуется коммитить manifest.json после каждой сборки
- Build hash автоматически соответствует коду в репозитории
- Упрощает процесс разработки и CI/CD

🤖 Generated with Claude Code