### PR TITLE
Review repository documentation for accuracy

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -4,10 +4,12 @@
 
 ```
 packages/
-├── infrastructure/  # HTTP, cache, logging, async utilities
-├── core/           # BaseTool, registry, type system
-├── search/         # Tool Search Engine
-└── yandex-tracker/ # Yandex Tracker MCP Server
+├── framework/
+│   ├── infrastructure/  # HTTP, cache, logging, async utilities
+│   ├── core/           # BaseTool, registry, type system
+│   └── search/         # Tool Search Engine
+└── servers/
+    └── yandex-tracker/ # Yandex Tracker MCP Server
 ```
 
 ## Тесты

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ npm run depcruise  # Validates dependency graph
 
 **Key Principle:** Infrastructure does NOT know about domain (Yandex.Tracker, MCP)
 
-**Details:** [packages/infrastructure/README.md](packages/infrastructure/README.md)
+**Details:** [packages/framework/infrastructure/README.md](packages/framework/infrastructure/README.md)
 
 ### @mcp-framework/core
 
@@ -104,7 +104,7 @@ npm run depcruise  # Validates dependency graph
 
 **Key Principle:** Generic `BaseTool<TFacade>` — facade-agnostic design
 
-**Details:** [packages/core/README.md](packages/core/README.md)
+**Details:** [packages/framework/core/README.md](packages/framework/core/README.md)
 
 ### @mcp-framework/search
 
@@ -118,7 +118,7 @@ npm run depcruise  # Validates dependency graph
 
 **Key Principle:** Compile-time indexing (zero runtime overhead)
 
-**Details:** [packages/search/README.md](packages/search/README.md)
+**Details:** [packages/framework/search/README.md](packages/framework/search/README.md)
 
 ### mcp-server-yandex-tracker
 
@@ -270,7 +270,7 @@ const results = await executor.execute(
 
 **Result Type:** `BatchResult<T>` (discriminated union: fulfilled | rejected)
 
-**Details:** [packages/infrastructure/README.md](packages/infrastructure/README.md#parallel-execution)
+**Details:** [packages/framework/infrastructure/README.md](packages/framework/infrastructure/README.md#parallel-execution)
 
 ---
 
@@ -325,7 +325,7 @@ packages/servers/yandex-tracker/src/composition-root/
    - Max 100 entries
    - Key: `${query}_${strategy}`
 
-**Details:** [packages/search/README.md](packages/search/README.md)
+**Details:** [packages/framework/search/README.md](packages/framework/search/README.md)
 
 ---
 
@@ -500,9 +500,9 @@ npm run validate
 
 ### Framework Packages
 
-- **[packages/infrastructure/README.md](packages/infrastructure/README.md)** — Infrastructure API
-- **[packages/core/README.md](packages/core/README.md)** — Core API
-- **[packages/search/README.md](packages/search/README.md)** — Search system
+- **[packages/framework/infrastructure/README.md](packages/framework/infrastructure/README.md)** — Infrastructure API
+- **[packages/framework/core/README.md](packages/framework/core/README.md)** — Core API
+- **[packages/framework/search/README.md](packages/framework/search/README.md)** — Search system
 
 ### Yandex Tracker
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,9 @@ packages/
 ```
 
 **Детали:**
-- **Infrastructure** — [packages/infrastructure/README.md](packages/infrastructure/README.md)
-- **Core** — [packages/core/README.md](packages/core/README.md)
-- **Search** — [packages/search/README.md](packages/search/README.md)
+- **Infrastructure** — [packages/framework/infrastructure/README.md](packages/framework/infrastructure/README.md)
+- **Core** — [packages/framework/core/README.md](packages/framework/core/README.md)
+- **Search** — [packages/framework/search/README.md](packages/framework/search/README.md)
 - **Yandex Tracker** — [packages/servers/yandex-tracker/README.md](packages/servers/yandex-tracker/README.md)
 
 ---
@@ -291,9 +291,9 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - **Архитектура monorepo:** [ARCHITECTURE.md](./ARCHITECTURE.md)
 - **Migration guide v1 → v2:** [MIGRATION.md](./MIGRATION.md)
 - **Framework packages:**
-  - [Infrastructure API](packages/infrastructure/README.md)
-  - [Core API](packages/core/README.md)
-  - [Search System](packages/search/README.md)
+  - [Infrastructure API](packages/framework/infrastructure/README.md)
+  - [Core API](packages/framework/core/README.md)
+  - [Search System](packages/framework/search/README.md)
 - **Yandex Tracker:**
   - [Yandex Tracker CLAUDE.md](packages/servers/yandex-tracker/CLAUDE.md)
   - [Yandex Tracker README.md](packages/servers/yandex-tracker/README.md)

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ npm install @mcp-framework/core
 
 ### Packages
 
-- **Infrastructure:** [packages/infrastructure/README.md](packages/infrastructure/README.md)
-- **Core:** [packages/core/README.md](packages/core/README.md)
-- **Search:** [packages/search/README.md](packages/search/README.md)
+- **Infrastructure:** [packages/framework/infrastructure/README.md](packages/framework/infrastructure/README.md)
+- **Core:** [packages/framework/core/README.md](packages/framework/core/README.md)
+- **Search:** [packages/framework/search/README.md](packages/framework/search/README.md)
 - **Yandex Tracker:** [packages/servers/yandex-tracker/README.md](packages/servers/yandex-tracker/README.md)
 
 ---

--- a/packages/servers/yandex-tracker/CLAUDE.md
+++ b/packages/servers/yandex-tracker/CLAUDE.md
@@ -182,10 +182,10 @@ ESSENTIAL_TOOLS=ping,search_tools
 
 **ОБЯЗАТЕЛЬНО прочитай перед работой с компонентом:**
 
-- **MCP Tools** — [src/mcp/README.md](src/mcp/README.md)
-- **API Operations** — [src/api_operations/README.md](src/api_operations/README.md)
-- **Entities** — [src/entities/README.md](src/entities/README.md)
-- **DTO** — [src/dto/README.md](src/dto/README.md)
+- **MCP Tools** — [src/tools/README.md](src/tools/README.md)
+- **API Operations** — [src/tracker_api/api_operations/README.md](src/tracker_api/api_operations/README.md)
+- **Entities** — [src/tracker_api/entities/README.md](src/tracker_api/entities/README.md)
+- **DTO** — [src/tracker_api/dto/README.md](src/tracker_api/dto/README.md)
 - **Dependency Injection** — [src/composition-root/README.md](src/composition-root/README.md)
 - **Тестирование** — [tests/README.md](tests/README.md)
 
@@ -197,7 +197,7 @@ ESSENTIAL_TOOLS=ping,search_tools
 
 ### Добавление MCP Tool
 
-- [ ] 📖 Прочитай [src/mcp/README.md](src/mcp/README.md)
+- [ ] 📖 Прочитай [src/tools/README.md](src/tools/README.md)
 - [ ] Создай структуру: `{feature}/{action}/{name}.schema.ts`, `.definition.ts`, `.tool.ts`, `index.ts`
 - [ ] Добавь `static readonly METADATA`:
   - [ ] ⚠️ Если tool ИЗМЕНЯЕТ данные → `requiresExplicitUserConsent: true`

--- a/packages/servers/yandex-tracker/README.md
+++ b/packages/servers/yandex-tracker/README.md
@@ -298,7 +298,7 @@ npm run validate:tools     # Проверка регистрации tools/opera
 
 3. **Готово!** DI контейнер автоматически зарегистрирует инструмент.
 
-**Подробнее:** [src/mcp/README.md](src/mcp/README.md)
+**Подробнее:** [src/tools/README.md](src/tools/README.md)
 
 ### Технологический стек
 
@@ -317,9 +317,9 @@ npm run validate:tools     # Проверка регистрации tools/opera
 ### Для разработчиков
 
 - **[CLAUDE.md](./CLAUDE.md)** — правила для ИИ агентов и разработчиков
-- **[src/mcp/README.md](src/mcp/README.md)** — добавление MCP tools
-- **[src/api_operations/README.md](src/api_operations/README.md)** — API операции
-- **[src/entities/README.md](src/entities/README.md)** — domain entities
+- **[src/tools/README.md](src/tools/README.md)** — добавление MCP tools
+- **[src/tracker_api/api_operations/README.md](src/tracker_api/api_operations/README.md)** — API операции
+- **[src/tracker_api/entities/README.md](src/tracker_api/entities/README.md)** — domain entities
 - **[tests/README.md](tests/README.md)** — тестирование
 
 ### Monorepo

--- a/packages/servers/yandex-tracker/src/composition-root/README.md
+++ b/packages/servers/yandex-tracker/src/composition-root/README.md
@@ -455,7 +455,7 @@ container.bind(TYPES.HttpClient).toConstantValue(mockHttp); // ✅
 ## 🔗 См. также
 
 - **Operations:** [src/tracker_api/api_operations/README.md](../tracker_api/api_operations/README.md)
-- **MCP Tools:** [src/mcp/README.md](../mcp/README.md)
+- **MCP Tools:** [src/tools/README.md](../tools/README.md)
 - **Общие правила:** [CLAUDE.md](../../CLAUDE.md)
 - **Реальные unit тесты:** `tests/unit/tracker_api/facade/yandex-tracker.facade.test.ts`
 - **Реальные integration тесты:** `tests/integration/helpers/mcp-client.ts`

--- a/packages/servers/yandex-tracker/src/tools/README.md
+++ b/packages/servers/yandex-tracker/src/tools/README.md
@@ -1,0 +1,381 @@
+# MCP Tools — Yandex Tracker Конвенции
+
+**Разработка MCP tools для Yandex.Tracker сервера**
+
+---
+
+## 🎯 Назначение
+
+**MCP Tools** — это набор инструментов, которые Claude использует для взаимодействия с Яндекс.Трекер API.
+
+**Текущая структура:**
+- **API Tools** — работа с Яндекс.Трекер (задачи, проекты, комментарии, работа с очередями)
+- **Helper Tools** — утилиты (ping, search_tools)
+
+**Слоистая архитектура:**
+```
+MCP Tool → YandexTrackerFacade → API Operation → HttpClient → Яндекс.Трекер API
+```
+
+---
+
+## 📁 Структура
+
+```
+src/tools/
+├── api/                          # API tools (работа с Tracker)
+│   ├── issues/
+│   │   ├── get/
+│   │   │   ├── get-issues.definition.ts
+│   │   │   ├── get-issues.schema.ts
+│   │   │   └── get-issues.tool.ts
+│   │   ├── create/
+│   │   └── update/
+│   ├── projects/
+│   ├── comments/
+│   └── queues/
+├── helpers/                      # Вспомогательные tools
+│   ├── ping/
+│   └── search-tools/
+├── ping.definition.ts            # Корневой ping tool
+└── ping.tool.ts
+```
+
+---
+
+## 🚨 КРИТИЧЕСКИЕ ПРАВИЛА
+
+### 1. Используй Facade, НЕ Operations напрямую
+
+**❌ ЗАПРЕЩЕНО:**
+```typescript
+constructor(
+  private getIssuesOp: GetIssuesOperation  // WRONG!
+) {}
+```
+
+**✅ ПРАВИЛЬНО:**
+```typescript
+constructor(
+  private trackerFacade: YandexTrackerFacade
+) {}
+
+execute() {
+  const results = await this.trackerFacade.getIssues(keys);
+}
+```
+
+**Причина:** Facade инкапсулирует бизнес-логику, может объединять несколько операций, легче тестировать
+
+---
+
+### 2. Обязательные компоненты Tool
+
+**Каждый tool ДОЛЖЕН иметь:**
+
+1. **Static METADATA** — для Tool Search Engine
+```typescript
+static readonly METADATA: StaticToolMetadata = {
+  name: 'fyt_mcp_get_issues',
+  category: 'api',
+  tags: ['issues', 'tracker', 'read'],
+};
+```
+
+2. **Zod Schema** — валидация параметров
+```typescript
+const GetIssuesParamsSchema = z.object({
+  keys: z.array(z.string()).min(1).max(200),
+  fields: FieldsSchema.optional(),
+  expand: ExpandSchema.optional(),
+});
+```
+
+3. **Definition** — MCP ToolDefinition
+```typescript
+getDefinition(): ToolDefinition {
+  return GetIssuesDefinition.build();
+}
+```
+
+4. **Response Field Filter** — экономия токенов (80-90%)
+```typescript
+const filtered = ResponseFieldFilter.filter(data, params.fields);
+return this.formatSuccess({ issues: filtered });
+```
+
+---
+
+### 3. Флаг безопасности `requiresExplicitUserConsent`
+
+**⚠️ Если tool ИЗМЕНЯЕТ данные:**
+```typescript
+static readonly METADATA: StaticToolMetadata = {
+  name: 'fyt_mcp_update_issue',
+  requiresExplicitUserConsent: true,  // ⚠️ ОБЯЗАТЕЛЬНО
+};
+```
+
+**✅ Если tool только ЧИТАЕТ:**
+```typescript
+static readonly METADATA: StaticToolMetadata = {
+  name: 'fyt_mcp_get_issues',
+  // requiresExplicitUserConsent отсутствует (или false)
+};
+```
+
+**Проверка:** `npm run validate:tools`
+
+**Опасные операции:** `update`, `create`, `delete`, `transition`, `execute`
+**Безопасные операции:** `get`, `find`, `search`, `list`, `ping`
+
+---
+
+### 4. Batch-операции
+
+**✅ Используй BatchResultProcessor для обработки:**
+```typescript
+const processed = BatchResultProcessor.process(
+  results,
+  (item) => ResponseFieldFilter.filter(item, params.fields)
+);
+
+// Структура:
+// { successful: [{ key, data }], failed: [{ key, error }] }
+```
+
+**✅ Логируй результаты через ResultLogger:**
+```typescript
+ResultLogger.logBatchSuccess(this.logger, 'get_issues', {
+  totalRequested: keys.length,
+  successful: processed.successful.length,
+  failed: processed.failed.length,
+});
+```
+
+---
+
+## 📋 Процесс создания нового API Tool
+
+### Шаг 1: Создать структуру файлов
+
+```bash
+mkdir -p src/tools/api/{feature}/{action}/
+cd src/tools/api/{feature}/{action}/
+
+# Создать файлы:
+# - {action}-{feature}.schema.ts
+# - {action}-{feature}.definition.ts
+# - {action}-{feature}.tool.ts
+# - index.ts
+```
+
+### Шаг 2: Schema (Zod валидация)
+
+```typescript
+// get-issues.schema.ts
+import { z } from 'zod';
+import { IssueKeySchema, FieldsSchema } from '@mcp-framework/core';
+
+export const GetIssuesParamsSchema = z.object({
+  keys: z.array(IssueKeySchema).min(1).max(200),
+  fields: FieldsSchema.optional(),
+});
+
+export type GetIssuesParams = z.infer<typeof GetIssuesParamsSchema>;
+```
+
+**Переиспользуй схемы** из `@mcp-framework/core`:
+- `IssueKeySchema` — ключ задачи
+- `FieldsSchema` — фильтр полей
+- `ExpandSchema` — expand параметры
+
+---
+
+### Шаг 3: Definition (MCP ToolDefinition)
+
+```typescript
+// get-issues.definition.ts
+export class GetIssuesDefinition {
+  static build(): ToolDefinition {
+    return {
+      name: GetIssuesTool.METADATA.name,
+      description: this.buildDescription(),
+      inputSchema: zodToJsonSchema(GetIssuesParamsSchema),
+    };
+  }
+
+  private static buildDescription(): string {
+    return wrapWithSafetyWarning(`
+      Получить информацию о задачах в Яндекс.Трекере.
+
+      Параметры:
+      - keys: Массив ключей задач (например, ["QUEUE-1", "QUEUE-2"])
+      - fields: Опциональный фильтр полей (экономия токенов)
+    `);
+  }
+}
+```
+
+**⚠️ Для опасных операций:** Используй `wrapWithSafetyWarning()`
+
+---
+
+### Шаг 4: Tool (реализация)
+
+```typescript
+// get-issues.tool.ts
+import { BaseTool } from '@mcp-framework/core';
+
+export class GetIssuesTool extends BaseTool<YandexTrackerFacade> {
+  static readonly METADATA: StaticToolMetadata = {
+    name: 'fyt_mcp_get_issues',
+    category: 'api',
+    tags: ['issues', 'tracker', 'read'],
+  };
+
+  getDefinition(): ToolDefinition {
+    return GetIssuesDefinition.build();
+  }
+
+  async execute(params: unknown): Promise<ToolResponse> {
+    // 1. Валидация
+    const validated = this.validateParams(GetIssuesParamsSchema, params);
+
+    // 2. Вызов facade
+    const results = await this.facade.getIssues(validated.keys);
+
+    // 3. Обработка результатов
+    const processed = BatchResultProcessor.process(
+      results,
+      (item) => ResponseFieldFilter.filter(item, validated.fields)
+    );
+
+    // 4. Логирование
+    ResultLogger.logBatchSuccess(this.logger, 'get_issues', {
+      totalRequested: validated.keys.length,
+      successful: processed.successful.length,
+      failed: processed.failed.length,
+    });
+
+    // 5. Форматирование ответа
+    return this.formatSuccess({ issues: processed });
+  }
+}
+```
+
+---
+
+### Шаг 5: Регистрация
+
+**Добавить 1 строку в `src/composition-root/definitions/tool-definitions.ts`:**
+```typescript
+import { GetIssuesTool } from '../tools/api/issues/get/get-issues.tool.js';
+
+export const TOOL_DEFINITIONS = [
+  // ... existing tools
+  GetIssuesTool,
+];
+```
+
+**Автоматическая проверка:**
+```bash
+npm run validate:tools  # Проверит регистрацию всех *.tool.ts
+```
+
+---
+
+## 🔧 Утилиты для Tools
+
+### ResponseFieldFilter
+
+**Назначение:** Фильтрация полей ответа (экономия 80-90% токенов)
+
+```typescript
+import { ResponseFieldFilter } from '@mcp-framework/core';
+
+// БЕЗ фильтрации: 10KB данных
+const fullIssue = { key, summary, description, ..., assignee: {...}, followers: [...] };
+
+// С фильтрацией: 1KB данных
+const filtered = ResponseFieldFilter.filter(fullIssue, ['key', 'summary', 'assignee.login']);
+// Результат: { key, summary, assignee: { login } }
+```
+
+**⚠️ ВСЕГДА фильтруй перед возвратом!**
+
+---
+
+### BatchResultProcessor
+
+**Назначение:** Обработка `BatchResult<TKey, TValue>` → разделение на successful/failed
+
+```typescript
+import { BatchResultProcessor } from '@mcp-framework/core';
+
+const results: BatchResult<string, Issue> = await facade.getIssues(keys);
+
+const processed = BatchResultProcessor.process(
+  results,
+  (issue) => ResponseFieldFilter.filter(issue, params.fields)
+);
+
+// Структура:
+// {
+//   successful: [{ key: 'QUEUE-1', data: {...} }],
+//   failed: [{ key: 'QUEUE-2', error: 'Not found' }]
+// }
+```
+
+---
+
+### ResultLogger
+
+**Назначение:** Structured JSON логирование результатов
+
+```typescript
+import { ResultLogger } from '@mcp-framework/core';
+
+ResultLogger.logBatchSuccess(logger, 'operation_name', {
+  totalRequested: 10,
+  successful: 8,
+  failed: 2,
+});
+```
+
+---
+
+## 📊 Tool Discovery Modes
+
+### Eager (по умолчанию)
+
+```bash
+TOOL_DISCOVERY_MODE=eager  # Все tools при старте
+```
+
+**Когда использовать:** Claude Code on the Web, production
+
+---
+
+### Lazy (экспериментальный)
+
+```bash
+TOOL_DISCOVERY_MODE=lazy
+ESSENTIAL_TOOLS=ping,search_tools
+```
+
+**Workflow:**
+1. Claude видит только `[ping, search_tools]`
+2. Использует `search_tools` для поиска нужного tool
+3. Вызывает найденный tool
+
+**Когда использовать:** Claude Desktop, 30+ tools
+
+---
+
+## 🔗 См. также
+
+- **Общие утилиты:** [@mcp-framework/core](../../../../../framework/core/src/tools/common/README.md)
+- **API Operations:** [../tracker_api/api_operations/README.md](../tracker_api/api_operations/README.md)
+- **Dependency Injection:** [../composition-root/README.md](../composition-root/README.md)
+- **Yandex Tracker CLAUDE.md:** [../../CLAUDE.md](../../CLAUDE.md)


### PR DESCRIPTION
Детали:
- Исправлены 15 битых ссылок на framework пакеты после миграции на monorepo (packages/infrastructure → packages/framework/infrastructure)
- Создан src/tools/README.md для документации MCP tools (381 строка)
- Исправлены 5 ссылок src/mcp/ → src/tools/ в yandex-tracker
- Обновлены пути в .serena/memories/project_overview.md для Serena AI
- Все ссылки теперь указывают на правильные пути в monorepo

Преимущества:
- ИИ агенты теперь могут найти всю документацию
- Нет битых ссылок при навигации по документам
- Serena AI получает актуальную информацию о структуре проекта

🤖 Generated with Claude Code