### PR TITLE
Write integration tests for MCP Tools

### DIFF
--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/attachment/get-thumbnail.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/attachment/get-thumbnail.operation.ts
@@ -54,6 +54,44 @@ export class GetThumbnailOperation extends BaseOperation {
   }
 
   /**
+   * Получить метаданные файла без скачивания содержимого
+   *
+   * Используется для получения информации о файле (имя, размер, MIME тип, etc)
+   * перед скачиванием миниатюры.
+   *
+   * @param issueId - идентификатор или ключ задачи
+   * @param attachmentId - идентификатор файла
+   * @returns метаданные файла
+   *
+   * @example
+   * ```typescript
+   * const metadata = await getThumbnailOp.getMetadata('TEST-123', '67890');
+   * console.log(`Файл: ${metadata.name}, размер: ${metadata.size} байт`);
+   * ```
+   */
+  async getMetadata(issueId: string, attachmentId: string): Promise<AttachmentWithUnknownFields> {
+    this.logger.debug(
+      `GetThumbnailOperation: получение метаданных для attachmentId=${attachmentId}`
+    );
+
+    // Получаем список всех файлов и находим нужный
+    const attachments = await this.httpClient.get<AttachmentWithUnknownFields[]>(
+      `/v2/issues/${issueId}/attachments`
+    );
+
+    const attachment = attachments.find((a) => a.id === attachmentId);
+
+    if (!attachment) {
+      throw new Error(
+        `Файл с id=${attachmentId} не найден в задаче ${issueId}. ` +
+          `Доступные файлы: ${attachments.map((a) => a.id).join(', ')}`
+      );
+    }
+
+    return attachment;
+  }
+
+  /**
    * Проверить, поддерживает ли файл миниатюры
    *
    * Полезно перед вызовом execute() для избежания ошибок API.

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -405,14 +405,23 @@ export class YandexTrackerFacade {
     input?: DownloadAttachmentInput
   ): Promise<DownloadAttachmentOutput> {
     const operation = this.getOperation<{
-      execute: (
-        id: string,
-        attId: string,
-        fname: string,
-        input?: DownloadAttachmentInput
-      ) => Promise<DownloadAttachmentOutput>;
+      execute: (id: string, attId: string, fname: string) => Promise<Buffer>;
+      getMetadata: (id: string, attId: string) => Promise<AttachmentWithUnknownFields>;
     }>('DownloadAttachmentOperation');
-    return operation.execute(issueId, attachmentId, filename, input);
+
+    // Получаем метаданные файла
+    const metadata = await operation.getMetadata(issueId, attachmentId);
+
+    // Скачиваем файл
+    const buffer = await operation.execute(issueId, attachmentId, filename);
+
+    // Формируем результат
+    const content = input?.returnBase64 ? buffer.toString('base64') : buffer;
+
+    return {
+      content,
+      metadata,
+    };
   }
 
   /**
@@ -440,12 +449,22 @@ export class YandexTrackerFacade {
     input?: DownloadAttachmentInput
   ): Promise<DownloadAttachmentOutput> {
     const operation = this.getOperation<{
-      execute: (
-        id: string,
-        attId: string,
-        input?: DownloadAttachmentInput
-      ) => Promise<DownloadAttachmentOutput>;
+      execute: (id: string, attId: string) => Promise<Buffer>;
+      getMetadata: (id: string, attId: string) => Promise<AttachmentWithUnknownFields>;
     }>('GetThumbnailOperation');
-    return operation.execute(issueId, attachmentId, input);
+
+    // Получаем метаданные файла
+    const metadata = await operation.getMetadata(issueId, attachmentId);
+
+    // Скачиваем миниатюру
+    const buffer = await operation.execute(issueId, attachmentId);
+
+    // Формируем результат
+    const content = input?.returnBase64 ? buffer.toString('base64') : buffer;
+
+    return {
+      content,
+      metadata,
+    };
   }
 }

--- a/packages/servers/yandex-tracker/tests/integration/helpers/mock-server.ts
+++ b/packages/servers/yandex-tracker/tests/integration/helpers/mock-server.ts
@@ -555,6 +555,194 @@ export class MockServer {
     return this;
   }
 
+  // ============================================================
+  // ATTACHMENTS API МЕТОДЫ
+  // ============================================================
+
+  /**
+   * Mock успешного получения списка файлов задачи
+   */
+  mockGetAttachmentsSuccess(issueKey: string, attachments: unknown[]): this {
+    const mockKey = `GET /v2/issues/${issueKey}/attachments`;
+    this.mockAdapter.onGet(`/v2/issues/${issueKey}/attachments`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [200, attachments];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при получении списка файлов
+   */
+  mockGetAttachments404(issueKey: string): this {
+    const response = generateError404();
+    const mockKey = `GET /v2/issues/${issueKey}/attachments`;
+    this.mockAdapter.onGet(`/v2/issues/${issueKey}/attachments`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешной загрузки файла
+   */
+  mockUploadAttachmentSuccess(issueKey: string, attachment: unknown): this {
+    const mockKey = `POST /v2/issues/${issueKey}/attachments`;
+    this.mockAdapter.onPost(`/v2/issues/${issueKey}/attachments`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [201, attachment];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 403 при загрузке файла
+   */
+  mockUploadAttachment403(issueKey: string): this {
+    const response = generateError403();
+    const mockKey = `POST /v2/issues/${issueKey}/attachments`;
+    this.mockAdapter.onPost(`/v2/issues/${issueKey}/attachments`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [403, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешного скачивания файла
+   */
+  mockDownloadAttachmentSuccess(issueKey: string, attachmentId: string, filename: string): this {
+    const mockKey = `GET /v2/issues/${issueKey}/attachments/${attachmentId}/${filename}`;
+    const fileContent = Buffer.from('test file content');
+    this.mockAdapter
+      .onGet(`/v2/issues/${issueKey}/attachments/${attachmentId}/${filename}`)
+      .reply(() => {
+        const index = this.pendingMocks.indexOf(mockKey);
+        if (index !== -1) {
+          this.pendingMocks.splice(index, 1);
+        }
+        return [
+          200,
+          fileContent,
+          {
+            'content-type': 'application/octet-stream',
+            'content-disposition': `attachment; filename="${filename}"`,
+          },
+        ];
+      });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при скачивании файла
+   */
+  mockDownloadAttachment404(issueKey: string, attachmentId: string, filename: string): this {
+    const response = generateError404();
+    const mockKey = `GET /v2/issues/${issueKey}/attachments/${attachmentId}/${filename}`;
+    this.mockAdapter
+      .onGet(`/v2/issues/${issueKey}/attachments/${attachmentId}/${filename}`)
+      .reply(() => {
+        const index = this.pendingMocks.indexOf(mockKey);
+        if (index !== -1) {
+          this.pendingMocks.splice(index, 1);
+        }
+        return [404, response];
+      });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешного удаления файла
+   */
+  mockDeleteAttachmentSuccess(issueKey: string, attachmentId: string): this {
+    const mockKey = `DELETE /v2/issues/${issueKey}/attachments/${attachmentId}`;
+    this.mockAdapter.onDelete(`/v2/issues/${issueKey}/attachments/${attachmentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [204, ''];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при удалении файла
+   */
+  mockDeleteAttachment404(issueKey: string, attachmentId: string): this {
+    const response = generateError404();
+    const mockKey = `DELETE /v2/issues/${issueKey}/attachments/${attachmentId}`;
+    this.mockAdapter.onDelete(`/v2/issues/${issueKey}/attachments/${attachmentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешного получения миниатюры
+   */
+  mockGetThumbnailSuccess(issueKey: string, attachmentId: string): this {
+    const mockKey = `GET /v2/issues/${issueKey}/thumbnails/${attachmentId}`;
+    const thumbnailContent = Buffer.from('thumbnail image content');
+    this.mockAdapter.onGet(`/v2/issues/${issueKey}/thumbnails/${attachmentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [
+        200,
+        thumbnailContent,
+        {
+          'content-type': 'image/png',
+        },
+      ];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при получении миниатюры
+   */
+  mockGetThumbnail404(issueKey: string, attachmentId: string): this {
+    const response = generateError404();
+    const mockKey = `GET /v2/issues/${issueKey}/thumbnails/${attachmentId}`;
+    this.mockAdapter.onGet(`/v2/issues/${issueKey}/thumbnails/${attachmentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
   /**
    * Очистить все моки и восстановить оригинальный адаптер
    */

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/delete/delete-attachment.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/delete/delete-attachment.tool.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Интеграционные тесты для delete-attachment tool
+ *
+ * Тестирование end-to-end flow:
+ * MCP Client → ToolRegistry → DeleteAttachmentTool → DeleteAttachmentOperation → HttpClient → API (mock)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('delete-attachment integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    // ВАЖНО: создаём MCP клиент СНАЧАЛА, чтобы получить axios instance
+    client = await createTestClient({
+      logLevel: 'silent', // Отключаем логи в тестах
+    });
+
+    // Затем создаём MockServer с axios instance из клиента
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    // Очищаем моки после каждого теста
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен успешно удалить файл из задачи', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachmentId = '12345';
+
+      mockServer.mockDeleteAttachmentSuccess(issueId, attachmentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_attachment', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response).toMatchObject({
+        issueId,
+        attachmentId,
+        deleted: true,
+      });
+
+      expect(response).toHaveProperty('message');
+      expect(response.message).toContain('успешно удален');
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен успешно удалить файл с другим attachmentId', async () => {
+      // Arrange
+      const issueId = 'QUEUE-2';
+      const attachmentId = '67890';
+
+      mockServer.mockDeleteAttachmentSuccess(issueId, attachmentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_attachment', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.deleted).toBe(true);
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (файл не найден)', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachmentId = 'nonexistent';
+
+      mockServer.mockDeleteAttachment404(issueId, attachmentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_attachment', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Validation', () => {
+    it('должен вернуть ошибку при пустом issueId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_attachment', {
+        issueId: '',
+        attachmentId: '12345',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при пустом attachmentId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_attachment', {
+        issueId: 'QUEUE-1',
+        attachmentId: '',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при отсутствии обязательных параметров', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_attachment', {});
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/download/download-attachment.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/download/download-attachment.tool.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Интеграционные тесты для download-attachment tool
+ *
+ * Тестирование end-to-end flow:
+ * MCP Client → ToolRegistry → DownloadAttachmentTool → DownloadAttachmentOperation → HttpClient → API (mock)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('download-attachment integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    // ВАЖНО: создаём MCP клиент СНАЧАЛА, чтобы получить axios instance
+    client = await createTestClient({
+      logLevel: 'silent', // Отключаем логи в тестах
+    });
+
+    // Затем создаём MockServer с axios instance из клиента
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    // Очищаем моки после каждого теста
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен успешно скачать файл и вернуть base64', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachmentId = '12345';
+      const filename = 'test-file.txt';
+
+      // Мокируем запрос на список файлов для получения метаданных
+      mockServer.mockGetAttachmentsSuccess(issueId, [
+        {
+          id: attachmentId,
+          name: filename,
+          mimetype: 'text/plain',
+          size: 100,
+          createdBy: { id: '1', display: 'Test User' },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          self: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}`,
+          content: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}/${filename}`,
+        },
+      ]);
+      mockServer.mockDownloadAttachmentSuccess(issueId, attachmentId, filename);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {
+        issueId,
+        attachmentId,
+        filename,
+      });
+
+      // Assert
+      if (result.isError) {
+        console.log('Error result:', result.content[0]?.text);
+      }
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response).toMatchObject({
+        issueId,
+        attachmentId,
+        filename,
+      });
+
+      expect(response).toHaveProperty('base64');
+      expect(response).toHaveProperty('size');
+      expect(response).toHaveProperty('mimetype');
+      expect(typeof response.base64).toBe('string');
+      expect(response.base64.length).toBeGreaterThan(0);
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен скачать и вернуть метаданные файла', async () => {
+      // Arrange
+      const issueId = 'QUEUE-2';
+      const attachmentId = '67890';
+      const filename = 'document.pdf';
+
+      // Мокируем запрос на список файлов для получения метаданных
+      mockServer.mockGetAttachmentsSuccess(issueId, [
+        {
+          id: attachmentId,
+          name: filename,
+          mimetype: 'application/pdf',
+          size: 2048,
+          createdBy: { id: '1', display: 'Test User' },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          self: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}`,
+          content: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}/${filename}`,
+        },
+      ]);
+      mockServer.mockDownloadAttachmentSuccess(issueId, attachmentId, filename);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {
+        issueId,
+        attachmentId,
+        filename,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.size).toBeGreaterThan(0);
+      expect(response).toHaveProperty('mimetype');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (файл не найден)', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachmentId = 'nonexistent';
+      const filename = 'missing.txt';
+
+      // Мокируем запрос на список файлов, но файл не найден
+      mockServer.mockGetAttachments404(issueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {
+        issueId,
+        attachmentId,
+        filename,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Validation', () => {
+    it('должен вернуть ошибку при пустом issueId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {
+        issueId: '',
+        attachmentId: '12345',
+        filename: 'test.txt',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при пустом attachmentId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {
+        issueId: 'QUEUE-1',
+        attachmentId: '',
+        filename: 'test.txt',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при пустом filename', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {
+        issueId: 'QUEUE-1',
+        attachmentId: '12345',
+        filename: '',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при отсутствии обязательных параметров', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_download_attachment', {});
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/get/get-attachments.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/get/get-attachments.tool.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Интеграционные тесты для get-attachments tool
+ *
+ * Тестирование end-to-end flow:
+ * MCP Client → ToolRegistry → GetAttachmentsTool → GetAttachmentsOperation → HttpClient → API (mock)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+import {
+  createAttachmentListFixture,
+  createImageAttachmentFixture,
+} from '../../../../../../helpers/attachment.fixture.js';
+
+describe('get-attachments integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    // ВАЖНО: создаём MCP клиент СНАЧАЛА, чтобы получить axios instance
+    client = await createTestClient({
+      logLevel: 'silent', // Отключаем логи в тестах
+    });
+
+    // Затем создаём MockServer с axios instance из клиента
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    // Очищаем моки после каждого теста
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен успешно получить список файлов задачи', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachments = createAttachmentListFixture(3);
+      mockServer.mockGetAttachmentsSuccess(issueId, attachments);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_attachments', {
+        issueId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response).toMatchObject({
+        issueId,
+        attachmentsCount: 3,
+      });
+
+      expect(response.attachments).toHaveLength(3);
+      expect(response.attachments[0]).toHaveProperty('id');
+      expect(response.attachments[0]).toHaveProperty('name');
+      expect(response.attachments[0]).toHaveProperty('mimetype');
+      expect(response.attachments[0]).toHaveProperty('size');
+      expect(response.attachments[0]).toHaveProperty('downloadUrl');
+      expect(response.attachments[0]).toHaveProperty('createdBy');
+      expect(response.attachments[0]).toHaveProperty('createdAt');
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен вернуть пустой список для задачи без файлов', async () => {
+      // Arrange
+      const issueId = 'QUEUE-2';
+      mockServer.mockGetAttachmentsSuccess(issueId, []);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_attachments', {
+        issueId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response).toMatchObject({
+        issueId,
+        attachmentsCount: 0,
+        attachments: [],
+      });
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен включать thumbnailUrl для изображений', async () => {
+      // Arrange
+      const issueId = 'QUEUE-3';
+      const imageAttachment = createImageAttachmentFixture({
+        name: 'screenshot.png',
+      });
+      mockServer.mockGetAttachmentsSuccess(issueId, [imageAttachment]);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_attachments', {
+        issueId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.attachments[0]).toHaveProperty('thumbnailUrl');
+      expect(response.attachments[0].thumbnailUrl).toContain('thumbnails');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (задача не найдена)', async () => {
+      // Arrange
+      const issueId = 'NONEXISTENT-1';
+      mockServer.mockGetAttachments404(issueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_attachments', {
+        issueId,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Validation', () => {
+    it('должен вернуть ошибку при пустом issueId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_attachments', {
+        issueId: '',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при отсутствии issueId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_attachments', {});
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/thumbnail/get-thumbnail.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/thumbnail/get-thumbnail.tool.integration.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Интеграционные тесты для get-thumbnail tool
+ *
+ * Тестирование end-to-end flow:
+ * MCP Client → ToolRegistry → GetThumbnailTool → GetThumbnailOperation → HttpClient → API (mock)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('get-thumbnail integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    // ВАЖНО: создаём MCP клиент СНАЧАЛА, чтобы получить axios instance
+    client = await createTestClient({
+      logLevel: 'silent', // Отключаем логи в тестах
+    });
+
+    // Затем создаём MockServer с axios instance из клиента
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    // Очищаем моки после каждого теста
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен успешно получить миниатюру изображения в base64', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachmentId = '12345';
+
+      // Мокируем запрос на список файлов для получения метаданных
+      mockServer.mockGetAttachmentsSuccess(issueId, [
+        {
+          id: attachmentId,
+          name: 'screenshot.png',
+          mimetype: 'image/png',
+          size: 1024,
+          createdBy: { id: '1', display: 'Test User' },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          self: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}`,
+          content: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}/screenshot.png`,
+          thumbnail: `https://api.tracker.yandex.net/v2/issues/${issueId}/thumbnails/${attachmentId}`,
+        },
+      ]);
+      mockServer.mockGetThumbnailSuccess(issueId, attachmentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response).toMatchObject({
+        issueId,
+        attachmentId,
+      });
+
+      expect(response).toHaveProperty('base64');
+      expect(response).toHaveProperty('size');
+      expect(response).toHaveProperty('mimetype');
+      expect(typeof response.base64).toBe('string');
+      expect(response.base64.length).toBeGreaterThan(0);
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен вернуть метаданные миниатюры', async () => {
+      // Arrange
+      const issueId = 'QUEUE-2';
+      const attachmentId = '67890';
+
+      // Мокируем запрос на список файлов для получения метаданных
+      mockServer.mockGetAttachmentsSuccess(issueId, [
+        {
+          id: attachmentId,
+          name: 'photo.jpg',
+          mimetype: 'image/jpeg',
+          size: 2048,
+          createdBy: { id: '1', display: 'Test User' },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          self: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}`,
+          content: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}/photo.jpg`,
+          thumbnail: `https://api.tracker.yandex.net/v2/issues/${issueId}/thumbnails/${attachmentId}`,
+        },
+      ]);
+      mockServer.mockGetThumbnailSuccess(issueId, attachmentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.size).toBeGreaterThan(0);
+      expect(response).toHaveProperty('mimetype');
+      expect(response.mimetype).toContain('image');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (миниатюра не найдена)', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const attachmentId = 'nonexistent';
+
+      // Мокируем запрос на список файлов, но файл не найден
+      mockServer.mockGetAttachments404(issueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка');
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обработать ошибку когда файл не является изображением', async () => {
+      // Arrange
+      const issueId = 'QUEUE-2';
+      const attachmentId = '12345';
+
+      // Мокируем запрос на список файлов - файл есть, но метаданные не содержат thumbnail
+      mockServer.mockGetAttachmentsSuccess(issueId, [
+        {
+          id: attachmentId,
+          name: 'document.pdf',
+          mimetype: 'application/pdf',
+          size: 2048,
+          createdBy: { id: '1', display: 'Test User' },
+          createdAt: '2024-01-01T00:00:00.000Z',
+          self: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}`,
+          content: `https://api.tracker.yandex.net/v2/issues/${issueId}/attachments/${attachmentId}/document.pdf`,
+          // Нет thumbnail для не-изображений
+        },
+      ]);
+      // Миниатюра доступна только для изображений, для других типов файлов будет 404
+      mockServer.mockGetThumbnail404(issueId, attachmentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {
+        issueId,
+        attachmentId,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Validation', () => {
+    it('должен вернуть ошибку при пустом issueId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {
+        issueId: '',
+        attachmentId: '12345',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при пустом attachmentId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {
+        issueId: 'QUEUE-1',
+        attachmentId: '',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при отсутствии обязательных параметров', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_thumbnail', {});
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/upload/upload-attachment.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/issues/attachments/upload/upload-attachment.tool.integration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Интеграционные тесты для upload-attachment tool
+ *
+ * Тестирование end-to-end flow:
+ * MCP Client → ToolRegistry → UploadAttachmentTool → UploadAttachmentOperation → HttpClient → API (mock)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+import { createAttachmentFixture } from '../../../../../../helpers/attachment.fixture.js';
+
+describe('upload-attachment integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    // ВАЖНО: создаём MCP клиент СНАЧАЛА, чтобы получить axios instance
+    client = await createTestClient({
+      logLevel: 'silent', // Отключаем логи в тестах
+    });
+
+    // Затем создаём MockServer с axios instance из клиента
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    // Очищаем моки после каждого теста
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен успешно загрузить файл через base64', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const filename = 'test-file.txt';
+      const fileContent = Buffer.from('test file content').toString('base64');
+      const uploadedAttachment = createAttachmentFixture({
+        name: filename,
+      });
+
+      mockServer.mockUploadAttachmentSuccess(issueId, uploadedAttachment);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId,
+        filename,
+        fileContent,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response).toMatchObject({
+        issueId,
+      });
+
+      expect(response.attachment).toHaveProperty('id');
+      expect(response.attachment).toHaveProperty('name', filename);
+      expect(response.attachment).toHaveProperty('mimetype');
+      expect(response.attachment).toHaveProperty('size');
+      expect(response.attachment).toHaveProperty('downloadUrl');
+      expect(response.attachment).toHaveProperty('createdBy');
+      expect(response.attachment).toHaveProperty('createdAt');
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен успешно загрузить файл с указанным mimetype', async () => {
+      // Arrange
+      const issueId = 'QUEUE-2';
+      const filename = 'document.pdf';
+      const fileContent = Buffer.from('PDF content').toString('base64');
+      const mimetype = 'application/pdf';
+      const uploadedAttachment = createAttachmentFixture({
+        name: filename,
+        mimetype,
+      });
+
+      mockServer.mockUploadAttachmentSuccess(issueId, uploadedAttachment);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId,
+        filename,
+        fileContent,
+        mimetype,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.attachment).toHaveProperty('mimetype', mimetype);
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен успешно загрузить изображение', async () => {
+      // Arrange
+      const issueId = 'QUEUE-3';
+      const filename = 'screenshot.png';
+      const fileContent = Buffer.from('PNG image data').toString('base64');
+      const uploadedAttachment = createAttachmentFixture({
+        name: filename,
+        mimetype: 'image/png',
+        thumbnail: `https://api.tracker.yandex.net/v2/issues/${issueId}/thumbnails/12345`,
+      });
+
+      mockServer.mockUploadAttachmentSuccess(issueId, uploadedAttachment);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId,
+        filename,
+        fileContent,
+        mimetype: 'image/png',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.attachment).toHaveProperty('thumbnailUrl');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 403 (доступ запрещён)', async () => {
+      // Arrange
+      const issueId = 'QUEUE-1';
+      const filename = 'test.txt';
+      const fileContent = Buffer.from('test').toString('base64');
+
+      mockServer.mockUploadAttachment403(issueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId,
+        filename,
+        fileContent,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка');
+
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Validation', () => {
+    it('должен вернуть ошибку при пустом issueId', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId: '',
+        filename: 'test.txt',
+        fileContent: 'dGVzdA==',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при пустом filename', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId: 'QUEUE-1',
+        filename: '',
+        fileContent: 'dGVzdA==',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+
+    it('должен вернуть ошибку при отсутствии fileContent и filePath', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_upload_attachment', {
+        issueId: 'QUEUE-1',
+        filename: 'test.txt',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('Ошибка валидации параметров');
+    });
+  });
+});


### PR DESCRIPTION
Детали:
- Добавлены integration тесты для get-attachments, upload-attachment, download-attachment, delete-attachment, get-thumbnail (33 теста)
- Расширен MockServer 10 новыми методами для Attachments API
- Исправлен баг в YandexTrackerFacade: методы downloadAttachment и getThumbnail теперь корректно обрабатывают Buffer из операций
- Добавлен метод getMetadata() в GetThumbnailOperation для единообразия с DownloadAttachmentOperation

Все тесты проходят: 704 passed, 2 skipped

🤖 Generated with Claude Code