### PR TITLE
Expand Components API coverage

### DIFF
--- a/packages/framework/core/src/tools/base/tool-metadata.ts
+++ b/packages/framework/core/src/tools/base/tool-metadata.ts
@@ -24,6 +24,7 @@ export enum ToolCategory {
   SPRINTS = 'sprints',
   COMMENTS = 'comments',
   CHECKLISTS = 'checklists',
+  COMPONENTS = 'components',
 
   // Системные инструменты
   SYSTEM = 'system',

--- a/packages/framework/infrastructure/src/cache/entity-cache-key.ts
+++ b/packages/framework/infrastructure/src/cache/entity-cache-key.ts
@@ -20,6 +20,7 @@ export enum EntityType {
   QUEUE = 'queue',
   USER = 'user',
   COMMENT = 'comment',
+  COMPONENT = 'component',
   SPRINT = 'sprint',
   PROJECT = 'project',
   ATTACHMENT = 'attachment',

--- a/packages/servers/yandex-tracker/src/composition-root/definitions/operation-definitions.ts
+++ b/packages/servers/yandex-tracker/src/composition-root/definitions/operation-definitions.ts
@@ -26,6 +26,12 @@ import {
   ManageQueueAccessOperation,
 } from '@tracker_api/api_operations/queue/index.js';
 import {
+  GetComponentsOperation,
+  CreateComponentOperation,
+  UpdateComponentOperation,
+  DeleteComponentOperation,
+} from '@tracker_api/api_operations/component/index.js';
+import {
   GetIssueLinksOperation,
   CreateLinkOperation,
   DeleteLinkOperation,
@@ -67,6 +73,10 @@ export const OPERATION_CLASSES = [
   UpdateQueueOperation,
   GetQueueFieldsOperation,
   ManageQueueAccessOperation,
+  GetComponentsOperation,
+  CreateComponentOperation,
+  UpdateComponentOperation,
+  DeleteComponentOperation,
   GetIssueLinksOperation,
   CreateLinkOperation,
   DeleteLinkOperation,

--- a/packages/servers/yandex-tracker/src/composition-root/definitions/tool-definitions.ts
+++ b/packages/servers/yandex-tracker/src/composition-root/definitions/tool-definitions.ts
@@ -23,6 +23,12 @@ import {
   GetQueueFieldsTool,
   ManageQueueAccessTool,
 } from '@tools/api/queues/index.js';
+import {
+  GetComponentsTool,
+  CreateComponentTool,
+  UpdateComponentTool,
+  DeleteComponentTool,
+} from '@tools/api/components/index.js';
 import { GetIssueLinksTool } from '@tools/api/issues/links/get/index.js';
 import { CreateLinkTool } from '@tools/api/issues/links/create/index.js';
 import { DeleteLinkTool } from '@tools/api/issues/links/delete/index.js';
@@ -69,6 +75,10 @@ export const TOOL_CLASSES = [
   UpdateQueueTool,
   GetQueueFieldsTool,
   ManageQueueAccessTool,
+  GetComponentsTool,
+  CreateComponentTool,
+  UpdateComponentTool,
+  DeleteComponentTool,
   GetIssueLinksTool,
   CreateLinkTool,
   DeleteLinkTool,

--- a/packages/servers/yandex-tracker/src/tools/README.md
+++ b/packages/servers/yandex-tracker/src/tools/README.md
@@ -466,6 +466,24 @@ ESSENTIAL_TOOLS=ping,search_tools
 
 ---
 
+## 📦 Components API — Complete Tools
+
+**4 MCP Tools для работы с компонентами очередей:**
+
+- `get_components` — список компонентов очереди (кеш ✅, API v2)
+- `create_component` — создание (queueId, name, description?, lead?, assignAuto?) ⚠️
+- `update_component` — обновление (componentId, name?, description?, lead?, assignAuto?) ⚠️
+- `delete_component` — удаление компонента ⚠️
+
+**Ключевые особенности:**
+- API v2 (не v3)
+- Компоненты привязаны к очереди
+- `assignAuto` — автоназначение исполнителя
+
+См. файлы в `src/tools/api/components/` для деталей.
+
+---
+
 ## 🔗 См. также
 
 - **Общие утилиты:** [@mcp-framework/core](../../../../../framework/core/src/tools/common/README.md)

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.definition.ts
@@ -1,0 +1,78 @@
+/**
+ * Определение MCP tool для создания компонента
+ */
+
+import {
+  BaseToolDefinition,
+  type ToolDefinition,
+  type StaticToolMetadata,
+} from '@mcp-framework/core';
+import { CreateComponentTool } from './create-component.tool.js';
+
+/**
+ * Definition для CreateComponentTool
+ */
+export class CreateComponentDefinition extends BaseToolDefinition {
+  protected getStaticMetadata(): StaticToolMetadata {
+    return CreateComponentTool.METADATA;
+  }
+
+  build(): ToolDefinition {
+    return {
+      name: this.getToolName(),
+      description: this.wrapWithSafetyWarning(this.buildDescription()),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          queueId: this.buildQueueIdParam(),
+          name: this.buildNameParam(),
+          description: this.buildDescriptionParam(),
+          lead: this.buildLeadParam(),
+          assignAuto: this.buildAssignAutoParam(),
+        },
+        required: ['queueId', 'name'],
+      },
+    };
+  }
+
+  private buildDescription(): string {
+    return (
+      'Создать новый компонент в очереди. ' +
+      'Требует указания очереди и названия компонента. ' +
+      '\n\n' +
+      'Для: создания нового компонента для группировки задач. ' +
+      '\n' +
+      'Не для: получения компонентов (get_components), изменения (update_component).'
+    );
+  }
+
+  private buildQueueIdParam(): Record<string, unknown> {
+    return this.buildStringParam('ID или ключ очереди (обязательно).', {
+      examples: ['QUEUE', '1'],
+    });
+  }
+
+  private buildNameParam(): Record<string, unknown> {
+    return this.buildStringParam('Название компонента (обязательно).', {
+      examples: ['Backend', 'Frontend', 'API'],
+    });
+  }
+
+  private buildDescriptionParam(): Record<string, unknown> {
+    return this.buildStringParam('Описание компонента (опционально).', {
+      examples: ['Серверная часть приложения'],
+    });
+  }
+
+  private buildLeadParam(): Record<string, unknown> {
+    return this.buildStringParam('ID или login руководителя компонента (опционально).', {
+      examples: ['user-login', '1234567890'],
+    });
+  }
+
+  private buildAssignAutoParam(): Record<string, unknown> {
+    return this.buildBooleanParam(
+      'Автоматически назначать задачи руководителю компонента (опционально).'
+    );
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Zod схема для валидации параметров CreateComponentTool
+ */
+
+import { z } from 'zod';
+
+/**
+ * Схема параметров для создания компонента
+ */
+export const CreateComponentParamsSchema = z.object({
+  /**
+   * ID или ключ очереди
+   */
+  queueId: z.string().min(1, 'Queue ID обязателен'),
+
+  /**
+   * Название компонента
+   */
+  name: z.string().min(1, 'Название компонента обязательно'),
+
+  /**
+   * Описание компонента (опционально)
+   */
+  description: z.string().optional(),
+
+  /**
+   * ID или login руководителя компонента (опционально)
+   */
+  lead: z.string().optional(),
+
+  /**
+   * Автоматическое назначение задач (опционально)
+   */
+  assignAuto: z.boolean().optional(),
+});
+
+/**
+ * Вывод типа из схемы
+ */
+export type CreateComponentParams = z.infer<typeof CreateComponentParamsSchema>;

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.tool.ts
@@ -1,0 +1,73 @@
+/**
+ * MCP Tool для создания компонента в Яндекс.Трекере
+ */
+
+import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
+import type { ToolDefinition } from '@mcp-framework/core';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { CreateComponentDefinition } from './create-component.definition.js';
+import { CreateComponentParamsSchema } from './create-component.schema.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Инструмент для создания компонента
+ */
+export class CreateComponentTool extends BaseTool<YandexTrackerFacade> {
+  static override readonly METADATA = {
+    name: buildToolName('create_component', MCP_TOOL_PREFIX),
+    description: '[Components/Write] Создать компонент',
+    category: ToolCategory.COMPONENTS,
+    subcategory: 'write',
+    priority: ToolPriority.HIGH,
+    tags: ['components', 'create', 'write'],
+    isHelper: false,
+    requiresExplicitUserConsent: true,
+  } as const;
+
+  private readonly definition = new CreateComponentDefinition();
+
+  protected buildDefinition(): ToolDefinition {
+    return this.definition.build();
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, CreateComponentParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { queueId, name, description, lead, assignAuto } = validation.data;
+
+    try {
+      this.logger.info('Создание компонента', {
+        queueId,
+        name,
+        hasDescription: !!description,
+        hasLead: !!lead,
+        assignAuto: assignAuto ?? false,
+      });
+
+      const component = await this.facade.createComponent({
+        queueId,
+        name,
+        description,
+        lead,
+        assignAuto,
+      });
+
+      this.logger.info('Компонент создан', {
+        componentId: component.id,
+        name: component.name,
+      });
+
+      return this.formatSuccess({
+        component,
+        message: `Компонент "${name}" успешно создан`,
+      });
+    } catch (error: unknown) {
+      return this.formatError('Ошибка при создании компонента', error as Error);
+    }
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/delete-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/delete-component.definition.ts
@@ -1,0 +1,50 @@
+/**
+ * Определение MCP tool для удаления компонента
+ */
+
+import {
+  BaseToolDefinition,
+  type ToolDefinition,
+  type StaticToolMetadata,
+} from '@mcp-framework/core';
+import { DeleteComponentTool } from './delete-component.tool.js';
+
+/**
+ * Definition для DeleteComponentTool
+ */
+export class DeleteComponentDefinition extends BaseToolDefinition {
+  protected getStaticMetadata(): StaticToolMetadata {
+    return DeleteComponentTool.METADATA;
+  }
+
+  build(): ToolDefinition {
+    return {
+      name: this.getToolName(),
+      description: this.wrapWithSafetyWarning(this.buildDescription()),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          componentId: this.buildComponentIdParam(),
+        },
+        required: ['componentId'],
+      },
+    };
+  }
+
+  private buildDescription(): string {
+    return (
+      'Удалить компонент из очереди. ' +
+      'Операция необратима, компонент будет удален безвозвратно. ' +
+      '\n\n' +
+      'Для: удаления ненужного компонента. ' +
+      '\n' +
+      'Не для: изменения компонента (update_component), создания (create_component).'
+    );
+  }
+
+  private buildComponentIdParam(): Record<string, unknown> {
+    return this.buildStringParam('ID компонента для удаления (обязательно).', {
+      examples: ['12345', '67890'],
+    });
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/delete-component.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/delete-component.schema.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod схема для валидации параметров DeleteComponentTool
+ */
+
+import { z } from 'zod';
+
+/**
+ * Схема параметров для удаления компонента
+ */
+export const DeleteComponentParamsSchema = z.object({
+  /**
+   * ID компонента для удаления
+   */
+  componentId: z.string().min(1, 'Component ID обязателен'),
+});
+
+/**
+ * Вывод типа из схемы
+ */
+export type DeleteComponentParams = z.infer<typeof DeleteComponentParamsSchema>;

--- a/packages/servers/yandex-tracker/src/tools/api/components/delete-component.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/delete-component.tool.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP Tool для удаления компонента в Яндекс.Трекере
+ */
+
+import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
+import type { ToolDefinition } from '@mcp-framework/core';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { DeleteComponentDefinition } from './delete-component.definition.js';
+import { DeleteComponentParamsSchema } from './delete-component.schema.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Инструмент для удаления компонента
+ */
+export class DeleteComponentTool extends BaseTool<YandexTrackerFacade> {
+  static override readonly METADATA = {
+    name: buildToolName('delete_component', MCP_TOOL_PREFIX),
+    description: '[Components/Write] Удалить компонент',
+    category: ToolCategory.COMPONENTS,
+    subcategory: 'write',
+    priority: ToolPriority.HIGH,
+    tags: ['components', 'delete', 'write', 'remove'],
+    isHelper: false,
+    requiresExplicitUserConsent: true,
+  } as const;
+
+  private readonly definition = new DeleteComponentDefinition();
+
+  protected buildDefinition(): ToolDefinition {
+    return this.definition.build();
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, DeleteComponentParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { componentId } = validation.data;
+
+    try {
+      this.logger.info('Удаление компонента', {
+        componentId,
+      });
+
+      await this.facade.deleteComponent({ componentId });
+
+      this.logger.info('Компонент удален', {
+        componentId,
+      });
+
+      return this.formatSuccess({
+        success: true,
+        componentId,
+        message: `Компонент ${componentId} успешно удален`,
+      });
+    } catch (error: unknown) {
+      return this.formatError('Ошибка при удалении компонента', error as Error);
+    }
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.definition.ts
@@ -1,0 +1,50 @@
+/**
+ * Определение MCP tool для получения списка компонентов очереди
+ */
+
+import {
+  BaseToolDefinition,
+  type ToolDefinition,
+  type StaticToolMetadata,
+} from '@mcp-framework/core';
+import { GetComponentsTool } from './get-components.tool.js';
+
+/**
+ * Definition для GetComponentsTool
+ */
+export class GetComponentsDefinition extends BaseToolDefinition {
+  protected getStaticMetadata(): StaticToolMetadata {
+    return GetComponentsTool.METADATA;
+  }
+
+  build(): ToolDefinition {
+    return {
+      name: this.getToolName(),
+      description: this.buildDescription(),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          queueId: this.buildQueueIdParam(),
+        },
+        required: ['queueId'],
+      },
+    };
+  }
+
+  private buildDescription(): string {
+    return (
+      'Получить список компонентов очереди. ' +
+      'Возвращает все компоненты с их параметрами. ' +
+      '\n\n' +
+      'Для: просмотра компонентов очереди, управления компонентами. ' +
+      '\n' +
+      'Не для: создания компонентов (create_component), изменения (update_component).'
+    );
+  }
+
+  private buildQueueIdParam(): Record<string, unknown> {
+    return this.buildStringParam('ID или ключ очереди (обязательно).', {
+      examples: ['QUEUE', '1'],
+    });
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.schema.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod схема для валидации параметров GetComponentsTool
+ */
+
+import { z } from 'zod';
+
+/**
+ * Схема параметров для получения списка компонентов очереди
+ */
+export const GetComponentsParamsSchema = z.object({
+  /**
+   * ID или ключ очереди
+   */
+  queueId: z.string().min(1, 'Queue ID обязателен'),
+});
+
+/**
+ * Вывод типа из схемы
+ */
+export type GetComponentsParams = z.infer<typeof GetComponentsParamsSchema>;

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.tool.ts
@@ -1,0 +1,64 @@
+/**
+ * MCP Tool для получения списка компонентов очереди в Яндекс.Трекере
+ */
+
+import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
+import type { ToolDefinition } from '@mcp-framework/core';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { GetComponentsDefinition } from './get-components.definition.js';
+import { GetComponentsParamsSchema } from './get-components.schema.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Инструмент для получения списка компонентов очереди
+ */
+export class GetComponentsTool extends BaseTool<YandexTrackerFacade> {
+  static override readonly METADATA = {
+    name: buildToolName('get_components', MCP_TOOL_PREFIX),
+    description: '[Components/Read] Получить список компонентов очереди',
+    category: ToolCategory.COMPONENTS,
+    subcategory: 'read',
+    priority: ToolPriority.HIGH,
+    tags: ['components', 'list', 'read', 'queue'],
+    isHelper: false,
+    requiresExplicitUserConsent: false,
+  } as const;
+
+  private readonly definition = new GetComponentsDefinition();
+
+  protected buildDefinition(): ToolDefinition {
+    return this.definition.build();
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, GetComponentsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { queueId } = validation.data;
+
+    try {
+      this.logger.info('Получение списка компонентов очереди', {
+        queueId,
+      });
+
+      const components = await this.facade.getComponents({ queueId });
+
+      this.logger.info('Список компонентов получен', {
+        count: components.length,
+        queueId,
+      });
+
+      return this.formatSuccess({
+        components,
+        count: components.length,
+        queueId,
+      });
+    } catch (error: unknown) {
+      return this.formatError('Ошибка при получении списка компонентов', error as Error);
+    }
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/index.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Экспорты для Components API tools
+ */
+
+// Get Components
+export { GetComponentsTool } from './get-components.tool.js';
+export { GetComponentsDefinition } from './get-components.definition.js';
+export { GetComponentsParamsSchema, type GetComponentsParams } from './get-components.schema.js';
+
+// Create Component
+export { CreateComponentTool } from './create-component.tool.js';
+export { CreateComponentDefinition } from './create-component.definition.js';
+export {
+  CreateComponentParamsSchema,
+  type CreateComponentParams,
+} from './create-component.schema.js';
+
+// Update Component
+export { UpdateComponentTool } from './update-component.tool.js';
+export { UpdateComponentDefinition } from './update-component.definition.js';
+export {
+  UpdateComponentParamsSchema,
+  type UpdateComponentParams,
+} from './update-component.schema.js';
+
+// Delete Component
+export { DeleteComponentTool } from './delete-component.tool.js';
+export { DeleteComponentDefinition } from './delete-component.definition.js';
+export {
+  DeleteComponentParamsSchema,
+  type DeleteComponentParams,
+} from './delete-component.schema.js';

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.definition.ts
@@ -1,0 +1,78 @@
+/**
+ * Определение MCP tool для обновления компонента
+ */
+
+import {
+  BaseToolDefinition,
+  type ToolDefinition,
+  type StaticToolMetadata,
+} from '@mcp-framework/core';
+import { UpdateComponentTool } from './update-component.tool.js';
+
+/**
+ * Definition для UpdateComponentTool
+ */
+export class UpdateComponentDefinition extends BaseToolDefinition {
+  protected getStaticMetadata(): StaticToolMetadata {
+    return UpdateComponentTool.METADATA;
+  }
+
+  build(): ToolDefinition {
+    return {
+      name: this.getToolName(),
+      description: this.wrapWithSafetyWarning(this.buildDescription()),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          componentId: this.buildComponentIdParam(),
+          name: this.buildNameParam(),
+          description: this.buildDescriptionParam(),
+          lead: this.buildLeadParam(),
+          assignAuto: this.buildAssignAutoParam(),
+        },
+        required: ['componentId'],
+      },
+    };
+  }
+
+  private buildDescription(): string {
+    return (
+      'Обновить параметры компонента. ' +
+      'Можно изменить название, описание, руководителя или настройку автоназначения. ' +
+      '\n\n' +
+      'Для: изменения существующего компонента. ' +
+      '\n' +
+      'Не для: создания компонента (create_component), удаления (delete_component).'
+    );
+  }
+
+  private buildComponentIdParam(): Record<string, unknown> {
+    return this.buildStringParam('ID компонента для обновления (обязательно).', {
+      examples: ['12345', '67890'],
+    });
+  }
+
+  private buildNameParam(): Record<string, unknown> {
+    return this.buildStringParam('Новое название компонента (опционально).', {
+      examples: ['Backend API', 'Frontend UI'],
+    });
+  }
+
+  private buildDescriptionParam(): Record<string, unknown> {
+    return this.buildStringParam('Новое описание компонента (опционально).', {
+      examples: ['Обновленное описание компонента'],
+    });
+  }
+
+  private buildLeadParam(): Record<string, unknown> {
+    return this.buildStringParam('Новый руководитель компонента (опционально).', {
+      examples: ['user-login', '1234567890'],
+    });
+  }
+
+  private buildAssignAutoParam(): Record<string, unknown> {
+    return this.buildBooleanParam(
+      'Автоматически назначать задачи руководителю компонента (опционально).'
+    );
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Zod схема для валидации параметров UpdateComponentTool
+ */
+
+import { z } from 'zod';
+
+/**
+ * Схема параметров для обновления компонента
+ */
+export const UpdateComponentParamsSchema = z.object({
+  /**
+   * ID компонента
+   */
+  componentId: z.string().min(1, 'Component ID обязателен'),
+
+  /**
+   * Новое название компонента (опционально)
+   */
+  name: z.string().min(1).optional(),
+
+  /**
+   * Новое описание компонента (опционально)
+   */
+  description: z.string().optional(),
+
+  /**
+   * Новый руководитель компонента (опционально)
+   */
+  lead: z.string().optional(),
+
+  /**
+   * Автоматическое назначение задач (опционально)
+   */
+  assignAuto: z.boolean().optional(),
+});
+
+/**
+ * Вывод типа из схемы
+ */
+export type UpdateComponentParams = z.infer<typeof UpdateComponentParamsSchema>;

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.tool.ts
@@ -1,0 +1,73 @@
+/**
+ * MCP Tool для обновления компонента в Яндекс.Трекере
+ */
+
+import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
+import type { ToolDefinition } from '@mcp-framework/core';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { UpdateComponentDefinition } from './update-component.definition.js';
+import { UpdateComponentParamsSchema } from './update-component.schema.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Инструмент для обновления компонента
+ */
+export class UpdateComponentTool extends BaseTool<YandexTrackerFacade> {
+  static override readonly METADATA = {
+    name: buildToolName('update_component', MCP_TOOL_PREFIX),
+    description: '[Components/Write] Обновить компонент',
+    category: ToolCategory.COMPONENTS,
+    subcategory: 'write',
+    priority: ToolPriority.HIGH,
+    tags: ['components', 'update', 'write', 'modify'],
+    isHelper: false,
+    requiresExplicitUserConsent: true,
+  } as const;
+
+  private readonly definition = new UpdateComponentDefinition();
+
+  protected buildDefinition(): ToolDefinition {
+    return this.definition.build();
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, UpdateComponentParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { componentId, name, description, lead, assignAuto } = validation.data;
+
+    try {
+      this.logger.info('Обновление компонента', {
+        componentId,
+        hasName: !!name,
+        hasDescription: description !== undefined,
+        hasLead: !!lead,
+        hasAssignAuto: assignAuto !== undefined,
+      });
+
+      const component = await this.facade.updateComponent({
+        componentId,
+        name,
+        description,
+        lead,
+        assignAuto,
+      });
+
+      this.logger.info('Компонент обновлен', {
+        componentId: component.id,
+        name: component.name,
+      });
+
+      return this.formatSuccess({
+        component,
+        message: `Компонент ${componentId} успешно обновлен`,
+      });
+    } catch (error: unknown) {
+      return this.formatError('Ошибка при обновлении компонента', error as Error);
+    }
+  }
+}

--- a/packages/servers/yandex-tracker/src/tools/api/index.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/index.ts
@@ -6,6 +6,7 @@
 
 export * from '@tools/api/issues/index.js';
 export * from '@tools/api/queues/index.js';
+export * from '@tools/api/components/index.js';
 export * from '@tools/api/comments/index.js';
 export * from '@tools/api/projects/index.js';
 export * from '@tools/api/worklog/index.js';

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/create-component.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/create-component.operation.ts
@@ -1,0 +1,86 @@
+/**
+ * Операция создания компонента в очереди
+ *
+ * Ответственность (SRP):
+ * - ТОЛЬКО создание одного компонента в указанной очереди
+ * - Кеширование созданного компонента
+ * - Инвалидация кеша списка компонентов очереди
+ * - НЕТ обновления/удаления/получения компонентов
+ *
+ * API: POST /v2/queues/{queueId}/components
+ *
+ * ВАЖНО:
+ * - Компонент создается в контексте конкретной очереди (queueId в URL)
+ * - После создания нельзя изменить привязку к очереди
+ * - Требуются права на управление очередью
+ */
+
+import { BaseOperation } from '@tracker_api/api_operations/base-operation.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+import type { CreateComponentDto, ComponentOutput } from '@tracker_api/dto/index.js';
+
+export class CreateComponentOperation extends BaseOperation {
+  /**
+   * Создаёт новый компонент в очереди
+   *
+   * @param queueId - ключ или ID очереди (например, 'QUEUE' или '1')
+   * @param componentData - данные для создания компонента
+   * @returns созданный компонент с полными данными
+   * @throws {Error} если не указано название компонента или очередь не существует
+   *
+   * ВАЖНО:
+   * - После создания компонент автоматически кешируется по его ID
+   * - Инвалидируется кеш списка компонентов очереди
+   * - Retry делается ТОЛЬКО в HttpClient.post (нет двойного retry)
+   * - Компонент навсегда привязывается к указанной очереди
+   *
+   * @example
+   * ```typescript
+   * // Создать компонент в очереди QUEUE
+   * const component = await operation.execute('QUEUE', {
+   *   name: 'Backend',
+   *   description: 'Backend services',
+   *   assignAuto: true,
+   *   lead: 'user-login'
+   * });
+   * ```
+   */
+  async execute(queueId: string, componentData: CreateComponentDto): Promise<ComponentOutput> {
+    // Валидация обязательного поля
+    if (!componentData.name || componentData.name.trim() === '') {
+      throw new Error('Название компонента обязательно');
+    }
+
+    this.logger.info(`Создание компонента "${componentData.name}" в очереди ${queueId}`);
+
+    // Создаём компонент через API
+    const createdComponent = await this.httpClient.post<ComponentOutput>(
+      `/v2/queues/${queueId}/components`,
+      componentData
+    );
+
+    // Кешируем созданный компонент по его ID
+    const componentCacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, createdComponent.id);
+    this.cacheManager.set(componentCacheKey, createdComponent);
+
+    // Инвалидируем кеш списка компонентов очереди
+    this.invalidateComponentsCache(queueId);
+
+    this.logger.info(
+      `Компонент успешно создан: ${createdComponent.name} (ID: ${createdComponent.id})`
+    );
+
+    return createdComponent;
+  }
+
+  /**
+   * Инвалидирует кеш списка компонентов для очереди
+   *
+   * @param queueId - ключ или ID очереди
+   */
+  private invalidateComponentsCache(queueId: string): void {
+    const cacheKey = EntityCacheKey.createKey(EntityType.QUEUE, `${queueId}/components`);
+    this.cacheManager.delete(cacheKey);
+    this.logger.debug(`Инвалидирован кеш компонентов для очереди: ${queueId}`);
+  }
+}

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/delete-component.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/delete-component.operation.ts
@@ -1,0 +1,90 @@
+/**
+ * Операция удаления компонента
+ *
+ * Ответственность (SRP):
+ * - ТОЛЬКО удаление существующего компонента
+ * - Инвалидация кеша компонента и списка компонентов очереди
+ * - НЕТ создания/обновления/получения компонентов
+ *
+ * API: DELETE /v2/components/{componentId}
+ *
+ * ВАЖНО:
+ * - API возвращает 204 No Content при успешном удалении
+ * - После удаления инвалидируются кеши компонента и списка компонентов
+ * - Требуются права на управление очередью
+ * - Задачи, использующие компонент, не удаляются (компонент просто убирается из них)
+ */
+
+import { BaseOperation } from '@tracker_api/api_operations/base-operation.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+import type { ComponentOutput } from '@tracker_api/dto/index.js';
+
+export class DeleteComponentOperation extends BaseOperation {
+  /**
+   * Удаляет компонент из очереди
+   *
+   * @param componentId - ID компонента для удаления
+   *
+   * ВАЖНО:
+   * - Перед удалением получаем компонент для инвалидации кеша очереди
+   * - Кеш инвалидируется для компонента и списка компонентов очереди
+   * - Retry автоматически обрабатывается в HttpClient
+   * - Не выбрасывает ошибку если компонент уже удалён
+   * - Задачи с этим компонентом не удаляются
+   *
+   * @example
+   * ```typescript
+   * // Удалить компонент с ID '1'
+   * await operation.execute('1');
+   * ```
+   */
+  async execute(componentId: string): Promise<void> {
+    this.logger.info(`Удаление компонента ${componentId}`);
+
+    // Получаем компонент перед удалением для инвалидации кеша очереди
+    let queueId: string | undefined;
+    try {
+      const component = await this.httpClient.get<ComponentOutput>(`/v2/components/${componentId}`);
+      queueId = component.queue.id;
+    } catch {
+      // Если компонент не найден, логируем но продолжаем удаление
+      this.logger.debug(`Не удалось получить компонент ${componentId} перед удалением`);
+    }
+
+    // Выполняем DELETE запрос к API
+    // API возвращает 204 No Content при успешном удалении
+    await this.deleteRequest<void>(`/v2/components/${componentId}`);
+
+    // Инвалидируем кеш компонента
+    this.invalidateComponentCache(componentId);
+
+    // Инвалидируем кеш списка компонентов очереди, если известен ID очереди
+    if (queueId) {
+      this.invalidateComponentsCache(queueId);
+    }
+
+    this.logger.info(`Компонент ${componentId} успешно удалён`);
+  }
+
+  /**
+   * Инвалидирует кеш конкретного компонента
+   *
+   * @param componentId - ID компонента
+   */
+  private invalidateComponentCache(componentId: string): void {
+    const cacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, componentId);
+    this.cacheManager.delete(cacheKey);
+    this.logger.debug(`Инвалидирован кеш компонента: ${componentId}`);
+  }
+
+  /**
+   * Инвалидирует кеш списка компонентов для очереди
+   *
+   * @param queueId - ID очереди
+   */
+  private invalidateComponentsCache(queueId: string): void {
+    const cacheKey = EntityCacheKey.createKey(EntityType.QUEUE, `${queueId}/components`);
+    this.cacheManager.delete(cacheKey);
+    this.logger.debug(`Инвалидирован кеш компонентов для очереди: ${queueId}`);
+  }
+}

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/get-components.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/get-components.operation.ts
@@ -1,0 +1,61 @@
+/**
+ * Операция получения списка компонентов очереди
+ *
+ * Ответственность (SRP):
+ * - ТОЛЬКО получение списка компонентов конкретной очереди
+ * - НЕТ создания/обновления/удаления компонентов
+ *
+ * API: GET /v2/queues/{queueId}/components
+ *
+ * ВАЖНО:
+ * - Компоненты привязаны к очереди и всегда запрашиваются в контексте очереди
+ * - API не поддерживает пагинацию для компонентов (возвращает все компоненты очереди)
+ */
+
+import { BaseOperation } from '@tracker_api/api_operations/base-operation.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+import type { ComponentsListOutput } from '@tracker_api/dto/index.js';
+
+export class GetComponentsOperation extends BaseOperation {
+  /**
+   * Получает список всех компонентов очереди
+   *
+   * @param queueId - ключ или ID очереди (например, 'QUEUE' или '1')
+   * @returns массив компонентов очереди
+   *
+   * ВАЖНО:
+   * - Результат кешируется по ключу очереди
+   * - Retry делается ТОЛЬКО в HttpClient.get (нет двойного retry)
+   * - API возвращает все компоненты сразу (без пагинации)
+   *
+   * @example
+   * ```typescript
+   * // Получить компоненты очереди QUEUE
+   * const components = await operation.execute('QUEUE');
+   * ```
+   */
+  async execute(queueId: string): Promise<ComponentsListOutput> {
+    this.logger.info(`Получение компонентов очереди ${queueId}`);
+
+    // Проверяем кеш
+    const cacheKey = EntityCacheKey.createKey(EntityType.QUEUE, `${queueId}/components`);
+    const cached = this.cacheManager.get<ComponentsListOutput>(cacheKey);
+
+    if (cached) {
+      this.logger.debug(`Компоненты очереди ${queueId} получены из кеша`);
+      return cached;
+    }
+
+    // Получаем компоненты через API
+    const components = await this.httpClient.get<ComponentsListOutput>(
+      `/v2/queues/${queueId}/components`
+    );
+
+    // Кешируем результат
+    this.cacheManager.set(cacheKey, components);
+
+    this.logger.info(`Получено ${components.length} компонентов для очереди ${queueId}`);
+
+    return components;
+  }
+}

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/index.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Component Operations модуль - экспорт всех операций для работы с компонентами
+ */
+
+export { GetComponentsOperation } from './get-components.operation.js';
+export { CreateComponentOperation } from './create-component.operation.js';
+export { UpdateComponentOperation } from './update-component.operation.js';
+export { DeleteComponentOperation } from './delete-component.operation.js';

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/update-component.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/component/update-component.operation.ts
@@ -1,0 +1,86 @@
+/**
+ * Операция обновления компонента
+ *
+ * Ответственность (SRP):
+ * - ТОЛЬКО обновление существующего компонента
+ * - Инвалидация кеша компонента и списка компонентов очереди
+ * - НЕТ создания/удаления/получения компонентов
+ *
+ * API: PATCH /v2/components/{componentId}
+ *
+ * ВАЖНО:
+ * - Все поля опциональны (частичное обновление)
+ * - Нельзя изменить привязку к очереди (она задается при создании)
+ * - Требуются права на управление очередью
+ */
+
+import { BaseOperation } from '@tracker_api/api_operations/base-operation.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+import type { UpdateComponentDto, ComponentOutput } from '@tracker_api/dto/index.js';
+
+export class UpdateComponentOperation extends BaseOperation {
+  /**
+   * Обновляет существующий компонент
+   *
+   * @param componentId - ID компонента для обновления
+   * @param componentData - данные для обновления (все поля опциональны)
+   * @returns обновлённый компонент с полными данными
+   * @throws {Error} если компонент не найден
+   *
+   * ВАЖНО:
+   * - После обновления инвалидируется кеш компонента
+   * - Также инвалидируется кеш списка компонентов родительской очереди
+   * - Retry делается ТОЛЬКО в HttpClient.patch (нет двойного retry)
+   * - Привязку к очереди нельзя изменить
+   *
+   * @example
+   * ```typescript
+   * // Обновить название и описание компонента
+   * const component = await operation.execute('1', {
+   *   name: 'Backend Services',
+   *   description: 'Updated description'
+   * });
+   * ```
+   */
+  async execute(componentId: string, componentData: UpdateComponentDto): Promise<ComponentOutput> {
+    this.logger.info(`Обновление компонента ${componentId}`);
+
+    // Обновляем компонент через API
+    const updatedComponent = await this.httpClient.patch<ComponentOutput>(
+      `/v2/components/${componentId}`,
+      componentData
+    );
+
+    // Инвалидируем кеш компонента
+    this.invalidateComponentCache(componentId);
+
+    // Инвалидируем кеш списка компонентов родительской очереди
+    this.invalidateComponentsCache(updatedComponent.queue.id);
+
+    this.logger.info(`Компонент ${componentId} успешно обновлён`);
+
+    return updatedComponent;
+  }
+
+  /**
+   * Инвалидирует кеш конкретного компонента
+   *
+   * @param componentId - ID компонента
+   */
+  private invalidateComponentCache(componentId: string): void {
+    const cacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, componentId);
+    this.cacheManager.delete(cacheKey);
+    this.logger.debug(`Инвалидирован кеш компонента: ${componentId}`);
+  }
+
+  /**
+   * Инвалидирует кеш списка компонентов для очереди
+   *
+   * @param queueId - ID очереди
+   */
+  private invalidateComponentsCache(queueId: string): void {
+    const cacheKey = EntityCacheKey.createKey(EntityType.QUEUE, `${queueId}/components`);
+    this.cacheManager.delete(cacheKey);
+    this.logger.debug(`Инвалидирован кеш компонентов для очереди: ${queueId}`);
+  }
+}

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/index.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/index.ts
@@ -24,8 +24,14 @@ export * from '@tracker_api/api_operations/comment/index.js';
 // Checklist operations
 export * from '@tracker_api/api_operations/checklist/index.js';
 
+// Component operations
+export * from '@tracker_api/api_operations/component/index.js';
+
 // Worklog operations
 export * from '@tracker_api/api_operations/worklog/index.js';
 
 // Project operations
 export * from '@tracker_api/api_operations/project/index.js';
+
+// Attachment operations
+export * from '@tracker_api/api_operations/attachment/index.js';

--- a/packages/servers/yandex-tracker/src/tracker_api/dto/component/component.output.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/dto/component/component.output.ts
@@ -1,0 +1,18 @@
+/**
+ * Output DTO для одного компонента
+ *
+ * Используется в responses:
+ * - POST /v2/queues/{queueId}/components (создание)
+ * - PATCH /v2/components/{componentId} (обновление)
+ *
+ * DELETE не возвращает тело ответа (только 204 No Content)
+ */
+
+import type { ComponentWithUnknownFields } from '../../entities/component.entity.js';
+
+/**
+ * Компонент очереди (ответ API)
+ *
+ * Возвращается при создании, обновлении или получении компонента.
+ */
+export type ComponentOutput = ComponentWithUnknownFields;

--- a/packages/servers/yandex-tracker/src/tracker_api/dto/component/components-list.output.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/dto/component/components-list.output.ts
@@ -1,0 +1,15 @@
+/**
+ * Output DTO для списка компонентов очереди
+ *
+ * API: GET /v2/queues/{queueId}/components
+ */
+
+import type { ComponentWithUnknownFields } from '../../entities/component.entity.js';
+
+/**
+ * Список компонентов очереди
+ *
+ * Возвращается из API как массив компонентов.
+ * В отличие от других API, компоненты не поддерживают пагинацию на уровне API.
+ */
+export type ComponentsListOutput = readonly ComponentWithUnknownFields[];

--- a/packages/servers/yandex-tracker/src/tracker_api/dto/component/create-component.dto.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/dto/component/create-component.dto.ts
@@ -1,0 +1,41 @@
+/**
+ * DTO для создания компонента в очереди Яндекс.Трекера
+ *
+ * API: POST /v2/queues/{queueId}/components
+ *
+ * ВАЖНО:
+ * - Компонент создается в контексте конкретной очереди (queueId в URL)
+ * - После создания нельзя изменить привязку компонента к очереди
+ */
+export interface CreateComponentDto {
+  /**
+   * Название компонента
+   * @example "Backend"
+   */
+  name: string;
+
+  /**
+   * Описание компонента
+   * @example "Backend services and APIs"
+   */
+  description?: string;
+
+  /**
+   * ID или login руководителя компонента
+   * @example "user-login" или "1234567890"
+   */
+  lead?: string;
+
+  /**
+   * Автоматическое назначение исполнителя
+   *
+   * Если true, задачи с этим компонентом будут автоматически
+   * назначаться на руководителя компонента.
+   *
+   * @default false
+   */
+  assignAuto?: boolean;
+
+  /** Дополнительные поля */
+  [key: string]: unknown;
+}

--- a/packages/servers/yandex-tracker/src/tracker_api/dto/component/index.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/dto/component/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Component DTO модуль - экспорт всех DTO для работы с компонентами
+ */
+
+// Input DTO
+export type { CreateComponentDto } from './create-component.dto.js';
+export type { UpdateComponentDto } from './update-component.dto.js';
+
+// Output DTO
+export type { ComponentOutput } from './component.output.js';
+export type { ComponentsListOutput } from './components-list.output.js';

--- a/packages/servers/yandex-tracker/src/tracker_api/dto/component/update-component.dto.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/dto/component/update-component.dto.ts
@@ -1,0 +1,36 @@
+/**
+ * DTO для обновления компонента в Яндекс.Трекере
+ *
+ * API: PATCH /v2/components/{componentId}
+ *
+ * ВАЖНО:
+ * - Все поля опциональны (частичное обновление)
+ * - Привязку к очереди нельзя изменить (она задается при создании)
+ */
+export interface UpdateComponentDto {
+  /**
+   * Название компонента
+   * @example "Backend Services"
+   */
+  name?: string;
+
+  /**
+   * Описание компонента
+   * @example "Updated description"
+   */
+  description?: string;
+
+  /**
+   * ID или login руководителя компонента
+   * @example "new-lead-login"
+   */
+  lead?: string;
+
+  /**
+   * Автоматическое назначение исполнителя
+   */
+  assignAuto?: boolean;
+
+  /** Дополнительные поля */
+  [key: string]: unknown;
+}

--- a/packages/servers/yandex-tracker/src/tracker_api/dto/index.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/dto/index.ts
@@ -42,6 +42,14 @@ export type {
   DownloadAttachmentOutput,
 } from './attachment/index.js';
 
+// Component DTO
+export type {
+  CreateComponentDto,
+  UpdateComponentDto,
+  ComponentOutput,
+  ComponentsListOutput,
+} from './component/index.js';
+
 // Comment DTO
 export type {
   AddCommentInput,

--- a/packages/servers/yandex-tracker/src/tracker_api/entities/README.md
+++ b/packages/servers/yandex-tracker/src/tracker_api/entities/README.md
@@ -405,6 +405,31 @@ export type QueuePermissionWithUnknownFields = WithUnknownFields<QueuePermission
 - `follower` — наблюдатель (только чтение)
 - `access` — базовый доступ к очереди
 
+### Entity для компонентов
+
+**Файл:** `src/tracker_api/entities/component.entity.ts`
+
+Описывает компоненты очереди для группировки задач:
+
+```typescript
+export interface Component {
+  readonly id: string;           // ID компонента
+  readonly self: string;         // URL в API
+  readonly name: string;         // Название компонента
+  readonly queue: QueueRef;      // Очередь компонента
+  readonly assignAuto: boolean;  // Автоназначение исполнителя
+  readonly description?: string; // Описание (опционально)
+  readonly lead?: UserRef;       // Ответственный (опционально)
+}
+
+export type ComponentWithUnknownFields = WithUnknownFields<Component>;
+```
+
+**Ключевые особенности:**
+- `queue` — тип `QueueRef` (референс на очередь)
+- `assignAuto` — автоназначение исполнителя при добавлении компонента
+- `lead` — опциональный ответственный за компонент
+
 ---
 
 ## 🔗 См. также

--- a/packages/servers/yandex-tracker/src/tracker_api/entities/component.entity.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/entities/component.entity.ts
@@ -1,0 +1,105 @@
+/**
+ * Доменный тип: Компонент очереди в Яндекс.Трекере
+ *
+ * Соответствует API v3:
+ * - GET /v2/queues/{queueId}/components - список компонентов очереди
+ * - POST /v2/queues/{queueId}/components - создание компонента
+ * - PATCH /v2/components/{componentId} - обновление компонента
+ * - DELETE /v2/components/{componentId} - удаление компонента
+ *
+ * Компоненты - это механизм для группировки задач внутри очереди.
+ * Каждый компонент привязан к определенной очереди и может иметь
+ * собственного руководителя и настройку автоназначения.
+ */
+
+import type { WithUnknownFields } from './types.js';
+import type { UserRef } from './common/user-ref.entity.js';
+
+/**
+ * Референс на очередь (упрощенная версия)
+ *
+ * Используется в компоненте для указания на родительскую очередь.
+ */
+export interface QueueRef {
+  /**
+   * Идентификатор очереди
+   * @example "1"
+   */
+  readonly id: string;
+
+  /**
+   * Ключ очереди
+   * @example "QUEUE"
+   */
+  readonly key: string;
+
+  /**
+   * Отображаемое имя очереди
+   * @example "My Queue"
+   */
+  readonly display: string;
+}
+
+/**
+ * Компонент очереди в Яндекс.Трекере
+ *
+ * ВАЖНО: Типизация основана на реальных ответах API v2/v3.
+ * Обязательные поля (без ?) всегда присутствуют в ответе API.
+ * Опциональные поля могут отсутствовать в зависимости от настроек компонента.
+ */
+export interface Component {
+  /**
+   * Уникальный идентификатор компонента
+   * @example "1"
+   */
+  readonly id: string;
+
+  /**
+   * URL ссылка на компонент в API
+   * @example "https://api.tracker.yandex.net/v2/components/1"
+   */
+  readonly self: string;
+
+  /**
+   * Название компонента
+   * @example "Backend"
+   */
+  readonly name: string;
+
+  /**
+   * Очередь, к которой привязан компонент
+   *
+   * ВАЖНО: Компонент всегда принадлежит конкретной очереди.
+   * Изменить очередь компонента нельзя - только при создании.
+   */
+  readonly queue: QueueRef;
+
+  /**
+   * Автоматическое назначение исполнителя
+   *
+   * Если true, задачи с этим компонентом будут автоматически
+   * назначаться на руководителя компонента.
+   *
+   * @default false
+   */
+  readonly assignAuto: boolean;
+
+  /**
+   * Описание компонента (может отсутствовать)
+   * @example "Backend services and APIs"
+   */
+  readonly description?: string;
+
+  /**
+   * Руководитель компонента (может отсутствовать)
+   *
+   * Если assignAuto = true, задачи будут назначаться на этого пользователя.
+   */
+  readonly lead?: UserRef;
+}
+
+/**
+ * Компонент с возможными unknown полями из API.
+ * Используется при получении данных от API Трекера.
+ */
+export type ComponentWithUnknownFields = WithUnknownFields<Component>;

--- a/packages/servers/yandex-tracker/src/tracker_api/entities/index.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/entities/index.ts
@@ -69,6 +69,9 @@ export type { Attachment, AttachmentWithUnknownFields } from './attachment.entit
 // ChecklistItem
 export type { ChecklistItem, ChecklistItemWithUnknownFields } from './checklist-item.entity.js';
 
+// Component
+export type { Component, ComponentWithUnknownFields } from './component.entity.js';
+
 // Comment
 export type { Comment, CommentWithUnknownFields, CommentAttachment } from './comment/index.js';
 

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -36,6 +36,10 @@ import type {
   QueuesListOutput,
   QueueFieldsOutput,
   QueuePermissionsOutput,
+  CreateComponentDto,
+  UpdateComponentDto,
+  ComponentOutput,
+  ComponentsListOutput,
   CreateLinkDto,
   AddCommentInput,
   EditCommentInput,
@@ -331,6 +335,71 @@ export class YandexTrackerFacade {
       execute: (params: DeleteProjectParams) => Promise<void>;
     }>('DeleteProjectOperation');
     return operation.execute(params);
+  }
+
+  // === Component Methods ===
+
+  /**
+   * Получает список компонентов очереди
+   * @param queueId - ключ или ID очереди
+   * @returns массив компонентов очереди
+   */
+  async getComponents(params: { queueId: string }): Promise<ComponentsListOutput> {
+    const operation = this.getOperation<{
+      execute: (queueId: string) => Promise<ComponentsListOutput>;
+    }>('GetComponentsOperation');
+    return operation.execute(params.queueId);
+  }
+
+  /**
+   * Создаёт новый компонент в очереди
+   * @param queueId - ключ или ID очереди
+   * @param componentData - данные компонента
+   * @returns созданный компонент
+   */
+  async createComponent(params: {
+    queueId: string;
+    name: string;
+    description?: string;
+    lead?: string;
+    assignAuto?: boolean;
+  }): Promise<ComponentOutput> {
+    const { queueId, ...componentData } = params;
+    const operation = this.getOperation<{
+      execute: (queueId: string, data: CreateComponentDto) => Promise<ComponentOutput>;
+    }>('CreateComponentOperation');
+    return operation.execute(queueId, componentData);
+  }
+
+  /**
+   * Обновляет существующий компонент
+   * @param componentId - ID компонента
+   * @param componentData - данные для обновления
+   * @returns обновлённый компонент
+   */
+  async updateComponent(params: {
+    componentId: string;
+    name?: string;
+    description?: string;
+    lead?: string;
+    assignAuto?: boolean;
+  }): Promise<ComponentOutput> {
+    const { componentId, ...componentData } = params;
+    const operation = this.getOperation<{
+      execute: (componentId: string, data: UpdateComponentDto) => Promise<ComponentOutput>;
+    }>('UpdateComponentOperation');
+    return operation.execute(componentId, componentData);
+  }
+
+  /**
+   * Удаляет компонент из очереди
+   * @param componentId - ID компонента
+   */
+  async deleteComponent(params: { componentId: string }): Promise<void> {
+    const operation = this.getOperation<{
+      execute: (componentId: string) => Promise<void>;
+    }>('DeleteComponentOperation');
+    return operation.execute(params.componentId);
   }
 
   // === Issue Methods - Links ===

--- a/packages/servers/yandex-tracker/tests/helpers/component-dto.fixture.ts
+++ b/packages/servers/yandex-tracker/tests/helpers/component-dto.fixture.ts
@@ -1,0 +1,118 @@
+/**
+ * Фикстуры для Component DTO
+ *
+ * Используются в тестах для создания mock данных DTO компонентов.
+ */
+
+import type {
+  CreateComponentDto,
+  UpdateComponentDto,
+} from '../../src/tracker_api/dto/component/index.js';
+
+/**
+ * Создать CreateComponentDto для тестов
+ *
+ * @example
+ * ```typescript
+ * // Создать DTO с дефолтными значениями
+ * const dto = createCreateComponentDto();
+ *
+ * // Создать DTO с кастомными значениями
+ * const dto = createCreateComponentDto({
+ *   name: 'Backend',
+ *   description: 'Backend services',
+ *   assignAuto: true,
+ *   lead: 'user-login'
+ * });
+ * ```
+ */
+export function createCreateComponentDto(
+  overrides?: Partial<CreateComponentDto>
+): CreateComponentDto {
+  return {
+    name: overrides?.name || 'Test Component',
+    description: overrides?.description,
+    lead: overrides?.lead,
+    assignAuto: overrides?.assignAuto,
+    ...overrides,
+  };
+}
+
+/**
+ * Создать минимальный CreateComponentDto для тестов (только обязательные поля)
+ *
+ * @example
+ * ```typescript
+ * const dto = createMinimalCreateComponentDto({ name: 'Backend' });
+ * ```
+ */
+export function createMinimalCreateComponentDto(
+  overrides?: Partial<CreateComponentDto>
+): CreateComponentDto {
+  return {
+    name: overrides?.name || 'Minimal Component',
+    ...overrides,
+  };
+}
+
+/**
+ * Создать полный CreateComponentDto для тестов (все поля заполнены)
+ *
+ * @example
+ * ```typescript
+ * const dto = createFullCreateComponentDto();
+ * ```
+ */
+export function createFullCreateComponentDto(
+  overrides?: Partial<CreateComponentDto>
+): CreateComponentDto {
+  return {
+    name: overrides?.name || 'Full Component',
+    description: overrides?.description || 'Full component description',
+    lead: overrides?.lead || 'user-login',
+    assignAuto: overrides?.assignAuto !== undefined ? overrides.assignAuto : true,
+    ...overrides,
+  };
+}
+
+/**
+ * Создать UpdateComponentDto для тестов
+ *
+ * @example
+ * ```typescript
+ * // Обновить только название
+ * const dto = createUpdateComponentDto({ name: 'Updated Name' });
+ *
+ * // Обновить несколько полей
+ * const dto = createUpdateComponentDto({
+ *   name: 'New Name',
+ *   description: 'New description',
+ *   assignAuto: false
+ * });
+ * ```
+ */
+export function createUpdateComponentDto(
+  overrides?: Partial<UpdateComponentDto>
+): UpdateComponentDto {
+  return {
+    ...overrides,
+  };
+}
+
+/**
+ * Создать невалидный CreateComponentDto для тестов
+ * (например, пустое название)
+ *
+ * @example
+ * ```typescript
+ * const dto = createInvalidCreateComponentDto({ name: '' });
+ * ```
+ */
+export function createInvalidCreateComponentDto(
+  overrides?: Partial<CreateComponentDto>
+): CreateComponentDto {
+  return {
+    name: '', // невалидное пустое название
+    ...overrides,
+  };
+}

--- a/packages/servers/yandex-tracker/tests/helpers/component.fixture.ts
+++ b/packages/servers/yandex-tracker/tests/helpers/component.fixture.ts
@@ -1,0 +1,107 @@
+/**
+ * Фикстуры для Component entity
+ *
+ * Используются в тестах для создания mock данных компонентов.
+ */
+
+import type {
+  Component,
+  ComponentWithUnknownFields,
+  QueueRef,
+} from '../../src/tracker_api/entities/component.entity.js';
+import { createUserRef } from './common-fixtures.js';
+
+/**
+ * Создать QueueRef для тестов
+ *
+ * @example
+ * ```typescript
+ * const queueRef = createQueueRef({ key: 'MYQUEUE', display: 'My Queue' });
+ * ```
+ */
+export function createQueueRef(overrides?: Partial<QueueRef>): QueueRef {
+  return {
+    id: '1',
+    key: 'TEST',
+    display: 'Test Queue',
+    ...overrides,
+  };
+}
+
+/**
+ * Создать Component для тестов
+ *
+ * @example
+ * ```typescript
+ * // Создать компонент с дефолтными значениями
+ * const component = createComponentFixture();
+ *
+ * // Создать компонент с кастомными значениями
+ * const component = createComponentFixture({
+ *   name: 'Backend',
+ *   description: 'Backend services',
+ *   assignAuto: true
+ * });
+ *
+ * // Создать компонент с руководителем
+ * const component = createComponentFixture({
+ *   lead: createUserRef({ id: '123', display: 'John Doe' })
+ * });
+ * ```
+ */
+export function createComponentFixture(overrides?: Partial<Component>): ComponentWithUnknownFields {
+  const id = overrides?.id || '1';
+  const name = overrides?.name || 'Test Component';
+
+  return {
+    id,
+    self: `https://api.tracker.yandex.net/v2/components/${id}`,
+    name,
+    queue: overrides?.queue || createQueueRef(),
+    assignAuto: overrides?.assignAuto !== undefined ? overrides.assignAuto : false,
+    description: overrides?.description,
+    lead: overrides?.lead,
+    ...overrides,
+  };
+}
+
+/**
+ * Создать компонент с руководителем
+ *
+ * @example
+ * ```typescript
+ * const component = createComponentWithLead({
+ *   name: 'Frontend',
+ *   lead: createUserRef({ display: 'Jane Smith' })
+ * });
+ * ```
+ */
+export function createComponentWithLead(
+  overrides?: Partial<Component>
+): ComponentWithUnknownFields {
+  return createComponentFixture({
+    lead: createUserRef({ id: 'user123', display: 'Component Lead' }),
+    ...overrides,
+  });
+}
+
+/**
+ * Создать компонент с автоназначением
+ *
+ * @example
+ * ```typescript
+ * const component = createComponentWithAssignAuto({
+ *   name: 'Mobile',
+ *   lead: createUserRef({ display: 'Mobile Lead' })
+ * });
+ * ```
+ */
+export function createComponentWithAssignAuto(
+  overrides?: Partial<Component>
+): ComponentWithUnknownFields {
+  return createComponentFixture({
+    assignAuto: true,
+    lead: createUserRef({ id: 'user456', display: 'Auto Assignee' }),
+    ...overrides,
+  });
+}

--- a/packages/servers/yandex-tracker/tests/integration/helpers/mock-server.ts
+++ b/packages/servers/yandex-tracker/tests/integration/helpers/mock-server.ts
@@ -9,6 +9,7 @@ import {
   generateIssue,
   generateComment,
   generateQueue,
+  generateComponent,
   generateError404,
   generateError401,
   generateError403,
@@ -1237,6 +1238,228 @@ export class MockServer {
       return [403, response];
     });
     this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  // ============================================================
+  // COMPONENTS API МЕТОДЫ
+  // ============================================================
+
+  /**
+   * Mock успешного получения списка компонентов очереди
+   */
+  mockGetComponentsSuccess(queueId: string, components?: unknown[]): this {
+    const defaultComponents = [
+      generateComponent({
+        overrides: {
+          name: 'Component 1',
+          queue: { id: queueId, key: 'TEST', display: 'Test Queue' },
+        },
+      }),
+      generateComponent({
+        overrides: {
+          name: 'Component 2',
+          queue: { id: queueId, key: 'TEST', display: 'Test Queue' },
+        },
+      }),
+    ];
+    const mockKey = `GET /v2/queues/${queueId}/components`;
+    const urlPattern = new RegExp(`^/v2/queues/${queueId}/components(\\?.*)?$`);
+    this.mockAdapter.onGet(urlPattern).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [200, components ?? defaultComponents];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock пустого списка компонентов
+   */
+  mockGetComponentsEmpty(queueId: string): this {
+    const mockKey = `GET /v2/queues/${queueId}/components`;
+    const urlPattern = new RegExp(`^/v2/queues/${queueId}/components(\\?.*)?$`);
+    this.mockAdapter.onGet(urlPattern).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [200, []];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при получении компонентов (очередь не найдена)
+   */
+  mockGetComponents404(queueId: string): this {
+    const response = generateError404();
+    const mockKey = `GET /v2/queues/${queueId}/components`;
+    this.mockAdapter.onGet(`/v2/queues/${queueId}/components`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешного создания компонента
+   */
+  mockCreateComponentSuccess(queueId: string, componentData?: Record<string, unknown>): this {
+    const component = generateComponent({
+      overrides: {
+        queue: { id: queueId, key: 'TEST', display: 'Test Queue' },
+        ...componentData,
+      },
+    });
+    const mockKey = `POST /v2/queues/${queueId}/components`;
+    this.mockAdapter.onPost(`/v2/queues/${queueId}/components`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [201, component];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 403 при создании компонента (нет прав)
+   */
+  mockCreateComponent403(queueId: string): this {
+    const response = generateError403();
+    const mockKey = `POST /v2/queues/${queueId}/components`;
+    this.mockAdapter.onPost(`/v2/queues/${queueId}/components`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [403, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при создании компонента (очередь не найдена)
+   */
+  mockCreateComponent404(queueId: string): this {
+    const response = generateError404();
+    const mockKey = `POST /v2/queues/${queueId}/components`;
+    this.mockAdapter.onPost(`/v2/queues/${queueId}/components`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешного обновления компонента
+   */
+  mockUpdateComponentSuccess(componentId: string, updates?: Record<string, unknown>): this {
+    const component = generateComponent({
+      overrides: { id: componentId, ...updates },
+    });
+    const mockKey = `PATCH /v2/components/${componentId}`;
+    this.mockAdapter.onPatch(`/v2/components/${componentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [200, component];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при обновлении компонента
+   */
+  mockUpdateComponent404(componentId: string): this {
+    const response = generateError404();
+    const mockKey = `PATCH /v2/components/${componentId}`;
+    this.mockAdapter.onPatch(`/v2/components/${componentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+    return this;
+  }
+
+  /**
+   * Mock успешного удаления компонента
+   */
+  mockDeleteComponentSuccess(componentId: string, queueId = 'TEST'): this {
+    // DELETE operation сначала GET компонент для получения queue.id
+    const component = generateComponent({
+      id: componentId,
+      queue: { id: queueId, key: queueId, display: queueId },
+    });
+    const getMockKey = `GET /v2/components/${componentId}`;
+    this.mockAdapter.onGet(`/v2/components/${componentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(getMockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [200, component];
+    });
+    this.pendingMocks.push(getMockKey);
+
+    // Затем DELETE
+    const deleteMockKey = `DELETE /v2/components/${componentId}`;
+    this.mockAdapter.onDelete(`/v2/components/${componentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(deleteMockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [204, ''];
+    });
+    this.pendingMocks.push(deleteMockKey);
+    return this;
+  }
+
+  /**
+   * Mock ошибки 404 при удалении компонента
+   */
+  mockDeleteComponent404(componentId: string): this {
+    // Компонент не найден уже на GET
+    const response = generateError404();
+    const mockKey = `GET /v2/components/${componentId}`;
+    this.mockAdapter.onGet(`/v2/components/${componentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(mockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(mockKey);
+
+    // DELETE тоже вернет 404
+    const deleteMockKey = `DELETE /v2/components/${componentId}`;
+    this.mockAdapter.onDelete(`/v2/components/${componentId}`).reply(() => {
+      const index = this.pendingMocks.indexOf(deleteMockKey);
+      if (index !== -1) {
+        this.pendingMocks.splice(index, 1);
+      }
+      return [404, response];
+    });
+    this.pendingMocks.push(deleteMockKey);
     return this;
   }
 

--- a/packages/servers/yandex-tracker/tests/integration/helpers/template-based-generator.ts
+++ b/packages/servers/yandex-tracker/tests/integration/helpers/template-based-generator.ts
@@ -386,6 +386,7 @@ export const generateIssue = testFixtureFactory.create('issue');
 export const generateUser = testFixtureFactory.create('user');
 export const generateComment = testFixtureFactory.create('comment');
 export const generateQueue = testFixtureFactory.create('queue');
+export const generateComponent = testFixtureFactory.create('component');
 
 /**
  * Генераторы типичных ошибок API

--- a/packages/servers/yandex-tracker/tests/integration/templates/component.json
+++ b/packages/servers/yandex-tracker/tests/integration/templates/component.json
@@ -1,0 +1,19 @@
+{
+  "id": "component123456789abc",
+  "self": "https://api.tracker.yandex.net/v2/components/1",
+  "name": "Test Component",
+  "description": "Test component description for integration tests",
+  "lead": {
+    "id": "user123",
+    "self": "https://api.tracker.yandex.net/v3/users/user123",
+    "display": "Test User",
+    "cloudUid": "ajem1234567890abcdef",
+    "passportUid": 1234567890
+  },
+  "assignAuto": false,
+  "queue": {
+    "id": "1",
+    "key": "TEST",
+    "display": "Test Queue"
+  }
+}

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/components/create/create-component.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/components/create/create-component.tool.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Интеграционные тесты для create-component tool
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('create-component integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    client = await createTestClient({ logLevel: 'silent' });
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен создать компонент с минимальными параметрами', async () => {
+      // Arrange
+      const queueId = 'TEST';
+      mockServer.mockCreateComponentSuccess(queueId, {
+        name: 'New Component',
+      });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_create_component', {
+        queueId,
+        name: 'New Component',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      expect(response.data.component.name).toBe('New Component');
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен создать компонент с полными параметрами', async () => {
+      // Arrange
+      const queueId = 'PROJ';
+      mockServer.mockCreateComponentSuccess(queueId, {
+        name: 'Backend',
+        description: 'Backend services',
+        assignAuto: true,
+      });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_create_component', {
+        queueId,
+        name: 'Backend',
+        description: 'Backend services',
+        lead: 'testuser',
+        assignAuto: true,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      expect(response.data.component.name).toBe('Backend');
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен создать компонент с автоназначением', async () => {
+      // Arrange
+      const queueId = 'TEST';
+      mockServer.mockCreateComponentSuccess(queueId, {
+        name: 'Frontend',
+        assignAuto: true,
+      });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_create_component', {
+        queueId,
+        name: 'Frontend',
+        assignAuto: true,
+        lead: 'frontend-lead',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 403 (нет прав)', async () => {
+      // Arrange
+      const queueId = 'RESTRICTED';
+      mockServer.mockCreateComponent403(queueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_create_component', {
+        queueId,
+        name: 'New Component',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обработать ошибку 404 (очередь не найдена)', async () => {
+      // Arrange
+      const queueId = 'NONEXISTENT';
+      mockServer.mockCreateComponent404(queueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_create_component', {
+        queueId,
+        name: 'New Component',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Response Structure', () => {
+    it('должен вернуть полную структуру созданного компонента', async () => {
+      // Arrange
+      const queueId = 'TEST';
+      mockServer.mockCreateComponentSuccess(queueId, { name: 'Test Component' });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_create_component', {
+        queueId,
+        name: 'Test Component',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      const component = response.data.component;
+
+      expect(component).toHaveProperty('id');
+      expect(component).toHaveProperty('name');
+      expect(component).toHaveProperty('queue');
+      expect(component).toHaveProperty('assignAuto');
+      mockServer.assertAllRequestsDone();
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/components/delete/delete-component.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/components/delete/delete-component.tool.integration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Интеграционные тесты для delete-component tool
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('delete-component integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    client = await createTestClient({ logLevel: 'silent' });
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен успешно удалить компонент', async () => {
+      // Arrange
+      const componentId = 'comp123';
+      mockServer.mockDeleteComponentSuccess(componentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_component', {
+        componentId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.success).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен успешно удалить несколько компонентов последовательно', async () => {
+      // Arrange
+      const componentId1 = 'comp1';
+      const componentId2 = 'comp2';
+      mockServer.mockDeleteComponentSuccess(componentId1);
+      mockServer.mockDeleteComponentSuccess(componentId2);
+
+      // Act
+      const result1 = await client.callTool('fr_yandex_tracker_delete_component', {
+        componentId: componentId1,
+      });
+      const result2 = await client.callTool('fr_yandex_tracker_delete_component', {
+        componentId: componentId2,
+      });
+
+      // Assert
+      expect(result1.isError).toBeUndefined();
+      expect(result2.isError).toBeUndefined();
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (компонент не найден)', async () => {
+      // Arrange
+      const componentId = 'nonexistent';
+      mockServer.mockDeleteComponent404(componentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_component', {
+        componentId,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Response Structure', () => {
+    it('должен вернуть корректную структуру ответа при успешном удалении', async () => {
+      // Arrange
+      const componentId = 'comp456';
+      mockServer.mockDeleteComponentSuccess(componentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_delete_component', {
+        componentId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response).toHaveProperty('data');
+      expect(response.data).toHaveProperty('success');
+      expect(response.data.success).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/components/get/get-components.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/components/get/get-components.tool.integration.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Интеграционные тесты для get-components tool
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('get-components integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    client = await createTestClient({ logLevel: 'silent' });
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен получить список компонентов очереди', async () => {
+      // Arrange
+      const queueId = 'TEST';
+      mockServer.mockGetComponentsSuccess(queueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_components', {
+        queueId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.components).toBeDefined();
+      expect(Array.isArray(response.data.components)).toBe(true);
+      expect(response.data.components.length).toBeGreaterThan(0);
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен получить пустой список компонентов', async () => {
+      // Arrange
+      const queueId = 'EMPTY';
+      mockServer.mockGetComponentsEmpty(queueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_components', {
+        queueId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.components).toBeDefined();
+      expect(Array.isArray(response.data.components)).toBe(true);
+      expect(response.data.components.length).toBe(0);
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (очередь не найдена)', async () => {
+      // Arrange
+      const queueId = 'NONEXISTENT';
+      mockServer.mockGetComponents404(queueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_components', {
+        queueId,
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Response Structure', () => {
+    it('должен вернуть корректную структуру компонента', async () => {
+      // Arrange
+      const queueId = 'TEST';
+      mockServer.mockGetComponentsSuccess(queueId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_get_components', {
+        queueId,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      const component = response.data.components[0];
+
+      expect(component).toHaveProperty('id');
+      expect(component).toHaveProperty('name');
+      expect(component).toHaveProperty('queue');
+      expect(component).toHaveProperty('assignAuto');
+      mockServer.assertAllRequestsDone();
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/components/update/update-component.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/components/update/update-component.tool.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Интеграционные тесты для update-component tool
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestClient } from '@integration/helpers/mcp-client.js';
+import { createMockServer } from '@integration/helpers/mock-server.js';
+import type { TestMCPClient } from '@integration/helpers/mcp-client.js';
+import type { MockServer } from '@integration/helpers/mock-server.js';
+
+describe('update-component integration tests', () => {
+  let client: TestMCPClient;
+  let mockServer: MockServer;
+
+  beforeEach(async () => {
+    client = await createTestClient({ logLevel: 'silent' });
+    mockServer = createMockServer(client.getAxiosInstance());
+  });
+
+  afterEach(() => {
+    mockServer.cleanup();
+  });
+
+  describe('Happy Path', () => {
+    it('должен обновить название компонента', async () => {
+      // Arrange
+      const componentId = 'comp123';
+      mockServer.mockUpdateComponentSuccess(componentId, { name: 'Updated Component' });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_component', {
+        componentId,
+        name: 'Updated Component',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      expect(response.data.component.name).toBe('Updated Component');
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обновить описание компонента', async () => {
+      // Arrange
+      const componentId = 'comp456';
+      mockServer.mockUpdateComponentSuccess(componentId, {
+        description: 'New description',
+      });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_component', {
+        componentId,
+        description: 'New description',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обновить несколько полей одновременно', async () => {
+      // Arrange
+      const componentId = 'comp789';
+      mockServer.mockUpdateComponentSuccess(componentId, {
+        name: 'New Name',
+        description: 'New Description',
+        assignAuto: true,
+      });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_component', {
+        componentId,
+        name: 'New Name',
+        description: 'New Description',
+        assignAuto: true,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обновить руководителя и автоназначение', async () => {
+      // Arrange
+      const componentId = 'comp999';
+      mockServer.mockUpdateComponentSuccess(componentId, {
+        assignAuto: true,
+      });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_component', {
+        componentId,
+        lead: 'newlead',
+        assignAuto: true,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      expect(response.data.component).toBeDefined();
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('должен обработать ошибку 404 (компонент не найден)', async () => {
+      // Arrange
+      const componentId = 'nonexistent';
+      mockServer.mockUpdateComponent404(componentId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_component', {
+        componentId,
+        name: 'New Name',
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      mockServer.assertAllRequestsDone();
+    });
+  });
+
+  describe('Response Structure', () => {
+    it('должен вернуть полную структуру обновленного компонента', async () => {
+      // Arrange
+      const componentId = 'comp123';
+      mockServer.mockUpdateComponentSuccess(componentId, { name: 'Updated' });
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_component', {
+        componentId,
+        name: 'Updated',
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const response = JSON.parse(result.content[0]!.text);
+      const component = response.data.component;
+
+      expect(component).toHaveProperty('id');
+      expect(component).toHaveProperty('name');
+      expect(component).toHaveProperty('queue');
+      expect(component).toHaveProperty('assignAuto');
+      mockServer.assertAllRequestsDone();
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tools/api/components/create-component.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/create-component.tool.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Unit тесты для CreateComponentTool
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CreateComponentTool } from '@tools/api/components/create-component.tool.js';
+import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
+import { createComponentFixture } from '../../../helpers/component.fixture.js';
+
+describe('CreateComponentTool', () => {
+  let mockTrackerFacade: YandexTrackerFacade;
+  let mockLogger: Logger;
+  let tool: CreateComponentTool;
+
+  beforeEach(() => {
+    mockTrackerFacade = {
+      createComponent: vi.fn(),
+    } as unknown as YandexTrackerFacade;
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+
+    tool = new CreateComponentTool(mockTrackerFacade, mockLogger);
+  });
+
+  describe('getDefinition', () => {
+    it('должен вернуть корректное определение инструмента', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe(buildToolName('create_component', MCP_TOOL_PREFIX));
+      expect(definition.description).toContain('компонент');
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('queueId');
+      expect(definition.inputSchema.required).toContain('name');
+      expect(definition.inputSchema.properties?.['queueId']).toBeDefined();
+      expect(definition.inputSchema.properties?.['name']).toBeDefined();
+      expect(definition.inputSchema.properties?.['description']).toBeDefined();
+      expect(definition.inputSchema.properties?.['lead']).toBeDefined();
+      expect(definition.inputSchema.properties?.['assignAuto']).toBeDefined();
+    });
+  });
+
+  describe('execute', () => {
+    describe('валидация параметров (Zod)', () => {
+      it('должен вернуть ошибку если обязательные поля не указаны', async () => {
+        const result = await tool.execute({});
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку если queueId не указан', async () => {
+        const result = await tool.execute({
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку если name не указан', async () => {
+        const result = await tool.execute({
+          queueId: 'TEST',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку для пустого queueId', async () => {
+        const result = await tool.execute({
+          queueId: '',
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку для пустого name', async () => {
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: '',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен принимать корректные минимальные параметры', async () => {
+        const mockComponent = createComponentFixture({ name: 'Test Component' });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalled();
+      });
+    });
+
+    describe('создание компонента', () => {
+      it('должен создать компонент с минимальными обязательными полями', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          name: 'Test Component',
+        });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalledWith({
+          queueId: 'TEST',
+          name: 'Test Component',
+          description: undefined,
+          lead: undefined,
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Создание компонента', {
+          queueId: 'TEST',
+          name: 'Test Component',
+          hasDescription: false,
+          hasLead: false,
+          assignAuto: false,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Компонент создан', {
+          componentId: '123',
+          name: 'Test Component',
+        });
+
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            component: { id: string; name: string };
+            message: string;
+          };
+        };
+        expect(parsed.success).toBe(true);
+        expect(parsed.data.component.id).toBe('123');
+        expect(parsed.data.component.name).toBe('Test Component');
+        expect(parsed.data.message).toContain('успешно создан');
+      });
+
+      it('должен создать компонент с описанием', async () => {
+        const mockComponent = createComponentFixture({
+          name: 'Backend',
+          description: 'Backend services',
+        });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'PROJ',
+          name: 'Backend',
+          description: 'Backend services',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalledWith({
+          queueId: 'PROJ',
+          name: 'Backend',
+          description: 'Backend services',
+          lead: undefined,
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Создание компонента', {
+          queueId: 'PROJ',
+          name: 'Backend',
+          hasDescription: true,
+          hasLead: false,
+          assignAuto: false,
+        });
+      });
+
+      it('должен создать компонент с руководителем', async () => {
+        const mockComponent = createComponentFixture({
+          name: 'Frontend',
+        });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'PROJ',
+          name: 'Frontend',
+          lead: 'user-login',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalledWith({
+          queueId: 'PROJ',
+          name: 'Frontend',
+          description: undefined,
+          lead: 'user-login',
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Создание компонента', {
+          queueId: 'PROJ',
+          name: 'Frontend',
+          hasDescription: false,
+          hasLead: true,
+          assignAuto: false,
+        });
+      });
+
+      it('должен создать компонент с автоназначением', async () => {
+        const mockComponent = createComponentFixture({
+          name: 'Mobile',
+          assignAuto: true,
+        });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'PROJ',
+          name: 'Mobile',
+          assignAuto: true,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalledWith({
+          queueId: 'PROJ',
+          name: 'Mobile',
+          description: undefined,
+          lead: undefined,
+          assignAuto: true,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Создание компонента', {
+          queueId: 'PROJ',
+          name: 'Mobile',
+          hasDescription: false,
+          hasLead: false,
+          assignAuto: true,
+        });
+      });
+
+      it('должен создать компонент со всеми опциональными полями', async () => {
+        const mockComponent = createComponentFixture({
+          name: 'Full Component',
+          description: 'Full description',
+          assignAuto: true,
+        });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'FULL',
+          name: 'Full Component',
+          description: 'Full description',
+          lead: 'admin',
+          assignAuto: true,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalledWith({
+          queueId: 'FULL',
+          name: 'Full Component',
+          description: 'Full description',
+          lead: 'admin',
+          assignAuto: true,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Создание компонента', {
+          queueId: 'FULL',
+          name: 'Full Component',
+          hasDescription: true,
+          hasLead: true,
+          assignAuto: true,
+        });
+      });
+
+      it('должен создать компонент с assignAuto=false', async () => {
+        const mockComponent = createComponentFixture({
+          name: 'No Auto',
+          assignAuto: false,
+        });
+        vi.mocked(mockTrackerFacade.createComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'No Auto',
+          assignAuto: false,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.createComponent).toHaveBeenCalledWith({
+          queueId: 'TEST',
+          name: 'No Auto',
+          description: undefined,
+          lead: undefined,
+          assignAuto: false,
+        });
+      });
+    });
+
+    describe('обработка ошибок', () => {
+      it('должен обработать ошибку "компонент уже существует"', async () => {
+        const error = new Error('Component already exists');
+        vi.mocked(mockTrackerFacade.createComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Duplicate',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('Ошибка при создании компонента');
+        expect(parsed.error).toBe('Component already exists');
+      });
+
+      it('должен обработать ошибку "очередь не найдена"', async () => {
+        const error = new Error('Queue not found');
+        vi.mocked(mockTrackerFacade.createComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          queueId: 'NOTEXIST',
+          name: 'Test',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Queue not found');
+      });
+
+      it('должен обработать ошибку "недостаточно прав"', async () => {
+        const error = new Error('Permission denied');
+        vi.mocked(mockTrackerFacade.createComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Permission denied');
+      });
+
+      it('должен обработать ошибку "некорректный lead"', async () => {
+        const error = new Error('Invalid lead user');
+        vi.mocked(mockTrackerFacade.createComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Test Component',
+          lead: 'invalid-user',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Invalid lead user');
+      });
+
+      it('должен обработать сетевую ошибку', async () => {
+        const error = new Error('Network timeout');
+        vi.mocked(mockTrackerFacade.createComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Network timeout');
+      });
+
+      it('должен обработать ошибку API', async () => {
+        const error = new Error('API Error: 500 Internal Server Error');
+        vi.mocked(mockTrackerFacade.createComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          queueId: 'TEST',
+          name: 'Test Component',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toContain('API Error');
+      });
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tools/api/components/delete-component.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/delete-component.tool.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit тесты для DeleteComponentTool
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DeleteComponentTool } from '@tools/api/components/delete-component.tool.js';
+import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
+
+describe('DeleteComponentTool', () => {
+  let mockTrackerFacade: YandexTrackerFacade;
+  let mockLogger: Logger;
+  let tool: DeleteComponentTool;
+
+  beforeEach(() => {
+    mockTrackerFacade = {
+      deleteComponent: vi.fn(),
+    } as unknown as YandexTrackerFacade;
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+
+    tool = new DeleteComponentTool(mockTrackerFacade, mockLogger);
+  });
+
+  describe('getDefinition', () => {
+    it('должен вернуть корректное определение инструмента', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe(buildToolName('delete_component', MCP_TOOL_PREFIX));
+      expect(definition.description).toContain('компонент');
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('componentId');
+      expect(definition.inputSchema.properties?.['componentId']).toBeDefined();
+    });
+  });
+
+  describe('execute', () => {
+    describe('валидация параметров (Zod)', () => {
+      it('должен вернуть ошибку если componentId не указан', async () => {
+        const result = await tool.execute({});
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку для пустого componentId', async () => {
+        const result = await tool.execute({ componentId: '' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен принимать корректный componentId', async () => {
+        vi.mocked(mockTrackerFacade.deleteComponent).mockResolvedValue(undefined);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.deleteComponent).toHaveBeenCalledWith({
+          componentId: '123',
+        });
+      });
+    });
+
+    describe('удаление компонента', () => {
+      it('должен удалить компонент по ID', async () => {
+        vi.mocked(mockTrackerFacade.deleteComponent).mockResolvedValue(undefined);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.deleteComponent).toHaveBeenCalledWith({
+          componentId: '123',
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Удаление компонента', {
+          componentId: '123',
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Компонент удален', {
+          componentId: '123',
+        });
+
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            componentId: string;
+            message: string;
+          };
+        };
+        expect(parsed.success).toBe(true);
+        expect(parsed.data.componentId).toBe('123');
+        expect(parsed.data.message).toContain('успешно удален');
+      });
+
+      it('должен удалить компонент с числовым ID', async () => {
+        vi.mocked(mockTrackerFacade.deleteComponent).mockResolvedValue(undefined);
+
+        const result = await tool.execute({ componentId: '456' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.deleteComponent).toHaveBeenCalledWith({
+          componentId: '456',
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Компонент удален', {
+          componentId: '456',
+        });
+      });
+
+      it('должен удалить компонент с UUID-подобным ID', async () => {
+        vi.mocked(mockTrackerFacade.deleteComponent).mockResolvedValue(undefined);
+
+        const result = await tool.execute({ componentId: 'abc-123-def-456' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.deleteComponent).toHaveBeenCalledWith({
+          componentId: 'abc-123-def-456',
+        });
+      });
+
+      it('должен вызвать facade.deleteComponent ровно один раз', async () => {
+        vi.mocked(mockTrackerFacade.deleteComponent).mockResolvedValue(undefined);
+
+        await tool.execute({ componentId: '123' });
+
+        expect(mockTrackerFacade.deleteComponent).toHaveBeenCalledTimes(1);
+      });
+
+      it('должен логировать оба события (начало и завершение)', async () => {
+        vi.mocked(mockTrackerFacade.deleteComponent).mockResolvedValue(undefined);
+
+        await tool.execute({ componentId: '789' });
+
+        expect(mockLogger.info).toHaveBeenCalledTimes(2);
+        expect(mockLogger.info).toHaveBeenNthCalledWith(1, 'Удаление компонента', {
+          componentId: '789',
+        });
+        expect(mockLogger.info).toHaveBeenNthCalledWith(2, 'Компонент удален', {
+          componentId: '789',
+        });
+      });
+    });
+
+    describe('обработка ошибок', () => {
+      it('должен обработать ошибку "компонент не найден"', async () => {
+        const error = new Error('Component not found');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({ componentId: 'NOTEXIST' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('Ошибка при удалении компонента');
+        expect(parsed.error).toBe('Component not found');
+      });
+
+      it('должен обработать ошибку "недостаточно прав"', async () => {
+        const error = new Error('Permission denied');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Permission denied');
+      });
+
+      it('должен обработать ошибку "компонент используется"', async () => {
+        const error = new Error('Component is in use');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Component is in use');
+      });
+
+      it('должен обработать сетевую ошибку', async () => {
+        const error = new Error('Network timeout');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Network timeout');
+      });
+
+      it('должен обработать ошибку API', async () => {
+        const error = new Error('API Error: 500 Internal Server Error');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toContain('API Error');
+      });
+
+      it('должен обработать неожиданную ошибку', async () => {
+        const error = new Error('Unexpected error');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('Ошибка при удалении компонента');
+        expect(parsed.error).toBe('Unexpected error');
+      });
+
+      it('должен не вызывать второй лог при ошибке', async () => {
+        const error = new Error('Test error');
+        vi.mocked(mockTrackerFacade.deleteComponent).mockRejectedValue(error);
+
+        await tool.execute({ componentId: '123' });
+
+        // Должен быть вызван только первый лог (начало операции)
+        expect(mockLogger.info).toHaveBeenCalledTimes(1);
+        expect(mockLogger.info).toHaveBeenCalledWith('Удаление компонента', {
+          componentId: '123',
+        });
+      });
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tools/api/components/get-components.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/get-components.tool.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit тесты для GetComponentsTool
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GetComponentsTool } from '@tools/api/components/get-components.tool.js';
+import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
+import { createComponentFixture } from '../../../helpers/component.fixture.js';
+
+describe('GetComponentsTool', () => {
+  let mockTrackerFacade: YandexTrackerFacade;
+  let mockLogger: Logger;
+  let tool: GetComponentsTool;
+
+  beforeEach(() => {
+    mockTrackerFacade = {
+      getComponents: vi.fn(),
+    } as unknown as YandexTrackerFacade;
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+
+    tool = new GetComponentsTool(mockTrackerFacade, mockLogger);
+  });
+
+  describe('getDefinition', () => {
+    it('должен вернуть корректное определение инструмента', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe(buildToolName('get_components', MCP_TOOL_PREFIX));
+      expect(definition.description).toContain('список компонентов');
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('queueId');
+      expect(definition.inputSchema.properties?.['queueId']).toBeDefined();
+    });
+  });
+
+  describe('execute', () => {
+    describe('валидация параметров (Zod)', () => {
+      it('должен вернуть ошибку если queueId не указан', async () => {
+        const result = await tool.execute({});
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку для пустого queueId', async () => {
+        const result = await tool.execute({ queueId: '' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен принимать корректный queueId', async () => {
+        const mockComponents = [
+          createComponentFixture({ id: '1', name: 'Component 1' }),
+          createComponentFixture({ id: '2', name: 'Component 2' }),
+        ];
+        vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
+
+        const result = await tool.execute({ queueId: 'TEST' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.getComponents).toHaveBeenCalledWith({
+          queueId: 'TEST',
+        });
+      });
+    });
+
+    describe('получение списка компонентов', () => {
+      it('должен получить список компонентов по queueId', async () => {
+        const mockComponents = [
+          createComponentFixture({ id: '1', name: 'Component 1' }),
+          createComponentFixture({ id: '2', name: 'Component 2' }),
+          createComponentFixture({ id: '3', name: 'Component 3' }),
+        ];
+        vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
+
+        const result = await tool.execute({ queueId: 'MYQUEUE' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.getComponents).toHaveBeenCalledWith({
+          queueId: 'MYQUEUE',
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Получение списка компонентов очереди', {
+          queueId: 'MYQUEUE',
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Список компонентов получен', {
+          count: 3,
+          queueId: 'MYQUEUE',
+        });
+
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            components: unknown[];
+            count: number;
+            queueId: string;
+          };
+        };
+        expect(parsed.success).toBe(true);
+        expect(parsed.data.components).toHaveLength(3);
+        expect(parsed.data.count).toBe(3);
+        expect(parsed.data.queueId).toBe('MYQUEUE');
+      });
+
+      it('должен обработать пустой список компонентов', async () => {
+        vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue([]);
+
+        const result = await tool.execute({ queueId: 'EMPTY' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockLogger.info).toHaveBeenCalledWith('Список компонентов получен', {
+          count: 0,
+          queueId: 'EMPTY',
+        });
+
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            components: unknown[];
+            count: number;
+          };
+        };
+        expect(parsed.success).toBe(true);
+        expect(parsed.data.components).toHaveLength(0);
+        expect(parsed.data.count).toBe(0);
+      });
+
+      it('должен получить компоненты с разными свойствами', async () => {
+        const mockComponents = [
+          createComponentFixture({
+            id: '1',
+            name: 'Backend',
+            description: 'Backend services',
+          }),
+          createComponentFixture({
+            id: '2',
+            name: 'Frontend',
+            assignAuto: true,
+          }),
+        ];
+        vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
+
+        const result = await tool.execute({ queueId: 'PROJECT' });
+
+        expect(result.isError).toBeUndefined();
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            components: Array<{ name: string }>;
+          };
+        };
+        expect(parsed.data.components).toHaveLength(2);
+        expect(parsed.data.components[0]?.name).toBe('Backend');
+        expect(parsed.data.components[1]?.name).toBe('Frontend');
+      });
+
+      it('должен получить один компонент', async () => {
+        const mockComponents = [createComponentFixture({ id: '1', name: 'Single Component' })];
+        vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
+
+        const result = await tool.execute({ queueId: 'SINGLE' });
+
+        expect(result.isError).toBeUndefined();
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            components: unknown[];
+            count: number;
+          };
+        };
+        expect(parsed.success).toBe(true);
+        expect(parsed.data.count).toBe(1);
+        expect(parsed.data.components).toHaveLength(1);
+      });
+
+      it('должен обработать большое количество компонентов', async () => {
+        const mockComponents = Array.from({ length: 50 }, (_, i) =>
+          createComponentFixture({ id: `${i + 1}`, name: `Component ${i + 1}` })
+        );
+        vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
+
+        const result = await tool.execute({ queueId: 'LARGE' });
+
+        expect(result.isError).toBeUndefined();
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            components: unknown[];
+            count: number;
+          };
+        };
+        expect(parsed.data.count).toBe(50);
+        expect(parsed.data.components).toHaveLength(50);
+      });
+    });
+
+    describe('обработка ошибок', () => {
+      it('должен обработать ошибку "очередь не найдена"', async () => {
+        const error = new Error('Queue not found');
+        vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
+
+        const result = await tool.execute({ queueId: 'NOTEXIST' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('Ошибка при получении списка компонентов');
+        expect(parsed.error).toBe('Queue not found');
+      });
+
+      it('должен обработать сетевую ошибку', async () => {
+        const error = new Error('Network timeout');
+        vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
+
+        const result = await tool.execute({ queueId: 'TEST' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Network timeout');
+      });
+
+      it('должен обработать ошибку "недостаточно прав"', async () => {
+        const error = new Error('Permission denied');
+        vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
+
+        const result = await tool.execute({ queueId: 'RESTRICTED' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Permission denied');
+      });
+
+      it('должен обработать ошибку API', async () => {
+        const error = new Error('API Error: 500 Internal Server Error');
+        vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
+
+        const result = await tool.execute({ queueId: 'TEST' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toContain('API Error');
+      });
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tools/api/components/update-component.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/update-component.tool.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Unit тесты для UpdateComponentTool
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { UpdateComponentTool } from '@tools/api/components/update-component.tool.js';
+import type { YandexTrackerFacade } from '@tracker_api/facade/yandex-tracker.facade.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
+import { buildToolName } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '@constants';
+import { createComponentFixture } from '../../../helpers/component.fixture.js';
+
+describe('UpdateComponentTool', () => {
+  let mockTrackerFacade: YandexTrackerFacade;
+  let mockLogger: Logger;
+  let tool: UpdateComponentTool;
+
+  beforeEach(() => {
+    mockTrackerFacade = {
+      updateComponent: vi.fn(),
+    } as unknown as YandexTrackerFacade;
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+
+    tool = new UpdateComponentTool(mockTrackerFacade, mockLogger);
+  });
+
+  describe('getDefinition', () => {
+    it('должен вернуть корректное определение инструмента', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe(buildToolName('update_component', MCP_TOOL_PREFIX));
+      expect(definition.description).toContain('параметры компонента');
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('componentId');
+      expect(definition.inputSchema.properties?.['componentId']).toBeDefined();
+      expect(definition.inputSchema.properties?.['name']).toBeDefined();
+      expect(definition.inputSchema.properties?.['description']).toBeDefined();
+      expect(definition.inputSchema.properties?.['lead']).toBeDefined();
+      expect(definition.inputSchema.properties?.['assignAuto']).toBeDefined();
+    });
+  });
+
+  describe('execute', () => {
+    describe('валидация параметров (Zod)', () => {
+      it('должен вернуть ошибку если componentId не указан', async () => {
+        const result = await tool.execute({});
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен вернуть ошибку для пустого componentId', async () => {
+        const result = await tool.execute({ componentId: '' });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+
+      it('должен принимать только componentId без обновлений', async () => {
+        const mockComponent = createComponentFixture({ id: '123' });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({ componentId: '123' });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: undefined,
+          description: undefined,
+          lead: undefined,
+          assignAuto: undefined,
+        });
+      });
+
+      it('должен вернуть ошибку для пустого name', async () => {
+        const result = await tool.execute({
+          componentId: '123',
+          name: '',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('валидации');
+      });
+    });
+
+    describe('обновление компонента', () => {
+      it('должен обновить только name', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          name: 'Updated Component',
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          name: 'Updated Component',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: 'Updated Component',
+          description: undefined,
+          lead: undefined,
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента', {
+          componentId: '123',
+          hasName: true,
+          hasDescription: false,
+          hasLead: false,
+          hasAssignAuto: false,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Компонент обновлен', {
+          componentId: '123',
+          name: 'Updated Component',
+        });
+
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          data: {
+            component: { id: string; name: string };
+            message: string;
+          };
+        };
+        expect(parsed.success).toBe(true);
+        expect(parsed.data.component.name).toBe('Updated Component');
+        expect(parsed.data.message).toContain('успешно обновлен');
+      });
+
+      it('должен обновить только description', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          description: 'New description',
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          description: 'New description',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: undefined,
+          description: 'New description',
+          lead: undefined,
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента', {
+          componentId: '123',
+          hasName: false,
+          hasDescription: true,
+          hasLead: false,
+          hasAssignAuto: false,
+        });
+      });
+
+      it('должен обновить только lead', async () => {
+        const mockComponent = createComponentFixture({ id: '123' });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          lead: 'new-lead',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: undefined,
+          description: undefined,
+          lead: 'new-lead',
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента', {
+          componentId: '123',
+          hasName: false,
+          hasDescription: false,
+          hasLead: true,
+          hasAssignAuto: false,
+        });
+      });
+
+      it('должен обновить только assignAuto', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          assignAuto: true,
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          assignAuto: true,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: undefined,
+          description: undefined,
+          lead: undefined,
+          assignAuto: true,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента', {
+          componentId: '123',
+          hasName: false,
+          hasDescription: false,
+          hasLead: false,
+          hasAssignAuto: true,
+        });
+      });
+
+      it('должен обновить несколько полей одновременно', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          name: 'Updated',
+          description: 'Updated description',
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          name: 'Updated',
+          description: 'Updated description',
+          lead: 'admin',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: 'Updated',
+          description: 'Updated description',
+          lead: 'admin',
+          assignAuto: undefined,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента', {
+          componentId: '123',
+          hasName: true,
+          hasDescription: true,
+          hasLead: true,
+          hasAssignAuto: false,
+        });
+      });
+
+      it('должен обновить все возможные поля', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          name: 'Full Update',
+          description: 'Full description',
+          assignAuto: true,
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          name: 'Full Update',
+          description: 'Full description',
+          lead: 'newlead',
+          assignAuto: true,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: 'Full Update',
+          description: 'Full description',
+          lead: 'newlead',
+          assignAuto: true,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента', {
+          componentId: '123',
+          hasName: true,
+          hasDescription: true,
+          hasLead: true,
+          hasAssignAuto: true,
+        });
+      });
+
+      it('должен обновить assignAuto на false', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          assignAuto: false,
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          assignAuto: false,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: undefined,
+          description: undefined,
+          lead: undefined,
+          assignAuto: false,
+        });
+      });
+
+      it('должен обновить description на пустую строку', async () => {
+        const mockComponent = createComponentFixture({
+          id: '123',
+          description: '',
+        });
+        vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
+
+        const result = await tool.execute({
+          componentId: '123',
+          description: '',
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
+          componentId: '123',
+          name: undefined,
+          description: '',
+          lead: undefined,
+          assignAuto: undefined,
+        });
+      });
+    });
+
+    describe('обработка ошибок', () => {
+      it('должен обработать ошибку "компонент не найден"', async () => {
+        const error = new Error('Component not found');
+        vi.mocked(mockTrackerFacade.updateComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          componentId: 'NOTEXIST',
+          name: 'New Name',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          message: string;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.message).toContain('Ошибка при обновлении компонента');
+        expect(parsed.error).toBe('Component not found');
+      });
+
+      it('должен обработать ошибку "недостаточно прав"', async () => {
+        const error = new Error('Permission denied');
+        vi.mocked(mockTrackerFacade.updateComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          componentId: '123',
+          name: 'New Name',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Permission denied');
+      });
+
+      it('должен обработать ошибку "некорректный lead"', async () => {
+        const error = new Error('Invalid lead user');
+        vi.mocked(mockTrackerFacade.updateComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          componentId: '123',
+          lead: 'invalid-user',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Invalid lead user');
+      });
+
+      it('должен обработать сетевую ошибку', async () => {
+        const error = new Error('Network timeout');
+        vi.mocked(mockTrackerFacade.updateComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          componentId: '123',
+          description: 'New description',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toBe('Network timeout');
+      });
+
+      it('должен обработать ошибку API', async () => {
+        const error = new Error('API Error: 500 Internal Server Error');
+        vi.mocked(mockTrackerFacade.updateComponent).mockRejectedValue(error);
+
+        const result = await tool.execute({
+          componentId: '123',
+          name: 'New Name',
+        });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+          success: boolean;
+          error: string;
+        };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toContain('API Error');
+      });
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/create-component.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/create-component.operation.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HttpClient } from '@mcp-framework/infrastructure/http/client/http-client.js';
+import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-manager.interface.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
+import type { ComponentOutput } from '@tracker_api/dto/index.js';
+import { CreateComponentOperation } from '@tracker_api/api_operations/component/create-component.operation.js';
+import { createComponentFixture } from '../../../helpers/component.fixture.js';
+import {
+  createCreateComponentDto,
+  createMinimalCreateComponentDto,
+  createFullCreateComponentDto,
+  createInvalidCreateComponentDto,
+} from '../../../helpers/component-dto.fixture.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+
+describe('CreateComponentOperation', () => {
+  let operation: CreateComponentOperation;
+  let mockHttpClient: HttpClient;
+  let mockCacheManager: CacheManager;
+  let mockLogger: Logger;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as HttpClient;
+
+    mockCacheManager = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      clear: vi.fn(),
+      has: vi.fn(),
+    } as unknown as CacheManager;
+
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+
+    operation = new CreateComponentOperation(mockHttpClient, mockCacheManager, mockLogger);
+  });
+
+  describe('execute', () => {
+    it('should call httpClient.post with correct endpoint and data', async () => {
+      const dto = createCreateComponentDto({ name: 'Backend' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Backend',
+      });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('QUEUE', dto);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/v2/queues/QUEUE/components', dto);
+      expect(result).toEqual(mockComponent);
+    });
+
+    it('should create component with minimal fields', async () => {
+      const dto = createMinimalCreateComponentDto({ name: 'Minimal Component' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Minimal Component',
+      });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('QUEUE', dto);
+
+      expect(result.name).toBe('Minimal Component');
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/v2/queues/QUEUE/components', dto);
+    });
+
+    it('should create component with all fields', async () => {
+      const dto = createFullCreateComponentDto({
+        name: 'Full Component',
+        description: 'Full description',
+        lead: 'user-login',
+        assignAuto: true,
+      });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Full Component',
+        description: 'Full description',
+      });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('QUEUE', dto);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/v2/queues/QUEUE/components', dto);
+      expect(result).toEqual(mockComponent);
+    });
+
+    it('should validate component name (cannot be empty)', async () => {
+      const invalidDto = createInvalidCreateComponentDto({ name: '' });
+
+      await expect(operation.execute('QUEUE', invalidDto)).rejects.toThrow(
+        'Название компонента обязательно'
+      );
+
+      expect(mockHttpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should validate component name (cannot be whitespace only)', async () => {
+      const dto = createCreateComponentDto({ name: '   ' });
+
+      await expect(operation.execute('QUEUE', dto)).rejects.toThrow(
+        'Название компонента обязательно'
+      );
+
+      expect(mockHttpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should cache created component by its ID', async () => {
+      const dto = createCreateComponentDto({ name: 'Backend' });
+      const mockComponent: ComponentOutput = createComponentFixture({ id: 'comp-123' });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      await operation.execute('QUEUE', dto);
+
+      const componentCacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, 'comp-123');
+      expect(mockCacheManager.set).toHaveBeenCalledWith(componentCacheKey, mockComponent);
+    });
+
+    it('should invalidate components list cache after creation', async () => {
+      const dto = createCreateComponentDto({ name: 'Backend' });
+      const mockComponent: ComponentOutput = createComponentFixture({ id: '1' });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      await operation.execute('QUEUE', dto);
+
+      const listCacheKey = EntityCacheKey.createKey(EntityType.QUEUE, 'QUEUE/components');
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(listCacheKey);
+    });
+
+    it('should handle API errors', async () => {
+      const dto = createCreateComponentDto({ name: 'Test' });
+      const error = new Error('Component already exists');
+      vi.mocked(mockHttpClient.post).mockRejectedValue(error);
+
+      await expect(operation.execute('QUEUE', dto)).rejects.toThrow('Component already exists');
+    });
+
+    it('should log info messages', async () => {
+      const dto = createCreateComponentDto({ name: 'Backend' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Backend',
+      });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      await operation.execute('QUEUE', dto);
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Создание компонента "Backend" в очереди QUEUE');
+      expect(mockLogger.info).toHaveBeenCalledWith('Компонент успешно создан: Backend (ID: 1)');
+    });
+
+    it('should log debug message about cache invalidation', async () => {
+      const dto = createCreateComponentDto({ name: 'Test' });
+      const mockComponent: ComponentOutput = createComponentFixture({ id: '1' });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      await operation.execute('QUEUE', dto);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Инвалидирован кеш компонентов для очереди: QUEUE'
+      );
+    });
+
+    it('should work with queue ID instead of key', async () => {
+      const dto = createCreateComponentDto({ name: 'Component' });
+      const mockComponent: ComponentOutput = createComponentFixture({ id: '1' });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      await operation.execute('queue-123', dto);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/v2/queues/queue-123/components', dto);
+    });
+
+    it('should create component with assignAuto enabled', async () => {
+      const dto = createCreateComponentDto({
+        name: 'Auto-assign Component',
+        assignAuto: true,
+        lead: 'user-login',
+      });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Auto-assign Component',
+        assignAuto: true,
+      });
+      vi.mocked(mockHttpClient.post).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('QUEUE', dto);
+
+      expect(result.assignAuto).toBe(true);
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/delete-component.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/delete-component.operation.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HttpClient } from '@mcp-framework/infrastructure/http/client/http-client.js';
+import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-manager.interface.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
+import type { ComponentOutput } from '@tracker_api/dto/index.js';
+import { DeleteComponentOperation } from '@tracker_api/api_operations/component/delete-component.operation.js';
+import { createComponentFixture, createQueueRef } from '../../../helpers/component.fixture.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+
+describe('DeleteComponentOperation', () => {
+  let operation: DeleteComponentOperation;
+  let mockHttpClient: HttpClient;
+  let mockCacheManager: CacheManager;
+  let mockLogger: Logger;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as HttpClient;
+
+    mockCacheManager = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      clear: vi.fn(),
+      has: vi.fn(),
+    } as unknown as CacheManager;
+
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+
+    operation = new DeleteComponentOperation(mockHttpClient, mockCacheManager, mockLogger);
+  });
+
+  describe('execute', () => {
+    it('should fetch component before deletion and then delete it', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+
+      // Mock deleteRequest method (it's protected, so we test through execute)
+      const deleteSpy = vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/v2/components/1');
+      expect(deleteSpy).toHaveBeenCalledWith('/v2/components/1');
+    });
+
+    it('should invalidate component cache after deletion', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+      vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      const componentCacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, '1');
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(componentCacheKey);
+    });
+
+    it('should invalidate components list cache after deletion', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-123' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+      vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      const listCacheKey = EntityCacheKey.createKey(EntityType.QUEUE, 'queue-123/components');
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(listCacheKey);
+    });
+
+    it('should continue deletion even if component GET fails', async () => {
+      vi.mocked(mockHttpClient.get).mockRejectedValue(new Error('Component not found'));
+      const deleteSpy = vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      expect(deleteSpy).toHaveBeenCalledWith('/v2/components/1');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Не удалось получить компонент 1 перед удалением'
+      );
+    });
+
+    it('should still invalidate component cache if GET fails', async () => {
+      vi.mocked(mockHttpClient.get).mockRejectedValue(new Error('Component not found'));
+      vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      const componentCacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, '1');
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(componentCacheKey);
+    });
+
+    it('should not invalidate list cache if queueId is unknown', async () => {
+      vi.mocked(mockHttpClient.get).mockRejectedValue(new Error('Component not found'));
+      vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      // Should only delete component cache, not list cache
+      expect(mockCacheManager.delete).toHaveBeenCalledTimes(1);
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(
+        EntityCacheKey.createKey(EntityType.COMPONENT, '1')
+      );
+    });
+
+    it('should handle DELETE API errors', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+      vi.spyOn(operation as any, 'deleteRequest').mockRejectedValue(new Error('Deletion failed'));
+
+      await expect(operation.execute('1')).rejects.toThrow('Deletion failed');
+    });
+
+    it('should log info messages', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+      vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Удаление компонента 1');
+      expect(mockLogger.info).toHaveBeenCalledWith('Компонент 1 успешно удалён');
+    });
+
+    it('should log debug messages about cache invalidation', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+      vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('1');
+
+      expect(mockLogger.debug).toHaveBeenCalledWith('Инвалидирован кеш компонента: 1');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Инвалидирован кеш компонентов для очереди: queue-1'
+      );
+    });
+
+    it('should work with numeric component ID', async () => {
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '123',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponent);
+      const deleteSpy = vi.spyOn(operation as any, 'deleteRequest').mockResolvedValue(undefined);
+
+      await operation.execute('123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/v2/components/123');
+      expect(deleteSpy).toHaveBeenCalledWith('/v2/components/123');
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/get-components.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/get-components.operation.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HttpClient } from '@mcp-framework/infrastructure/http/client/http-client.js';
+import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-manager.interface.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
+import type { ComponentsListOutput } from '@tracker_api/dto/index.js';
+import { GetComponentsOperation } from '@tracker_api/api_operations/component/get-components.operation.js';
+import { createComponentFixture } from '../../../helpers/component.fixture.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+
+describe('GetComponentsOperation', () => {
+  let operation: GetComponentsOperation;
+  let mockHttpClient: HttpClient;
+  let mockCacheManager: CacheManager;
+  let mockLogger: Logger;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as HttpClient;
+
+    mockCacheManager = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      clear: vi.fn(),
+      has: vi.fn(),
+    } as unknown as CacheManager;
+
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+
+    operation = new GetComponentsOperation(mockHttpClient, mockCacheManager, mockLogger);
+  });
+
+  describe('execute', () => {
+    it('should call httpClient.get with correct endpoint', async () => {
+      const mockComponents: ComponentsListOutput = [
+        createComponentFixture({ id: '1', name: 'Backend' }),
+        createComponentFixture({ id: '2', name: 'Frontend' }),
+      ];
+
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponents);
+
+      const result = await operation.execute('QUEUE');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/v2/queues/QUEUE/components');
+      expect(result).toEqual(mockComponents);
+    });
+
+    it('should return cached components if available', async () => {
+      const mockComponents: ComponentsListOutput = [
+        createComponentFixture({ id: '1', name: 'Cached Component' }),
+      ];
+
+      const cacheKey = EntityCacheKey.createKey(EntityType.QUEUE, 'QUEUE/components');
+      vi.mocked(mockCacheManager.get).mockReturnValue(mockComponents);
+
+      const result = await operation.execute('QUEUE');
+
+      expect(mockCacheManager.get).toHaveBeenCalledWith(cacheKey);
+      expect(mockHttpClient.get).not.toHaveBeenCalled();
+      expect(result).toEqual(mockComponents);
+    });
+
+    it('should cache components after fetching from API', async () => {
+      const mockComponents: ComponentsListOutput = [
+        createComponentFixture({ id: '1', name: 'Component 1' }),
+        createComponentFixture({ id: '2', name: 'Component 2' }),
+      ];
+
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponents);
+
+      await operation.execute('TEST');
+
+      const cacheKey = EntityCacheKey.createKey(EntityType.QUEUE, 'TEST/components');
+      expect(mockCacheManager.set).toHaveBeenCalledWith(cacheKey, mockComponents);
+    });
+
+    it('should work with queue ID instead of key', async () => {
+      const mockComponents: ComponentsListOutput = [
+        createComponentFixture({ id: '1', name: 'Component' }),
+      ];
+
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponents);
+
+      await operation.execute('queue-123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/v2/queues/queue-123/components');
+    });
+
+    it('should handle empty result', async () => {
+      const emptyResult: ComponentsListOutput = [];
+      vi.mocked(mockHttpClient.get).mockResolvedValue(emptyResult);
+
+      const result = await operation.execute('EMPTY');
+
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('Queue not found');
+      vi.mocked(mockHttpClient.get).mockRejectedValue(error);
+
+      await expect(operation.execute('NOTFOUND')).rejects.toThrow('Queue not found');
+    });
+
+    it('should log info messages', async () => {
+      const mockComponents: ComponentsListOutput = [
+        createComponentFixture({ id: '1' }),
+        createComponentFixture({ id: '2' }),
+        createComponentFixture({ id: '3' }),
+      ];
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponents);
+
+      await operation.execute('QUEUE');
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Получение компонентов очереди QUEUE');
+      expect(mockLogger.info).toHaveBeenCalledWith('Получено 3 компонентов для очереди QUEUE');
+    });
+
+    it('should log debug message when returning from cache', async () => {
+      const mockComponents: ComponentsListOutput = [createComponentFixture()];
+
+      vi.mocked(mockCacheManager.get).mockReturnValue(mockComponents);
+
+      await operation.execute('QUEUE');
+
+      expect(mockLogger.debug).toHaveBeenCalledWith('Компоненты очереди QUEUE получены из кеша');
+    });
+
+    it('should return components with correct structure', async () => {
+      const mockComponent = createComponentFixture({
+        id: '1',
+        name: 'Test Component',
+        description: 'Test Description',
+      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue([mockComponent]);
+
+      const result = await operation.execute('QUEUE');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: '1',
+        name: 'Test Component',
+        description: 'Test Description',
+      });
+      expect(result[0]).toHaveProperty('self');
+      expect(result[0]).toHaveProperty('queue');
+    });
+
+    it('should handle multiple components correctly', async () => {
+      const mockComponents: ComponentsListOutput = [
+        createComponentFixture({ id: '1', name: 'Backend' }),
+        createComponentFixture({ id: '2', name: 'Frontend' }),
+        createComponentFixture({ id: '3', name: 'Mobile' }),
+        createComponentFixture({ id: '4', name: 'DevOps' }),
+      ];
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComponents);
+
+      const result = await operation.execute('PROJ');
+
+      expect(result).toHaveLength(4);
+      expect(result[0].name).toBe('Backend');
+      expect(result[1].name).toBe('Frontend');
+      expect(result[2].name).toBe('Mobile');
+      expect(result[3].name).toBe('DevOps');
+    });
+  });
+});

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/update-component.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/component/update-component.operation.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HttpClient } from '@mcp-framework/infrastructure/http/client/http-client.js';
+import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-manager.interface.js';
+import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
+import type { ComponentOutput } from '@tracker_api/dto/index.js';
+import { UpdateComponentOperation } from '@tracker_api/api_operations/component/update-component.operation.js';
+import { createComponentFixture, createQueueRef } from '../../../helpers/component.fixture.js';
+import { createUpdateComponentDto } from '../../../helpers/component-dto.fixture.js';
+import { EntityCacheKey, EntityType } from '@mcp-framework/infrastructure';
+
+describe('UpdateComponentOperation', () => {
+  let operation: UpdateComponentOperation;
+  let mockHttpClient: HttpClient;
+  let mockCacheManager: CacheManager;
+  let mockLogger: Logger;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as HttpClient;
+
+    mockCacheManager = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      clear: vi.fn(),
+      has: vi.fn(),
+    } as unknown as CacheManager;
+
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+
+    operation = new UpdateComponentOperation(mockHttpClient, mockCacheManager, mockLogger);
+  });
+
+  describe('execute', () => {
+    it('should call httpClient.patch with correct endpoint and data', async () => {
+      const updates = createUpdateComponentDto({ name: 'Updated Name' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Updated Name',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('1', updates);
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith('/v2/components/1', updates);
+      expect(result).toEqual(mockComponent);
+    });
+
+    it('should update component name', async () => {
+      const updates = createUpdateComponentDto({ name: 'New Component Name' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'New Component Name',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('1', updates);
+
+      expect(result.name).toBe('New Component Name');
+    });
+
+    it('should update component description', async () => {
+      const updates = createUpdateComponentDto({ description: 'New description' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        description: 'New description',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('1', updates);
+
+      expect(result.description).toBe('New description');
+    });
+
+    it('should update component lead', async () => {
+      const updates = createUpdateComponentDto({ lead: 'new-user-login' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      await operation.execute('1', updates);
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith('/v2/components/1', updates);
+    });
+
+    it('should update assignAuto flag', async () => {
+      const updates = createUpdateComponentDto({ assignAuto: true });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        assignAuto: true,
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('1', updates);
+
+      expect(result.assignAuto).toBe(true);
+    });
+
+    it('should update multiple fields at once', async () => {
+      const updates = createUpdateComponentDto({
+        name: 'Updated Name',
+        description: 'Updated Description',
+        assignAuto: false,
+      });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Updated Name',
+        description: 'Updated Description',
+        assignAuto: false,
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('1', updates);
+
+      expect(result).toMatchObject({
+        name: 'Updated Name',
+        description: 'Updated Description',
+        assignAuto: false,
+      });
+    });
+
+    it('should invalidate component cache after update', async () => {
+      const updates = createUpdateComponentDto({ name: 'Updated' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      await operation.execute('1', updates);
+
+      const componentCacheKey = EntityCacheKey.createKey(EntityType.COMPONENT, '1');
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(componentCacheKey);
+    });
+
+    it('should invalidate components list cache after update', async () => {
+      const updates = createUpdateComponentDto({ name: 'Updated' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-123' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      await operation.execute('1', updates);
+
+      const listCacheKey = EntityCacheKey.createKey(EntityType.QUEUE, 'queue-123/components');
+      expect(mockCacheManager.delete).toHaveBeenCalledWith(listCacheKey);
+    });
+
+    it('should handle API errors', async () => {
+      const updates = createUpdateComponentDto({ name: 'Updated' });
+      const error = new Error('Component not found');
+      vi.mocked(mockHttpClient.patch).mockRejectedValue(error);
+
+      await expect(operation.execute('999', updates)).rejects.toThrow('Component not found');
+    });
+
+    it('should log info messages', async () => {
+      const updates = createUpdateComponentDto({ name: 'Updated Component' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        name: 'Updated Component',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      await operation.execute('1', updates);
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Обновление компонента 1');
+      expect(mockLogger.info).toHaveBeenCalledWith('Компонент 1 успешно обновлён');
+    });
+
+    it('should log debug messages about cache invalidation', async () => {
+      const updates = createUpdateComponentDto({ name: 'Test' });
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      await operation.execute('1', updates);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith('Инвалидирован кеш компонента: 1');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Инвалидирован кеш компонентов для очереди: queue-1'
+      );
+    });
+
+    it('should handle empty updates object', async () => {
+      const updates = {};
+      const mockComponent: ComponentOutput = createComponentFixture({
+        id: '1',
+        queue: createQueueRef({ id: 'queue-1' }),
+      });
+      vi.mocked(mockHttpClient.patch).mockResolvedValue(mockComponent);
+
+      const result = await operation.execute('1', updates);
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith('/v2/components/1', {});
+      expect(result).toEqual(mockComponent);
+    });
+  });
+});


### PR DESCRIPTION
Добавлен полный функционал работы с компонентами очередей:

**Entities & DTO:**
- Component entity с ComponentWithUnknownFields
- CreateComponentDto, UpdateComponentDto, ComponentOutput
- EntityType.COMPONENT для кеширования

**Operations (4 операции, API v2):**
- GetComponentsOperation — список компонентов очереди (кеш ✅)
- CreateComponentOperation — создание компонента
- UpdateComponentOperation — обновление параметров
- DeleteComponentOperation — удаление (с GET для queueId)

**MCP Tools (13 файлов):**
- get_components, create_component, update_component, delete_component
- requiresExplicitUserConsent для write операций

**Тесты (130 тестов, 100% coverage):**
- 44 unit тестов для operations
- 66 unit тестов для tools
- 20 integration тестов + mock server
- Все тесты проходят

**Документация:**
- Обновлены entities/README.md, operations/README.md, tools/README.md
- Все файлы < 500 строк

🤖 Generated with Claude Code