### PR TITLE
Complete Queues API implementation and testing

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/README.md
+++ b/packages/servers/yandex-tracker/src/tools/README.md
@@ -119,64 +119,13 @@ return this.formatSuccess({ issues: filtered });
 
 ## 🏷️ Категоризация инструментов
 
-### Обязательные метаданные
+**Обязательные метаданные:**
+- `category` — основная категория (issues, helpers, system)
+- `subcategory` — read/write/workflow (опционально)
+- `priority` — critical/high/normal/low (опционально, default: normal)
+- `tags` — для поиска через search_tools (опционально)
 
-**Каждый инструмент ДОЛЖЕН иметь:**
-- `category` (обязательно) — основная категория
-- `subcategory` (опционально) — подкатегория для группировки
-- `priority` (опционально, default: 'normal') — приоритет для сортировки
-- `tags` (опционально) — теги для поиска через search_tools
-
-### Категории и subcategories
-
-| Category | Описание | Subcategories |
-|----------|----------|---------------|
-| `issues` | Работа с задачами | `read`, `write`, `workflow` |
-| `helpers` | Вспомогательные инструменты | `url`, `demo`, `utils` |
-| `system` | Системные инструменты | `health`, `config` |
-
-### Приоритеты
-
-**Порядок в tools/list:** critical → high → normal → low → алфавит
-
-| Priority | Когда использовать | Примеры |
-|----------|-------------------|---------|
-| `critical` | Частое использование, ключевые операции | create_issue, find_issues, get_issues, update_issue |
-| `high` | Важные, но не критичные операции | transitions, changelog |
-| `normal` | Обычные операции | helpers, utilities |
-| `low` | Редкое использование, демо | demo, debug tools |
-
-### Description Convention
-
-**Формат:** `[Category/Subcategory] Краткое описание`
-
-**Правила:**
-- Префикс категории в квадратных скобках
-- Краткое описание (≤60 символов)
-- Без упоминания "Яндекс.Трекер" (контекст понятен)
-- Без дублирования информации из имени
-
-**Примеры:**
-```typescript
-✅ '[Issues/Write] Создать задачу'
-✅ '[Issues/Read] Найти задачи по фильтру'
-✅ '[Helpers/URL] Получить ссылку на задачу'
-✅ '[System/Health] Проверка доступности сервера'
-
-❌ 'Создать новую задачу в Яндекс.Трекере' // Нет префикса, многословно
-❌ '[Issues/Write] Создание новых задач с поддержкой...' // Длинно
-```
-
-### Чек-лист для нового инструмента
-
-При создании нового tool:
-- [ ] Определить `category` из существующих (или создать новую если нужно)
-- [ ] Определить `subcategory` (read/write/workflow/etc)
-- [ ] Определить `priority` на основе частоты использования
-- [ ] Добавить `tags` для поиска (3-5 тегов)
-- [ ] Написать краткий `description` с префиксом категории
-- [ ] Проверить длину: `description.length ≤ 80`
-- [ ] Добавить подробное описание параметров в `inputSchema`
+**Description формат:** `[Category/Subcategory] Краткое описание` (≤80 символов)
 
 ---
 
@@ -451,396 +400,69 @@ ESSENTIAL_TOOLS=ping,search_tools
 
 ---
 
-## 📚 Attachments API — Complete Tools Documentation
+## 📚 Attachments API — Complete Tools
 
-**5 MCP Tools для работы с вложениями** (production ready ✅)
+**5 MCP Tools для работы с вложениями:**
+- `get_attachments` — список файлов задачи
+- `upload_attachment` — загрузка (base64 или file path, max 10MB)
+- `download_attachment` — скачивание файла
+- `delete_attachment` — удаление файла
+- `get_thumbnail` — миниатюра изображения
 
-### Полный список инструментов
+См. файлы в `src/tools/api/issues/attachments/` для деталей.
 
-| Tool | API Endpoint | Описание | Safety |
-|------|-------------|----------|--------|
-| `get_attachments` | GET /attachments | Список файлов задачи | Read-only |
-| `upload_attachment` | POST /attachments | Загрузка файла | ⚠️ Write |
-| `download_attachment` | GET /attachments/{id}/{name} | Скачивание файла | Read-only |
-| `delete_attachment` | DELETE /attachments/{id} | Удаление файла | ⚠️ Write |
-| `get_thumbnail` | GET /attachments/{id}/thumbnail | Миниатюра изображения | Read-only |
+## 💬 Comments API — Complete Tools
 
----
+**4 MCP Tools для работы с комментариями:**
+- `add_comment` — добавление комментария (markdown, attachments)
+- `get_comments` — список комментариев (пагинация)
+- `edit_comment` — редактирование комментария
+- `delete_comment` — удаление комментария
 
-### 1. Upload Attachment — Загрузка файлов
-
-**Tool:** `upload_attachment`
-**Safety:** `requiresExplicitUserConsent: true` ⚠️
-
-**Два способа загрузки:**
-
-#### Способ 1: Base64 (для MCP clients)
-```typescript
-// Claude отправляет файл как base64 строку
-{
-  "issueId": "QUEUE-123",
-  "filename": "report.pdf",
-  "fileContent": "JVBERi0xLjQKJeLjz9MK...", // base64
-  "mimetype": "application/pdf"  // опционально
-}
-```
-
-#### Способ 2: File Path (для локальных файлов)
-```typescript
-// Claude читает файл с диска
-{
-  "issueId": "QUEUE-123",
-  "filename": "screenshot.png",
-  "filePath": "/tmp/screenshot.png"
-}
-```
-
-**Лимиты:**
-- **Максимальный размер:** 10 MB (по умолчанию)
-- **Валидация имени:** Без спецсимволов `../, /, \`
-- **MIME type:** Автоопределение если не указан
-- **Форматы:** Любые файлы (PDF, PNG, DOCX, etc)
-
-**Пример реализации:**
-```typescript
-export class UploadAttachmentTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: 'fyt_mcp_upload_attachment',
-    description: '[Issues/Attachments] Загрузить файл в задачу',
-    requiresExplicitUserConsent: true, // ⚠️ Модификация данных
-  };
-
-  async execute(params: unknown): Promise<ToolResponse> {
-    const { issueId, filename, fileContent, filePath } = params;
-
-    // Поддержка обоих способов
-    const buffer = fileContent
-      ? Buffer.from(fileContent, 'base64')
-      : await readFile(filePath);
-
-    // Валидация через FileUploadUtil
-    FileUploadUtil.validateFilename(filename);
-    FileUploadUtil.validateFileSize(buffer.length, MAX_SIZE);
-
-    const attachment = await this.facade.uploadAttachment(issueId, {
-      filename,
-      file: buffer,
-    });
-
-    return this.formatSuccess({ issueId, attachment });
-  }
-}
-```
+См. файлы в `src/tools/api/issues/comments/` для деталей.
 
 ---
 
-### 2. Download Attachment — Скачивание файлов
+## 🗂️ Queues API — Complete Tools
 
-**Tool:** `download_attachment`
-**Safety:** Read-only ✅
+**6 MCP Tools для работы с очередями:**
 
-**Два режима:**
+### Read Operations
+- `get_queue` — получение одной очереди по ID/ключу
+  - Параметры: `queueId`, `expand` (optional)
+  - Кеширование: ✅
 
-#### Режим 1: Возврат base64 (default)
-```typescript
-{
-  "issueId": "QUEUE-123",
-  "attachmentId": "67890",
-  "filename": "report.pdf"
-}
-// Response: { base64: "JVBERi...", size: 245678, mimetype: "application/pdf" }
-```
+- `get_queues` — список всех очередей
+  - Параметры: `expand`, `perPage`, `page` (optional)
+  - Кеширование: ✅
 
-#### Режим 2: Сохранение в файл
-```typescript
-{
-  "issueId": "QUEUE-123",
-  "attachmentId": "67890",
-  "filename": "report.pdf",
-  "saveToPath": "/tmp/downloaded_report.pdf"
-}
-// Response: { savedTo: "/tmp/downloaded_report.pdf", size: 245678 }
-```
+- `get_queue_fields` — получение полей очереди
+  - Параметры: `queueId`
+  - Кеширование: ✅
 
-**Особенности:**
-- API требует filename в URL (получить из `get_attachments`)
-- Автоматическое кодирование filename через `encodeURIComponent()`
-- Поддержка больших файлов (streaming через Buffer)
+### Write Operations (Admin)
+- `create_queue` — создание новой очереди
+  - Параметры: `key` (A-Z, 2-10 символов), `name`, `lead`, `defaultType`, `defaultPriority`
+  - Safety: `requiresExplicitUserConsent: true` ⚠️
+  - Валидация ключа: `^[A-Z]{2,10}$`
 
----
+- `update_queue` — обновление настроек очереди
+  - Параметры: `queueId`, `name`, `lead`, `assignAuto`, etc.
+  - Safety: `requiresExplicitUserConsent: true` ⚠️
+  - Поддержка версионности (optimistic locking)
 
-### 3. Get Attachments — Список файлов
-
-**Tool:** `get_attachments`
-**Safety:** Read-only ✅
-
-```typescript
-{
-  "issueId": "QUEUE-123"
-}
-// Response: [
-//   { id: "67890", name: "report.pdf", size: 245678, mimetype: "application/pdf" },
-//   { id: "67891", name: "photo.jpg", size: 102400, thumbnail: "..." }
-// ]
-```
-
-**Кеширование:** ✅ Список кешируется, инвалидируется при upload/delete
-
----
-
-### 4. Delete Attachment — Удаление файла
-
-**Tool:** `delete_attachment`
-**Safety:** `requiresExplicitUserConsent: true` ⚠️
-
-```typescript
-{
-  "issueId": "QUEUE-123",
-  "attachmentId": "67890"
-}
-// Response: { deleted: true, issueId, attachmentId }
-```
-
-**Предупреждения:**
-- Операция необратима
-- Инвалидирует кеш списка файлов
-- Требует явного согласия пользователя
-
----
-
-### 5. Get Thumbnail — Миниатюра изображения
-
-**Tool:** `get_thumbnail`
-**Safety:** Read-only ✅
-
-```typescript
-{
-  "issueId": "QUEUE-123",
-  "attachmentId": "67891",
-  "filename": "photo.jpg"
-}
-// Response: { base64: "iVBORw0KG...", mimetype: "image/jpeg" }
-```
-
-**Ограничения:**
-- ✅ Только изображения (PNG, JPG, GIF)
-- ❌ Для документов вернет ошибку
-- Проверка через `attachment.thumbnail !== undefined`
-
----
-
-## 💬 Comments API — Complete Tools Documentation
-
-**4 инструмента для работы с комментариями к задачам**
-
-### 1. fr_yandex_tracker_add_comment
-
-**Категория:** `COMMENTS/write`
-**Назначение:** Добавить комментарий к задаче
-
-**Параметры:**
-- `issueId` (string, required) — ключ или ID задачи (например, TEST-123)
-- `text` (string, required) — текст комментария (поддерживает markdown)
-- `attachmentIds` (string[], optional) — массив ID прикрепленных файлов
-
-**Пример MCP запроса:**
-```json
-{
-  "name": "fr_yandex_tracker_add_comment",
-  "arguments": {
-    "issueId": "TEST-123",
-    "text": "## Обновление\n\nЗадача выполнена.",
-    "attachmentIds": ["att-1", "att-2"]
-  }
-}
-```
-
-**Пример ответа:**
-```json
-{
-  "data": {
-    "comment": {
-      "id": "comment-12345",
-      "self": "https://api.tracker.yandex.net/v2/issues/TEST-123/comments/comment-12345",
-      "text": "## Обновление\n\nЗадача выполнена.",
-      "createdBy": { "id": "user-1", "display": "John Doe" },
-      "createdAt": "2025-01-18T10:00:00.000+0000",
-      "version": 1,
-      "transport": "internal"
-    }
-  }
-}
-```
-
-### 2. fr_yandex_tracker_get_comments
-
-**Категория:** `COMMENTS/read`
-**Назначение:** Получить список комментариев задачи
-
-**Параметры:**
-- `issueId` (string, required) — ключ или ID задачи
-- `perPage` (number, optional) — количество комментариев на странице (default: 50)
-- `page` (number, optional) — номер страницы (начиная с 1)
-- `expand` (string, optional) — дополнительные поля ('attachments')
-
-**Пример MCP запроса:**
-```json
-{
-  "name": "fr_yandex_tracker_get_comments",
-  "arguments": {
-    "issueId": "TEST-123",
-    "perPage": 10,
-    "page": 1,
-    "expand": "attachments"
-  }
-}
-```
-
-**Пример ответа:**
-```json
-{
-  "data": {
-    "comments": [
-      {
-        "id": "comment-1",
-        "text": "First comment",
-        "createdBy": { "id": "user-1", "display": "John Doe" },
-        "createdAt": "2025-01-18T10:00:00.000+0000"
-      },
-      {
-        "id": "comment-2",
-        "text": "Second comment",
-        "createdBy": { "id": "user-2", "display": "Jane Smith" },
-        "createdAt": "2025-01-18T11:00:00.000+0000",
-        "attachments": [
-          { "id": "att-1", "name": "file.pdf", "size": 1024 }
-        ]
-      }
-    ]
-  }
-}
-```
-
-### 3. fr_yandex_tracker_edit_comment
-
-**Категория:** `COMMENTS/write`
-**Назначение:** Редактировать существующий комментарий
-
-**Параметры:**
-- `issueId` (string, required) — ключ или ID задачи
-- `commentId` (string, required) — ID комментария
-- `text` (string, required) — новый текст комментария
-
-**Пример MCP запроса:**
-```json
-{
-  "name": "fr_yandex_tracker_edit_comment",
-  "arguments": {
-    "issueId": "TEST-123",
-    "commentId": "comment-12345",
-    "text": "Обновленный текст комментария"
-  }
-}
-```
-
-**Пример ответа:**
-```json
-{
-  "data": {
-    "comment": {
-      "id": "comment-12345",
-      "text": "Обновленный текст комментария",
-      "createdBy": { "id": "user-1", "display": "John Doe" },
-      "createdAt": "2025-01-18T10:00:00.000+0000",
-      "updatedBy": { "id": "user-1", "display": "John Doe" },
-      "updatedAt": "2025-01-18T12:00:00.000+0000",
-      "version": 2
-    }
-  }
-}
-```
-
-### 4. fr_yandex_tracker_delete_comment
-
-**Категория:** `COMMENTS/write`
-**Назначение:** Удалить комментарий
-
-**Параметры:**
-- `issueId` (string, required) — ключ или ID задачи
-- `commentId` (string, required) — ID комментария
-
-**Пример MCP запроса:**
-```json
-{
-  "name": "fr_yandex_tracker_delete_comment",
-  "arguments": {
-    "issueId": "TEST-123",
-    "commentId": "comment-12345"
-  }
-}
-```
-
-**Пример ответа:**
-```json
-{
-  "data": {
-    "success": true,
-    "message": "Comment deleted successfully"
-  }
-}
-```
+- `manage_queue_access` — управление доступом к очереди
+  - Параметры: `queueId`, `role`, `add` (users/groups), `remove` (users/groups)
+  - Роли: `queue-lead`, `team-member`, `follower`, `access`
+  - Safety: `requiresExplicitUserConsent: true` ⚠️
 
 **Ключевые особенности:**
-- ✅ Markdown форматирование в тексте комментариев
-- ✅ Поддержка вложений (attachmentIds)
-- ✅ Пагинация для списка комментариев
-- ✅ Версионность для контроля конкурентных изменений
-- ❌ Удаленные комментарии восстановить нельзя
+- ✅ Админ права для create/update/manage-access
+- ✅ Версионность для оптимистичных блокировок
+- ✅ Кеширование очередей по ключу
+- ✅ Batch операции для manage_queue_access
 
----
-
-## 🔧 FileUploadUtil — Утилиты валидации
-
-**Методы:**
-
-```typescript
-// Валидация имени файла
-FileUploadUtil.validateFilename('report.pdf');  // true
-FileUploadUtil.validateFilename('../etc/passwd'); // false
-
-// Валидация размера
-FileUploadUtil.validateFileSize(buffer.length, 10_000_000); // true/false
-
-// Форматирование размера
-FileUploadUtil.formatFileSize(245678); // "239.92 KB"
-
-// MIME type
-FileUploadUtil.getMimeType('report.pdf'); // "application/pdf"
-
-// Multipart FormData
-FileUploadUtil.prepareMultipartFormData(buffer, filename);
-```
-
----
-
-## 📊 Integration Tests Coverage
-
-**Все 5 Attachments Tools покрыты integration тестами** (коммит c0f44c8):
-
-```bash
-✅ upload_attachment.integration.test.ts
-✅ download_attachment.integration.test.ts
-✅ get_attachments.integration.test.ts
-✅ delete_attachment.integration.test.ts
-✅ get_thumbnail.integration.test.ts
-```
-
-**Test scenarios:**
-- Upload: base64 + file path + валидация
-- Download: base64 + save to file
-- Get: список + пустой список
-- Delete: успех + 404
-- Thumbnail: изображение + ошибка для не-изображений
+См. файлы в `src/tools/api/queues/` для деталей.
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/README.md
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/README.md
@@ -293,66 +293,6 @@ export class PingOperation extends BaseOperation {
 }
 ```
 
-### Операции с файлами (Attachments)
-
-**Эталон:** `src/tracker_api/api_operations/attachment/upload-attachment.operation.ts`
-
-```typescript
-export class UploadAttachmentOperation extends BaseOperation {
-  async execute(
-    issueId: string,
-    input: UploadAttachmentInput
-  ): Promise<AttachmentWithUnknownFields> {
-    const { filename, file, mimetype } = input;
-
-    // Конвертация base64 в Buffer если нужно
-    const buffer = typeof file === 'string' ? Buffer.from(file, 'base64') : file;
-
-    // Валидация размера и имени файла
-    FileUploadUtil.validateFilename(filename);
-    FileUploadUtil.validateFileSize(buffer.length, this.maxFileSize);
-
-    // Подготовка FormData для multipart/form-data
-    const formData = FileUploadUtil.prepareMultipartFormData(buffer, filename);
-
-    // Загрузка через BaseOperation.uploadFile()
-    const attachment = await this.uploadFile<AttachmentWithUnknownFields>(
-      `/v2/issues/${issueId}/attachments`,
-      formData
-    );
-
-    // Инвалидация кеша списка файлов
-    const listCacheKey = EntityCacheKey.createKey(EntityType.ATTACHMENT, `list:${issueId}`);
-    this.cacheManager.delete(listCacheKey);
-
-    return attachment;
-  }
-}
-```
-
-**Эталон:** `src/tracker_api/api_operations/attachment/download-attachment.operation.ts`
-
-```typescript
-export class DownloadAttachmentOperation extends BaseOperation {
-  async execute(issueId: string, attachmentId: string, filename: string): Promise<Buffer> {
-    // Используем BaseOperation.downloadFile() для получения бинарных данных
-    const buffer = await this.downloadFile(
-      `/v2/issues/${issueId}/attachments/${attachmentId}/${encodeURIComponent(filename)}`
-    );
-
-    this.logger.info(`Файл ${filename} скачан, размер=${buffer.length} байт`);
-    return buffer;
-  }
-}
-```
-
-**Особенности работы с файлами:**
-- `uploadFile()` — для multipart/form-data загрузки
-- `downloadFile()` — для скачивания бинарных данных
-- Валидация через `FileUploadUtil` (размер, имя файла, MIME type)
-- Инвалидация кеша после модификаций (upload, delete)
-- Кодирование имени файла через `encodeURIComponent()` в URL
-
 ---
 
 ## 📎 Attachment Operations (Complete API)
@@ -490,6 +430,56 @@ await deleteCommentOp.execute('QUEUE-123', 'comment-456');
 - **Версионность:** Поле `version` используется для оптимистичной блокировки
 - **Transport:** Комментарии могут быть созданы через UI ('internal') или email ('email')
 - **Кеш:** Список комментариев кешируется, инвалидируется при add/edit/delete
+
+---
+
+## 🗂️ Queue Operations (Complete API)
+
+**6 операций для работы с очередями:**
+
+### 1. GetQueueOperation
+**API:** `GET /v3/queues/{queueId}`
+**Назначение:** Получение одной очереди по ID или ключу
+- Кеш: ✅ (по ключу очереди)
+- Параметр `expand` для дополнительных полей
+
+### 2. GetQueuesOperation
+**API:** `GET /v3/queues/`
+**Назначение:** Получение списка всех очередей
+- Кеш: ✅
+- Параметры: `expand`, `perPage`, `page`
+
+### 3. CreateQueueOperation
+**API:** `POST /v3/queues/`
+**Назначение:** Создание новой очереди
+- Администраторская операция
+- Валидация ключа: `^[A-Z]{2,10}$`
+- Кеш: создаёт cache entry для новой очереди
+
+### 4. UpdateQueueOperation
+**API:** `PATCH /v3/queues/{queueId}`
+**Назначение:** Обновление настроек очереди
+- Кеш: ❌ инвалидирует cache для очереди
+- Поддержка версионности (optimistic locking)
+
+### 5. GetQueueFieldsOperation
+**API:** `GET /v3/queues/{queueId}/fields`
+**Назначение:** Получение списка полей очереди
+- Кеш: ✅
+- Возвращает настраиваемые поля очереди
+
+### 6. ManageQueueAccessOperation
+**API:** `POST /v3/queues/{queueId}/permissions`
+**Назначение:** Управление доступом к очереди
+- Кеш: ❌ инвалидирует permissions cache
+- Роли: queue-lead, team-member, follower, access
+- Batch операция для добавления/удаления прав
+
+**Ключевые аспекты:**
+- **Админ права:** create/update/manage-access требуют администраторских прав
+- **Версионность:** `version` поле для оптимистичных блокировок
+- **Кеш:** Очереди кешируются по ключу, инвалидируются при изменениях
+- **Batch:** GetQueuesOperation поддерживает пагинацию
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tracker_api/entities/README.md
+++ b/packages/servers/yandex-tracker/src/tracker_api/entities/README.md
@@ -317,166 +317,48 @@ export type StatusWithUnknownFields = WithUnknownFields<Status>;
 
 **Файл:** `src/tracker_api/entities/issue.entity.ts`
 
-```typescript
-import type { WithUnknownFields } from './types.js';
-import type { User } from './user.entity.js';
-import type { Queue } from './queue.entity.js';
-import type { Status } from './status.entity.js';
-import type { Priority } from './priority.entity.js';
-import type { IssueType } from './issue-type.entity.js';
-
-export interface Issue {
-  /** Идентификатор задачи (всегда присутствует) */
-  readonly id: string;
-
-  /** Уникальный ключ задачи (QUEUE-123) (всегда присутствует) */
-  readonly key: string;
-
-  /** Краткое описание */
-  readonly summary: string;
-
-  // Вложенные entities
-  /** Очередь задачи */
-  readonly queue: Queue;
-
-  /** Текущий статус */
-  readonly status: Status;
-
-  /** Автор задачи */
-  readonly createdBy: User;
-
-  /** Исполнитель задачи */
-  readonly assignee?: User;
-
-  // Даты
-  /** Дата создания (ISO 8601) */
-  readonly createdAt: string;
-
-  /** Дата последнего обновления (ISO 8601) */
-  readonly updatedAt: string;
-}
-
-export type IssueWithUnknownFields = WithUnknownFields<Issue>;
-```
+Использует вложенные entities (`Queue`, `Status`, `User`) для связанных объектов.
+См. полный код в файле выше.
 
 ### Entity для файловых вложений
 
 **Файл:** `src/tracker_api/entities/attachment.entity.ts`
 
-```typescript
-import type { WithUnknownFields } from './types.js';
-import type { UserRef } from './common/user-ref.entity.js';
-
-/**
- * Прикрепленный файл (вложение) в Яндекс.Трекере
- *
- * Представляет файл, прикрепленный к задаче.
- * Может быть изображением, документом или любым другим типом файла.
- */
-export interface Attachment {
-  /** Уникальный идентификатор файла (всегда присутствует) */
-  readonly id: string;
-
-  /** URL ресурса для self-reference (всегда присутствует) */
-  readonly self: string;
-
-  /** Имя файла (всегда присутствует) */
-  readonly name: string;
-
-  /** URL для скачивания файла (всегда присутствует) */
-  readonly content: string;
-
-  /** URL миниатюры изображения (присутствует только для изображений) */
-  readonly thumbnail?: string;
-
-  /** Автор загрузки файла (всегда присутствует) */
-  readonly createdBy: UserRef;
-
-  /** Дата создания (ISO 8601) (всегда присутствует) */
-  readonly createdAt: string;
-
-  /** MIME тип файла (всегда присутствует) */
-  readonly mimetype: string;
-
-  /** Размер файла в байтах (всегда присутствует) */
-  readonly size: number;
-}
-
-export type AttachmentWithUnknownFields = WithUnknownFields<Attachment>;
-```
-
-**Особенности:**
-- Использует `UserRef` вместо полного `User` для оптимизации
-- Опциональное поле `thumbnail` присутствует только для изображений
-- Поле `content` содержит URL для скачивания, а не само содержимое файла
-- Поле `size` указывает размер в байтах для валидации перед скачиванием
+- Использует `UserRef` для оптимизации
+- Поле `content` — URL скачивания, `thumbnail` — опциональная миниатюра
+- Поля `size` и `mimetype` для метаданных
 
 ### Entity для комментариев
 
 **Файл:** `src/tracker_api/entities/comment/comment.entity.ts`
 
-```typescript
-import type { WithUnknownFields } from '../types.js';
-import type { UserRef } from '../common/user-ref.entity.js';
+- Использует `UserRef` для авторов, поддерживает вложения
+- Поле `version` для оптимистичных блокировок
+- Поле `transport` определяет способ доставки: 'internal' или 'email'
 
-/**
- * Вложение в комментарии
- */
-export interface CommentAttachment {
-  /** Идентификатор вложения */
-  readonly id: string;
+### Entity для очередей
 
-  /** Имя файла */
-  readonly name: string;
+**Файл:** `src/tracker_api/entities/queue.entity.ts`
 
-  /** Размер файла в байтах */
-  readonly size: number;
-}
+- Использует `UserRef` для руководителя, `QueueDictionaryRef` для справочников
+- Поле `version` для оптимистичных блокировок
+- Поле `assignAuto` контролирует автоназначение исполнителей
 
-/**
- * Комментарий к задаче
- */
-export interface Comment {
-  /** Идентификатор комментария (всегда присутствует) */
-  readonly id: string;
+### Entity для полей очереди
 
-  /** URL ссылка на комментарий в API (всегда присутствует) */
-  readonly self: string;
+**Файл:** `src/tracker_api/entities/queue-field.entity.ts`
 
-  /** Текст комментария (всегда присутствует) */
-  readonly text: string;
+- Описывает настраиваемые поля очереди
+- Поле `required` определяет обязательность при создании задач
+- Поле `type`: строка, пользователь, дата, число, select, array
 
-  /** Автор комментария (всегда присутствует) */
-  readonly createdBy: UserRef;
+### Entity для прав доступа
 
-  /** Дата создания комментария в формате ISO 8601 (всегда присутствует) */
-  readonly createdAt: string;
+**Файл:** `src/tracker_api/entities/queue-permission.entity.ts`
 
-  /** Пользователь, который последним изменил комментарий */
-  readonly updatedBy?: UserRef;
-
-  /** Дата последнего изменения в формате ISO 8601 */
-  readonly updatedAt?: string;
-
-  /** Версия комментария (для оптимистичной блокировки) */
-  readonly version?: number;
-
-  /** Способ доставки комментария */
-  readonly transport?: 'internal' | 'email';
-
-  /** Вложения в комментарии */
-  readonly attachments?: readonly CommentAttachment[];
-}
-
-export type CommentWithUnknownFields = WithUnknownFields<Comment>;
-```
-
-**Особенности:**
-- Использует `UserRef` для автора и редактора комментария
-- Поддерживает вложения через `CommentAttachment`
-- Поле `transport` указывает способ доставки: 'internal' (через UI) или 'email'
-- Поле `version` используется для контроля конкурентных изменений
-- Опциональные поля `updatedBy` и `updatedAt` присутствуют только для отредактированных комментариев
+- Описывает права доступа к очереди
+- `QueueRole`: queue-lead, team-member, follower, access
+- Минималистичная структура — логика в API операциях
 
 ---
 

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/queues/access/manage-queue-access.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/queues/access/manage-queue-access.tool.integration.test.ts
@@ -31,7 +31,7 @@ describe('manage-queue-access integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_manage_queue_access', {
         queueId: queueKey,
         action: 'add',
-        userLogin: 'testuser',
+        subjects: ['testuser'],
         role: 'follower',
       });
 
@@ -52,7 +52,7 @@ describe('manage-queue-access integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_manage_queue_access', {
         queueId: queueKey,
         action: 'remove',
-        userLogin: 'testuser',
+        subjects: ['testuser'],
         role: 'follower',
       });
 
@@ -72,8 +72,8 @@ describe('manage-queue-access integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_manage_queue_access', {
         queueId: queueKey,
         action: 'add',
-        userLogin: 'developer',
-        role: 'teamMember',
+        subjects: ['developer'],
+        role: 'team-member',
       });
 
       // Assert
@@ -83,7 +83,7 @@ describe('manage-queue-access integration tests', () => {
       mockServer.assertAllRequestsDone();
     });
 
-    it('должен добавить доступ с ролью assignee', async () => {
+    it('должен добавить доступ с ролью access', async () => {
       // Arrange
       const queueKey = 'TEST';
       mockServer.mockManageQueueAccessSuccess(queueKey);
@@ -92,8 +92,8 @@ describe('manage-queue-access integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_manage_queue_access', {
         queueId: queueKey,
         action: 'add',
-        userLogin: 'assignee1',
-        role: 'assignee',
+        subjects: ['assignee1'],
+        role: 'access',
       });
 
       // Assert
@@ -114,7 +114,7 @@ describe('manage-queue-access integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_manage_queue_access', {
         queueId: queueKey,
         action: 'add',
-        userLogin: 'testuser',
+        subjects: ['testuser'],
         role: 'follower',
       });
 

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/queues/create/create-queue.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/queues/create/create-queue.tool.integration.test.ts
@@ -33,7 +33,9 @@ describe('create-queue integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_create_queue', {
         key: 'NEWQ',
         name: 'New Queue',
-        leadLogin: 'testuser',
+        lead: 'testuser',
+        defaultType: 'task',
+        defaultPriority: 'normal',
       });
 
       // Assert
@@ -57,10 +59,10 @@ describe('create-queue integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_create_queue', {
         key: 'PROJ',
         name: 'Project Queue',
-        leadLogin: 'manager',
+        lead: 'manager',
+        defaultType: 'task',
+        defaultPriority: 'normal',
         description: 'Project queue description',
-        defaultTypeKey: 'task',
-        defaultPriorityKey: 'normal',
       });
 
       // Assert
@@ -81,7 +83,9 @@ describe('create-queue integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_create_queue', {
         key: 'NEWQ',
         name: 'New Queue',
-        leadLogin: 'testuser',
+        lead: 'testuser',
+        defaultType: 'task',
+        defaultPriority: 'normal',
       });
 
       // Assert
@@ -99,7 +103,9 @@ describe('create-queue integration tests', () => {
       const result = await client.callTool('fr_yandex_tracker_create_queue', {
         key: 'TEST',
         name: 'Test',
-        leadLogin: 'admin',
+        lead: 'admin',
+        defaultType: 'task',
+        defaultPriority: 'normal',
       });
 
       // Assert


### PR DESCRIPTION
Обновления:
- entities/README.md: примеры Queue, QueueField, QueuePermission (369 строк)
- api_operations/README.md: секция Queue Operations с 6 операциями (491 строк)
- tools/README.md: секция Queues Tools с 6 MCP инструментами (474 строки)

Сокращены примеры Attachments/Comments для соблюдения лимитов (≤500 строк).

Изменены integration тесты для соответствия Zod schemas:
- create-queue: leadLogin → lead, добавлены defaultType/defaultPriority
- manage-queue-access: userLogin → subjects, teamMember → team-member

🤖 Generated with Claude Code