### PR TITLE
Refactor circular dependencies in parallel

### DIFF
--- a/packages/servers/yandex-tracker/scripts/cleanup-unused-imports.mjs
+++ b/packages/servers/yandex-tracker/scripts/cleanup-unused-imports.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Скрипт для очистки неиспользуемых импортов buildToolName
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TOOLS_DIR = path.join(__dirname, '../src/tools');
+
+async function findToolFiles(dir) {
+  const files = [];
+
+  async function walk(currentDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.name.endsWith('.tool.ts')) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  await walk(dir);
+  return files;
+}
+
+async function cleanupFile(filePath) {
+  let content = await fs.readFile(filePath, 'utf8');
+  let modified = false;
+
+  // Удалить buildToolName из импортов @mcp-framework/core
+  const coreImportRegex = /import\s+{\s*([^}]+)\s*}\s+from\s+['"]@mcp-framework\/core['"];/g;
+
+  content = content.replace(coreImportRegex, (match, imports) => {
+    const importList = imports.split(',').map(i => i.trim());
+
+    // Проверить, используется ли buildToolName в коде
+    if (importList.includes('buildToolName') && !content.includes('buildToolName(')) {
+      // Удалить buildToolName
+      const filtered = importList.filter(i => i !== 'buildToolName');
+      modified = true;
+
+      if (filtered.length === 0) {
+        return ''; // Удалить всю строку
+      }
+
+      return `import { ${filtered.join(', ')} } from '@mcp-framework/core';`;
+    }
+
+    return match;
+  });
+
+  if (modified) {
+    // Удалить пустые строки после удаления импорта
+    content = content.replace(/\n\n\n+/g, '\n\n');
+
+    await fs.writeFile(filePath, content, 'utf8');
+    console.log(`✅ Cleaned ${path.basename(filePath)}`);
+    return true;
+  }
+
+  return false;
+}
+
+async function main() {
+  console.log('🧹 Cleaning up unused imports...\n');
+
+  const toolFiles = await findToolFiles(TOOLS_DIR);
+  let cleanedCount = 0;
+
+  for (const file of toolFiles) {
+    if (await cleanupFile(file)) {
+      cleanedCount++;
+    }
+  }
+
+  console.log(`\n✅ Cleaned ${cleanedCount} files`);
+}
+
+main().catch(console.error);

--- a/packages/servers/yandex-tracker/scripts/refactor-circular-deps.mjs
+++ b/packages/servers/yandex-tracker/scripts/refactor-circular-deps.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * Скрипт для автоматизации рефакторинга циркулярных зависимостей
+ *
+ * Для каждого tool:
+ * 1. Находит definition.ts и tool.ts файлы
+ * 2. Извлекает METADATA из tool.ts
+ * 3. Создает metadata.ts с METADATA
+ * 4. Обновляет импорты в definition.ts и tool.ts
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TOOLS_DIR = path.join(__dirname, '../src/tools');
+
+/**
+ * Найти все definition файлы
+ */
+async function findDefinitionFiles(dir) {
+  const files = [];
+
+  async function walk(currentDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.name.endsWith('.definition.ts') && entry.name !== 'ping.definition.ts') {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  await walk(dir);
+  return files;
+}
+
+/**
+ * Извлечь METADATA из tool.ts
+ */
+function extractMetadata(toolContent) {
+  const metadataRegex = /static\s+(?:override\s+)?readonly\s+METADATA\s*=\s*({[\s\S]*?})\s*as\s+const;/;
+  const match = toolContent.match(metadataRegex);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[1];
+}
+
+/**
+ * Извлечь имя класса Tool из definition файла
+ */
+function extractToolClassName(definitionContent) {
+  // Ищем импорт вида: import { XxxTool } from './xxx.tool.js';
+  const importRegex = /import\s+{\s*(\w+Tool)\s*}\s+from\s+['"]\.\/[\w-]+\.tool\.js['"]/;
+  const match = definitionContent.match(importRegex);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[1];
+}
+
+/**
+ * Создать metadata файл
+ */
+async function createMetadataFile(toolPath, toolContent, toolClassName) {
+  const metadataContent = extractMetadata(toolContent);
+
+  if (!metadataContent) {
+    console.log(`⚠️  No METADATA found in ${path.basename(toolPath)}`);
+    return null;
+  }
+
+  // Извлечь импорты из tool.ts, которые нужны для METADATA
+  const imports = [];
+
+  // buildToolName, ToolCategory, ToolPriority всегда нужны
+  imports.push(`import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';`);
+  imports.push(`import type { StaticToolMetadata } from '@mcp-framework/core';`);
+
+  // Проверить, нужен ли MCP_TOOL_PREFIX
+  if (metadataContent.includes('MCP_TOOL_PREFIX')) {
+    // Определить правильный путь к constants
+    const toolDir = path.dirname(toolPath);
+    const srcDir = path.join(__dirname, '../src');
+    const relativePath = path.relative(toolDir, srcDir);
+    const constantsPath = path.join(relativePath, 'constants.js').replace(/\\/g, '/');
+
+    imports.push(`import { MCP_TOOL_PREFIX } from '${constantsPath}';`);
+  }
+
+  // Создать константу METADATA
+  const metadataVarName = toolClassName.replace('Tool', '').replace(/([A-Z])/g, '_$1').toUpperCase().substring(1) + '_TOOL_METADATA';
+
+  const metadataFileContent = `/**
+ * Метаданные для ${toolClassName}
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+${imports.join('\n')}
+
+/**
+ * Статические метаданные для ${toolClassName}
+ */
+export const ${metadataVarName}: StaticToolMetadata = ${metadataContent} as const;
+`;
+
+  const metadataPath = toolPath.replace('.tool.ts', '.metadata.ts');
+  await fs.writeFile(metadataPath, metadataFileContent, 'utf8');
+
+  console.log(`✅ Created ${path.basename(metadataPath)}`);
+  return { metadataPath, metadataVarName };
+}
+
+/**
+ * Обновить definition.ts
+ */
+async function updateDefinitionFile(definitionPath, toolClassName, metadataVarName) {
+  let content = await fs.readFile(definitionPath, 'utf8');
+
+  // Заменить импорт Tool на импорт METADATA
+  const toolImportRegex = new RegExp(`import\\s+{\\s*${toolClassName}\\s*}\\s+from\\s+['"]\\.\\/[\\w-]+\\.tool\\.js['"];?`);
+  const metadataImport = `import { ${metadataVarName} } from './${path.basename(definitionPath).replace('.definition.ts', '.metadata.js')}';`;
+
+  content = content.replace(toolImportRegex, metadataImport);
+
+  // Заменить использование Tool.METADATA на METADATA_VAR
+  content = content.replace(
+    new RegExp(`return\\s+${toolClassName}\\.METADATA;`, 'g'),
+    `return ${metadataVarName};`
+  );
+
+  await fs.writeFile(definitionPath, content, 'utf8');
+  console.log(`✅ Updated ${path.basename(definitionPath)}`);
+}
+
+/**
+ * Обновить tool.ts
+ */
+async function updateToolFile(toolPath, metadataVarName) {
+  let content = await fs.readFile(toolPath, 'utf8');
+
+  // Добавить импорт METADATA (после других импортов)
+  const lastImportIndex = content.lastIndexOf('import ');
+  const nextLineIndex = content.indexOf('\n', lastImportIndex);
+
+  const metadataImport = `import { ${metadataVarName} } from './${path.basename(toolPath).replace('.tool.ts', '.metadata.js')}';`;
+
+  // Вставить импорт после последнего импорта
+  content = content.slice(0, nextLineIndex + 1) + metadataImport + '\n' + content.slice(nextLineIndex + 1);
+
+  // Заменить статический METADATA на импортированный
+  const metadataRegex = /static\s+(?:override\s+)?readonly\s+METADATA\s*=\s*{[\s\S]*?}\s*as\s+const;/;
+  content = content.replace(metadataRegex, `static override readonly METADATA = ${metadataVarName};`);
+
+  // Удалить неиспользуемые импорты (ToolCategory, ToolPriority, buildToolName, MCP_TOOL_PREFIX)
+  // Удаляем только если они импортируются из @mcp-framework/core и больше нигде не используются
+  const linesToRemove = [];
+
+  // Проверить, используется ли buildToolName вне METADATA
+  if (!content.includes('buildToolName(') || content.match(/buildToolName\(/g).length === 1) {
+    linesToRemove.push('buildToolName');
+  }
+
+  // Проверить, используется ли ToolCategory вне METADATA
+  if (!content.includes('ToolCategory.') || content.split('ToolCategory.').length <= 2) {
+    linesToRemove.push('ToolCategory');
+  }
+
+  // Проверить, используется ли ToolPriority вне METADATA
+  if (!content.includes('ToolPriority.') || content.split('ToolPriority.').length <= 2) {
+    linesToRemove.push('ToolPriority');
+  }
+
+  // Удалить неиспользуемые импорты из строки импорта
+  if (linesToRemove.length > 0) {
+    const coreImportRegex = /import\s+{\s*([^}]+)\s*}\s+from\s+['"]@mcp-framework\/core['"];/;
+    content = content.replace(coreImportRegex, (match, imports) => {
+      let importList = imports.split(',').map(i => i.trim()).filter(i => !linesToRemove.includes(i));
+
+      if (importList.length === 0) {
+        return ''; // Удалить всю строку импорта
+      }
+
+      return `import { ${importList.join(', ')} } from '@mcp-framework/core';`;
+    });
+  }
+
+  // Удалить импорт MCP_TOOL_PREFIX если он был
+  content = content.replace(/import\s+{\s*MCP_TOOL_PREFIX\s*}\s+from\s+['"][^'"]+constants\.js['"];\n?/g, '');
+
+  await fs.writeFile(toolPath, content, 'utf8');
+  console.log(`✅ Updated ${path.basename(toolPath)}`);
+}
+
+/**
+ * Обработать один tool
+ */
+async function refactorTool(definitionPath) {
+  try {
+    const toolPath = definitionPath.replace('.definition.ts', '.tool.ts');
+
+    // Проверить, существует ли tool файл
+    try {
+      await fs.access(toolPath);
+    } catch {
+      console.log(`⚠️  No tool file for ${path.basename(definitionPath)}`);
+      return false;
+    }
+
+    // Проверить, не создан ли уже metadata файл
+    const metadataPath = definitionPath.replace('.definition.ts', '.metadata.ts');
+    try {
+      await fs.access(metadataPath);
+      console.log(`⏭️  Skipping ${path.basename(definitionPath)} (metadata already exists)`);
+      return false;
+    } catch {
+      // Metadata не существует, продолжаем
+    }
+
+    const definitionContent = await fs.readFile(definitionPath, 'utf8');
+    const toolContent = await fs.readFile(toolPath, 'utf8');
+
+    const toolClassName = extractToolClassName(definitionContent);
+    if (!toolClassName) {
+      console.log(`⚠️  Cannot extract tool class name from ${path.basename(definitionPath)}`);
+      return false;
+    }
+
+    console.log(`\n🔧 Refactoring ${toolClassName}...`);
+
+    // 1. Создать metadata файл
+    const result = await createMetadataFile(toolPath, toolContent, toolClassName);
+    if (!result) {
+      return false;
+    }
+
+    const { metadataVarName } = result;
+
+    // 2. Обновить definition.ts
+    await updateDefinitionFile(definitionPath, toolClassName, metadataVarName);
+
+    // 3. Обновить tool.ts
+    await updateToolFile(toolPath, metadataVarName);
+
+    console.log(`✅ ${toolClassName} refactored successfully`);
+    return true;
+
+  } catch (error) {
+    console.error(`❌ Error refactoring ${path.basename(definitionPath)}:`, error.message);
+    return false;
+  }
+}
+
+/**
+ * Главная функция
+ */
+async function main() {
+  console.log('🚀 Starting circular dependencies refactoring...\n');
+
+  const definitionFiles = await findDefinitionFiles(TOOLS_DIR);
+
+  console.log(`Found ${definitionFiles.length} definition files\n`);
+
+  let successCount = 0;
+  let skipCount = 0;
+  let failCount = 0;
+
+  for (const file of definitionFiles) {
+    const result = await refactorTool(file);
+    if (result === true) {
+      successCount++;
+    } else if (result === false) {
+      const metadataPath = file.replace('.definition.ts', '.metadata.ts');
+      try {
+        await fs.access(metadataPath);
+        skipCount++;
+      } catch {
+        failCount++;
+      }
+    }
+  }
+
+  console.log(`\n📊 Results:`);
+  console.log(`   ✅ Refactored: ${successCount}`);
+  console.log(`   ⏭️  Skipped: ${skipCount}`);
+  console.log(`   ❌ Failed: ${failCount}`);
+  console.log(`\n🎉 Done!`);
+}
+
+main().catch(console.error);

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/move/bulk-move-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/move/bulk-move-issues.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { BulkMoveIssuesTool } from './bulk-move-issues.tool.js';
+import { BULK_MOVE_ISSUES_TOOL_METADATA } from './bulk-move-issues.metadata.js';
 
 /**
  * Definition для BulkMoveIssuesTool
  */
 export class BulkMoveIssuesDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return BulkMoveIssuesTool.METADATA;
+    return BULK_MOVE_ISSUES_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/move/bulk-move-issues.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/move/bulk-move-issues.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для BulkMoveIssuesTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для BulkMoveIssuesTool
+ */
+export const BULK_MOVE_ISSUES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('bulk_move_issues', MCP_TOOL_PREFIX),
+  description: '[Bulk/Write] Массовое перемещение задач между очередями',
+  category: ToolCategory.ISSUES,
+  subcategory: 'bulk',
+  priority: ToolPriority.HIGH,
+  tags: ['bulk', 'move', 'queue', 'transfer', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/move/bulk-move-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/move/bulk-move-issues.tool.ts
@@ -8,15 +8,15 @@
  * - Асинхронная операция на сервере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { ResultLogger } from '@mcp-framework/core';
 import { BulkMoveIssuesDefinition } from './bulk-move-issues.definition.js';
 import { BulkMoveIssuesParamsSchema } from './bulk-move-issues.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { BULK_MOVE_ISSUES_TOOL_METADATA } from './bulk-move-issues.metadata.js';
 
 /**
  * Инструмент для массового перемещения задач между очередями
@@ -36,16 +36,7 @@ export class BulkMoveIssuesTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('bulk_move_issues', MCP_TOOL_PREFIX),
-    description: '[Bulk/Write] Массовое перемещение задач между очередями',
-    category: ToolCategory.ISSUES,
-    subcategory: 'bulk',
-    priority: ToolPriority.HIGH,
-    tags: ['bulk', 'move', 'queue', 'transfer', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = BULK_MOVE_ISSUES_TOOL_METADATA;
 
   private readonly definition = new BulkMoveIssuesDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/status/get-bulk-change-status.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/status/get-bulk-change-status.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetBulkChangeStatusTool } from './get-bulk-change-status.tool.js';
+import { GET_BULK_CHANGE_STATUS_TOOL_METADATA } from './get-bulk-change-status.metadata.js';
 
 /**
  * Definition для GetBulkChangeStatusTool
  */
 export class GetBulkChangeStatusDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetBulkChangeStatusTool.METADATA;
+    return GET_BULK_CHANGE_STATUS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/status/get-bulk-change-status.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/status/get-bulk-change-status.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetBulkChangeStatusTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для GetBulkChangeStatusTool
+ */
+export const GET_BULK_CHANGE_STATUS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_bulk_change_status', MCP_TOOL_PREFIX),
+  description: '[Bulk/Read] Получить статус bulk операции',
+  category: ToolCategory.ISSUES,
+  subcategory: 'bulk',
+  priority: ToolPriority.NORMAL,
+  tags: ['bulk', 'status', 'progress', 'read'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/status/get-bulk-change-status.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/status/get-bulk-change-status.tool.ts
@@ -7,14 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetBulkChangeStatusDefinition } from './get-bulk-change-status.definition.js';
 import { GetBulkChangeStatusParamsSchema } from './get-bulk-change-status.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { GET_BULK_CHANGE_STATUS_TOOL_METADATA } from './get-bulk-change-status.metadata.js';
 
 /**
  * Инструмент для получения статуса bulk операции
@@ -33,16 +33,7 @@ export class GetBulkChangeStatusTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_bulk_change_status', MCP_TOOL_PREFIX),
-    description: '[Bulk/Read] Получить статус bulk операции',
-    category: ToolCategory.ISSUES,
-    subcategory: 'bulk',
-    priority: ToolPriority.NORMAL,
-    tags: ['bulk', 'status', 'progress', 'read'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_BULK_CHANGE_STATUS_TOOL_METADATA;
 
   private readonly definition = new GetBulkChangeStatusDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/transition/bulk-transition-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/transition/bulk-transition-issues.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { BulkTransitionIssuesTool } from './bulk-transition-issues.tool.js';
+import { BULK_TRANSITION_ISSUES_TOOL_METADATA } from './bulk-transition-issues.metadata.js';
 
 /**
  * Definition для BulkTransitionIssuesTool
  */
 export class BulkTransitionIssuesDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return BulkTransitionIssuesTool.METADATA;
+    return BULK_TRANSITION_ISSUES_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/transition/bulk-transition-issues.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/transition/bulk-transition-issues.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для BulkTransitionIssuesTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для BulkTransitionIssuesTool
+ */
+export const BULK_TRANSITION_ISSUES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('bulk_transition_issues', MCP_TOOL_PREFIX),
+  description: '[Bulk/Write] Массовая смена статусов задач',
+  category: ToolCategory.ISSUES,
+  subcategory: 'bulk',
+  priority: ToolPriority.HIGH,
+  tags: ['bulk', 'transition', 'status', 'workflow', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/transition/bulk-transition-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/transition/bulk-transition-issues.tool.ts
@@ -8,15 +8,15 @@
  * - Асинхронная операция на сервере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { ResultLogger } from '@mcp-framework/core';
 import { BulkTransitionIssuesDefinition } from './bulk-transition-issues.definition.js';
 import { BulkTransitionIssuesParamsSchema } from './bulk-transition-issues.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { BULK_TRANSITION_ISSUES_TOOL_METADATA } from './bulk-transition-issues.metadata.js';
 
 /**
  * Инструмент для массовой смены статусов задач
@@ -36,16 +36,7 @@ export class BulkTransitionIssuesTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('bulk_transition_issues', MCP_TOOL_PREFIX),
-    description: '[Bulk/Write] Массовая смена статусов задач',
-    category: ToolCategory.ISSUES,
-    subcategory: 'bulk',
-    priority: ToolPriority.HIGH,
-    tags: ['bulk', 'transition', 'status', 'workflow', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = BULK_TRANSITION_ISSUES_TOOL_METADATA;
 
   private readonly definition = new BulkTransitionIssuesDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/update/bulk-update-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/update/bulk-update-issues.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { BulkUpdateIssuesTool } from './bulk-update-issues.tool.js';
+import { BULK_UPDATE_ISSUES_TOOL_METADATA } from './bulk-update-issues.metadata.js';
 
 /**
  * Definition для BulkUpdateIssuesTool
@@ -20,7 +20,7 @@ import { BulkUpdateIssuesTool } from './bulk-update-issues.tool.js';
  */
 export class BulkUpdateIssuesDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return BulkUpdateIssuesTool.METADATA;
+    return BULK_UPDATE_ISSUES_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/update/bulk-update-issues.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/update/bulk-update-issues.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для BulkUpdateIssuesTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для BulkUpdateIssuesTool
+ */
+export const BULK_UPDATE_ISSUES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('bulk_update_issues', MCP_TOOL_PREFIX),
+  description: '[Bulk/Write] Массовое обновление полей задач',
+  category: ToolCategory.ISSUES,
+  subcategory: 'bulk',
+  priority: ToolPriority.HIGH,
+  tags: ['bulk', 'update', 'mass', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/bulk-change/update/bulk-update-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/bulk-change/update/bulk-update-issues.tool.ts
@@ -8,15 +8,15 @@
  * - Асинхронная операция на сервере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { ResultLogger } from '@mcp-framework/core';
 import { BulkUpdateIssuesDefinition } from './bulk-update-issues.definition.js';
 import { BulkUpdateIssuesParamsSchema } from './bulk-update-issues.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { BULK_UPDATE_ISSUES_TOOL_METADATA } from './bulk-update-issues.metadata.js';
 
 /**
  * Инструмент для массового обновления задач
@@ -35,16 +35,7 @@ export class BulkUpdateIssuesTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('bulk_update_issues', MCP_TOOL_PREFIX),
-    description: '[Bulk/Write] Массовое обновление полей задач',
-    category: ToolCategory.ISSUES,
-    subcategory: 'bulk',
-    priority: ToolPriority.HIGH,
-    tags: ['bulk', 'update', 'mass', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = BULK_UPDATE_ISSUES_TOOL_METADATA;
 
   private readonly definition = new BulkUpdateIssuesDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/add/add-checklist-item.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/add/add-checklist-item.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { AddChecklistItemTool } from './add-checklist-item.tool.js';
+import { ADD_CHECKLIST_ITEM_TOOL_METADATA } from './add-checklist-item.metadata.js';
 
 /**
  * Definition для AddChecklistItemTool
@@ -20,7 +20,7 @@ import { AddChecklistItemTool } from './add-checklist-item.tool.js';
  */
 export class AddChecklistItemDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return AddChecklistItemTool.METADATA;
+    return ADD_CHECKLIST_ITEM_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/add/add-checklist-item.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/add/add-checklist-item.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для AddChecklistItemTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для AddChecklistItemTool
+ */
+export const ADD_CHECKLIST_ITEM_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('add_checklist_item', MCP_TOOL_PREFIX),
+  description: '[Checklist/Write] Добавить элемент в чеклист',
+  category: ToolCategory.CHECKLISTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['checklist', 'add', 'create', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/add/add-checklist-item.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/add/add-checklist-item.tool.ts
@@ -7,15 +7,15 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { ChecklistItemWithUnknownFields } from '@tracker_api/entities/index.js';
 import { AddChecklistItemDefinition } from '@tools/api/checklists/add/add-checklist-item.definition.js';
 import { AddChecklistItemParamsSchema } from '@tools/api/checklists/add/add-checklist-item.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { ADD_CHECKLIST_ITEM_TOOL_METADATA } from './add-checklist-item.metadata.js';
 
 /**
  * Инструмент для добавления элемента в чеклист задачи
@@ -29,16 +29,7 @@ export class AddChecklistItemTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('add_checklist_item', MCP_TOOL_PREFIX),
-    description: '[Checklist/Write] Добавить элемент в чеклист',
-    category: ToolCategory.CHECKLISTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['checklist', 'add', 'create', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = ADD_CHECKLIST_ITEM_TOOL_METADATA;
 
   private readonly definition = new AddChecklistItemDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DeleteChecklistItemTool } from './delete-checklist-item.tool.js';
+import { DELETE_CHECKLIST_ITEM_TOOL_METADATA } from './delete-checklist-item.metadata.js';
 
 /**
  * Definition для DeleteChecklistItemTool
@@ -20,7 +20,7 @@ import { DeleteChecklistItemTool } from './delete-checklist-item.tool.js';
  */
 export class DeleteChecklistItemDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DeleteChecklistItemTool.METADATA;
+    return DELETE_CHECKLIST_ITEM_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для DeleteChecklistItemTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteChecklistItemTool
+ */
+export const DELETE_CHECKLIST_ITEM_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_checklist_item', MCP_TOOL_PREFIX),
+  description: '[Checklist/Write] Удалить элемент из чеклиста',
+  category: ToolCategory.CHECKLISTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['checklist', 'delete', 'remove', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.tool.ts
@@ -7,14 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DeleteChecklistItemDefinition } from '@tools/api/checklists/delete/delete-checklist-item.definition.js';
 import { DeleteChecklistItemParamsSchema } from '@tools/api/checklists/delete/delete-checklist-item.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { DELETE_CHECKLIST_ITEM_TOOL_METADATA } from './delete-checklist-item.metadata.js';
 
 /**
  * Инструмент для удаления элемента из чеклиста задачи
@@ -28,16 +28,7 @@ export class DeleteChecklistItemTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('delete_checklist_item', MCP_TOOL_PREFIX),
-    description: '[Checklist/Write] Удалить элемент из чеклиста',
-    category: ToolCategory.CHECKLISTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['checklist', 'delete', 'remove', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = DELETE_CHECKLIST_ITEM_TOOL_METADATA;
 
   private readonly definition = new DeleteChecklistItemDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/get/get-checklist.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/get/get-checklist.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetChecklistTool } from './get-checklist.tool.js';
+import { GET_CHECKLIST_TOOL_METADATA } from './get-checklist.metadata.js';
 
 /**
  * Definition для GetChecklistTool
@@ -20,7 +20,7 @@ import { GetChecklistTool } from './get-checklist.tool.js';
  */
 export class GetChecklistDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetChecklistTool.METADATA;
+    return GET_CHECKLIST_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/get/get-checklist.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/get/get-checklist.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetChecklistTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для GetChecklistTool
+ */
+export const GET_CHECKLIST_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_checklist', MCP_TOOL_PREFIX),
+  description: '[Checklist/Read] Получить чеклист задачи',
+  category: ToolCategory.CHECKLISTS,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['checklist', 'get', 'read'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/get/get-checklist.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/get/get-checklist.tool.ts
@@ -7,15 +7,15 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { ChecklistItemWithUnknownFields } from '@tracker_api/entities/index.js';
 import { GetChecklistDefinition } from '@tools/api/checklists/get/get-checklist.definition.js';
 import { GetChecklistParamsSchema } from '@tools/api/checklists/get/get-checklist.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { GET_CHECKLIST_TOOL_METADATA } from './get-checklist.metadata.js';
 
 /**
  * Инструмент для получения чеклиста задачи
@@ -29,16 +29,7 @@ export class GetChecklistTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_checklist', MCP_TOOL_PREFIX),
-    description: '[Checklist/Read] Получить чеклист задачи',
-    category: ToolCategory.CHECKLISTS,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['checklist', 'get', 'read'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_CHECKLIST_TOOL_METADATA;
 
   private readonly definition = new GetChecklistDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UpdateChecklistItemTool } from './update-checklist-item.tool.js';
+import { UPDATE_CHECKLIST_ITEM_TOOL_METADATA } from './update-checklist-item.metadata.js';
 
 /**
  * Definition для UpdateChecklistItemTool
@@ -20,7 +20,7 @@ import { UpdateChecklistItemTool } from './update-checklist-item.tool.js';
  */
 export class UpdateChecklistItemDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UpdateChecklistItemTool.METADATA;
+    return UPDATE_CHECKLIST_ITEM_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для UpdateChecklistItemTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для UpdateChecklistItemTool
+ */
+export const UPDATE_CHECKLIST_ITEM_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_checklist_item', MCP_TOOL_PREFIX),
+  description: '[Checklist/Write] Обновить элемент чеклиста',
+  category: ToolCategory.CHECKLISTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['checklist', 'update', 'edit', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.tool.ts
@@ -7,15 +7,15 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { ChecklistItemWithUnknownFields } from '@tracker_api/entities/index.js';
 import { UpdateChecklistItemDefinition } from '@tools/api/checklists/update/update-checklist-item.definition.js';
 import { UpdateChecklistItemParamsSchema } from '@tools/api/checklists/update/update-checklist-item.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { UPDATE_CHECKLIST_ITEM_TOOL_METADATA } from './update-checklist-item.metadata.js';
 
 /**
  * Инструмент для обновления элемента чеклиста задачи
@@ -29,16 +29,7 @@ export class UpdateChecklistItemTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('update_checklist_item', MCP_TOOL_PREFIX),
-    description: '[Checklist/Write] Обновить элемент чеклиста',
-    category: ToolCategory.CHECKLISTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['checklist', 'update', 'edit', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = UPDATE_CHECKLIST_ITEM_TOOL_METADATA;
 
   private readonly definition = new UpdateChecklistItemDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/comments/add/add-comment.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/add/add-comment.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { AddCommentTool } from './add-comment.tool.js';
+import { ADD_COMMENT_TOOL_METADATA } from './add-comment.metadata.js';
 
 /**
  * Definition для AddCommentTool
@@ -20,7 +20,7 @@ import { AddCommentTool } from './add-comment.tool.js';
  */
 export class AddCommentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return AddCommentTool.METADATA;
+    return ADD_COMMENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/comments/add/add-comment.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/add/add-comment.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для AddCommentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для AddCommentTool
+ */
+export const ADD_COMMENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('add_comment', MCP_TOOL_PREFIX),
+  description: '[Comments/Write] Добавить комментарий к задаче',
+  category: ToolCategory.COMMENTS,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['comment', 'add', 'create', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/comments/add/add-comment.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/add/add-comment.tool.ts
@@ -7,15 +7,15 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { CommentWithUnknownFields } from '@tracker_api/entities/index.js';
 import { AddCommentDefinition } from '@tools/api/comments/add/add-comment.definition.js';
 import { AddCommentParamsSchema } from '@tools/api/comments/add/add-comment.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { ADD_COMMENT_TOOL_METADATA } from './add-comment.metadata.js';
 
 /**
  * Инструмент для добавления комментария к задаче
@@ -29,16 +29,7 @@ export class AddCommentTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('add_comment', MCP_TOOL_PREFIX),
-    description: '[Comments/Write] Добавить комментарий к задаче',
-    category: ToolCategory.COMMENTS,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['comment', 'add', 'create', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = ADD_COMMENT_TOOL_METADATA;
 
   private readonly definition = new AddCommentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/comments/delete/delete-comment.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/delete/delete-comment.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DeleteCommentTool } from './delete-comment.tool.js';
+import { DELETE_COMMENT_TOOL_METADATA } from './delete-comment.metadata.js';
 
 /**
  * Definition для DeleteCommentTool
  */
 export class DeleteCommentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DeleteCommentTool.METADATA;
+    return DELETE_COMMENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/comments/delete/delete-comment.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/delete/delete-comment.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для DeleteCommentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteCommentTool
+ */
+export const DELETE_COMMENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_comment', MCP_TOOL_PREFIX),
+  description: '[Comments/Write] Удалить комментарий',
+  category: ToolCategory.COMMENTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['comment', 'delete', 'remove', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/comments/delete/delete-comment.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/delete/delete-comment.tool.ts
@@ -7,14 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DeleteCommentDefinition } from '@tools/api/comments/delete/delete-comment.definition.js';
 import { DeleteCommentParamsSchema } from '@tools/api/comments/delete/delete-comment.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { DELETE_COMMENT_TOOL_METADATA } from './delete-comment.metadata.js';
 
 /**
  * Инструмент для удаления комментария
@@ -28,16 +28,7 @@ export class DeleteCommentTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('delete_comment', MCP_TOOL_PREFIX),
-    description: '[Comments/Write] Удалить комментарий',
-    category: ToolCategory.COMMENTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['comment', 'delete', 'remove', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = DELETE_COMMENT_TOOL_METADATA;
 
   private readonly definition = new DeleteCommentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/comments/edit/edit-comment.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/edit/edit-comment.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { EditCommentTool } from './edit-comment.tool.js';
+import { EDIT_COMMENT_TOOL_METADATA } from './edit-comment.metadata.js';
 
 /**
  * Definition для EditCommentTool
  */
 export class EditCommentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return EditCommentTool.METADATA;
+    return EDIT_COMMENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/comments/edit/edit-comment.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/edit/edit-comment.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для EditCommentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для EditCommentTool
+ */
+export const EDIT_COMMENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('edit_comment', MCP_TOOL_PREFIX),
+  description: '[Comments/Write] Редактировать комментарий',
+  category: ToolCategory.COMMENTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['comment', 'edit', 'update', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/comments/edit/edit-comment.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/edit/edit-comment.tool.ts
@@ -7,15 +7,15 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { CommentWithUnknownFields } from '@tracker_api/entities/index.js';
 import { EditCommentDefinition } from '@tools/api/comments/edit/edit-comment.definition.js';
 import { EditCommentParamsSchema } from '@tools/api/comments/edit/edit-comment.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { EDIT_COMMENT_TOOL_METADATA } from './edit-comment.metadata.js';
 
 /**
  * Инструмент для редактирования комментария
@@ -29,16 +29,7 @@ export class EditCommentTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('edit_comment', MCP_TOOL_PREFIX),
-    description: '[Comments/Write] Редактировать комментарий',
-    category: ToolCategory.COMMENTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['comment', 'edit', 'update', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = EDIT_COMMENT_TOOL_METADATA;
 
   private readonly definition = new EditCommentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetCommentsTool } from './get-comments.tool.js';
+import { GET_COMMENTS_TOOL_METADATA } from './get-comments.metadata.js';
 
 /**
  * Definition для GetCommentsTool
  */
 export class GetCommentsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetCommentsTool.METADATA;
+    return GET_COMMENTS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetCommentsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для GetCommentsTool
+ */
+export const GET_COMMENTS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_comments', MCP_TOOL_PREFIX),
+  description: '[Comments/Read] Получить комментарии задачи',
+  category: ToolCategory.COMMENTS,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['comment', 'get', 'list', 'read'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.tool.ts
@@ -7,14 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetCommentsDefinition } from '@tools/api/comments/get/get-comments.definition.js';
 import { GetCommentsParamsSchema } from '@tools/api/comments/get/get-comments.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { GET_COMMENTS_TOOL_METADATA } from './get-comments.metadata.js';
 
 /**
  * Инструмент для получения комментариев задачи
@@ -28,16 +28,7 @@ export class GetCommentsTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_comments', MCP_TOOL_PREFIX),
-    description: '[Comments/Read] Получить комментарии задачи',
-    category: ToolCategory.COMMENTS,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['comment', 'get', 'list', 'read'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_COMMENTS_TOOL_METADATA;
 
   private readonly definition = new GetCommentsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { CreateComponentTool } from './create-component.tool.js';
+import { CREATE_COMPONENT_TOOL_METADATA } from './create-component.metadata.js';
 
 /**
  * Definition для CreateComponentTool
  */
 export class CreateComponentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return CreateComponentTool.METADATA;
+    return CREATE_COMPONENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для CreateComponentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для CreateComponentTool
+ */
+export const CREATE_COMPONENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('create_component', MCP_TOOL_PREFIX),
+  description: '[Components/Write] Создать компонент',
+  category: ToolCategory.COMPONENTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['components', 'create', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.tool.ts
@@ -2,29 +2,20 @@
  * MCP Tool для создания компонента в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { CreateComponentDefinition } from './create-component.definition.js';
 import { CreateComponentParamsSchema } from './create-component.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { CREATE_COMPONENT_TOOL_METADATA } from './create-component.metadata.js';
 
 /**
  * Инструмент для создания компонента
  */
 export class CreateComponentTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('create_component', MCP_TOOL_PREFIX),
-    description: '[Components/Write] Создать компонент',
-    category: ToolCategory.COMPONENTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['components', 'create', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = CREATE_COMPONENT_TOOL_METADATA;
 
   private readonly definition = new CreateComponentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/components/delete-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/delete-component.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DeleteComponentTool } from './delete-component.tool.js';
+import { DELETE_COMPONENT_TOOL_METADATA } from './delete-component.metadata.js';
 
 /**
  * Definition для DeleteComponentTool
  */
 export class DeleteComponentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DeleteComponentTool.METADATA;
+    return DELETE_COMPONENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/components/delete-component.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/delete-component.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для DeleteComponentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteComponentTool
+ */
+export const DELETE_COMPONENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_component', MCP_TOOL_PREFIX),
+  description: '[Components/Write] Удалить компонент',
+  category: ToolCategory.COMPONENTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['components', 'delete', 'write', 'remove'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/components/delete-component.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/delete-component.tool.ts
@@ -2,29 +2,20 @@
  * MCP Tool для удаления компонента в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DeleteComponentDefinition } from './delete-component.definition.js';
 import { DeleteComponentParamsSchema } from './delete-component.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { DELETE_COMPONENT_TOOL_METADATA } from './delete-component.metadata.js';
 
 /**
  * Инструмент для удаления компонента
  */
 export class DeleteComponentTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('delete_component', MCP_TOOL_PREFIX),
-    description: '[Components/Write] Удалить компонент',
-    category: ToolCategory.COMPONENTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['components', 'delete', 'write', 'remove'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = DELETE_COMPONENT_TOOL_METADATA;
 
   private readonly definition = new DeleteComponentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetComponentsTool } from './get-components.tool.js';
+import { GET_COMPONENTS_TOOL_METADATA } from './get-components.metadata.js';
 
 /**
  * Definition для GetComponentsTool
  */
 export class GetComponentsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetComponentsTool.METADATA;
+    return GET_COMPONENTS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetComponentsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для GetComponentsTool
+ */
+export const GET_COMPONENTS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_components', MCP_TOOL_PREFIX),
+  description: '[Components/Read] Получить список компонентов очереди',
+  category: ToolCategory.COMPONENTS,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['components', 'list', 'read', 'queue'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.tool.ts
@@ -2,29 +2,20 @@
  * MCP Tool для получения списка компонентов очереди в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetComponentsDefinition } from './get-components.definition.js';
 import { GetComponentsParamsSchema } from './get-components.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { GET_COMPONENTS_TOOL_METADATA } from './get-components.metadata.js';
 
 /**
  * Инструмент для получения списка компонентов очереди
  */
 export class GetComponentsTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('get_components', MCP_TOOL_PREFIX),
-    description: '[Components/Read] Получить список компонентов очереди',
-    category: ToolCategory.COMPONENTS,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['components', 'list', 'read', 'queue'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_COMPONENTS_TOOL_METADATA;
 
   private readonly definition = new GetComponentsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UpdateComponentTool } from './update-component.tool.js';
+import { UPDATE_COMPONENT_TOOL_METADATA } from './update-component.metadata.js';
 
 /**
  * Definition для UpdateComponentTool
  */
 export class UpdateComponentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UpdateComponentTool.METADATA;
+    return UPDATE_COMPONENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для UpdateComponentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для UpdateComponentTool
+ */
+export const UPDATE_COMPONENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_component', MCP_TOOL_PREFIX),
+  description: '[Components/Write] Обновить компонент',
+  category: ToolCategory.COMPONENTS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['components', 'update', 'write', 'modify'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.tool.ts
@@ -2,29 +2,20 @@
  * MCP Tool для обновления компонента в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { UpdateComponentDefinition } from './update-component.definition.js';
 import { UpdateComponentParamsSchema } from './update-component.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { UPDATE_COMPONENT_TOOL_METADATA } from './update-component.metadata.js';
 
 /**
  * Инструмент для обновления компонента
  */
 export class UpdateComponentTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('update_component', MCP_TOOL_PREFIX),
-    description: '[Components/Write] Обновить компонент',
-    category: ToolCategory.COMPONENTS,
-    subcategory: 'write',
-    priority: ToolPriority.HIGH,
-    tags: ['components', 'update', 'write', 'modify'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = UPDATE_COMPONENT_TOOL_METADATA;
 
   private readonly definition = new UpdateComponentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/delete/delete-attachment.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/delete/delete-attachment.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для DeleteAttachmentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteAttachmentTool
+ */
+export const DELETE_ATTACHMENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_attachment', MCP_TOOL_PREFIX),
+  description: '[Issues/Attachments] Удалить файл из задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'attachments',
+  priority: ToolPriority.NORMAL,
+  tags: ['attachments', 'write', 'delete', 'files'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/download/download-attachment.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/download/download-attachment.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DownloadAttachmentTool } from './download-attachment.tool.js';
+import { DOWNLOAD_ATTACHMENT_TOOL_METADATA } from './download-attachment.metadata.js';
 
 /**
  * Definition для DownloadAttachmentTool
@@ -20,7 +20,7 @@ import { DownloadAttachmentTool } from './download-attachment.tool.js';
  */
 export class DownloadAttachmentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DownloadAttachmentTool.METADATA;
+    return DOWNLOAD_ATTACHMENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/download/download-attachment.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/download/download-attachment.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для DownloadAttachmentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для DownloadAttachmentTool
+ */
+export const DOWNLOAD_ATTACHMENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('download_attachment', MCP_TOOL_PREFIX),
+  description: '[Issues/Attachments] Скачать файл из задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'attachments',
+  priority: ToolPriority.HIGH,
+  tags: ['attachments', 'read', 'download', 'files'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/download/download-attachment.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/download/download-attachment.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -15,8 +15,7 @@ import { DownloadAttachmentDefinition } from './download-attachment.definition.j
 import { DownloadAttachmentParamsSchema } from './download-attachment.schema.js';
 import { writeFile } from 'node:fs/promises';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { DOWNLOAD_ATTACHMENT_TOOL_METADATA } from './download-attachment.metadata.js';
 
 /**
  * Инструмент для скачивания файла из задачи
@@ -36,15 +35,7 @@ export class DownloadAttachmentTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('download_attachment', MCP_TOOL_PREFIX),
-    description: '[Issues/Attachments] Скачать файл из задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'attachments',
-    priority: ToolPriority.HIGH,
-    tags: ['attachments', 'read', 'download', 'files'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = DOWNLOAD_ATTACHMENT_TOOL_METADATA;
 
   private readonly definition = new DownloadAttachmentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/get/get-attachments.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/get/get-attachments.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetAttachmentsTool } from './get-attachments.tool.js';
+import { GET_ATTACHMENTS_TOOL_METADATA } from './get-attachments.metadata.js';
 
 /**
  * Definition для GetAttachmentsTool
@@ -20,7 +20,7 @@ import { GetAttachmentsTool } from './get-attachments.tool.js';
  */
 export class GetAttachmentsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetAttachmentsTool.METADATA;
+    return GET_ATTACHMENTS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/get/get-attachments.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/get/get-attachments.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для GetAttachmentsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для GetAttachmentsTool
+ */
+export const GET_ATTACHMENTS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_attachments', MCP_TOOL_PREFIX),
+  description: '[Issues/Attachments] Получить список файлов задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'attachments',
+  priority: ToolPriority.HIGH,
+  tags: ['attachments', 'read', 'files', 'documents'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/get/get-attachments.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/get/get-attachments.tool.ts
@@ -7,15 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetAttachmentsDefinition } from './get-attachments.definition.js';
 import { GetAttachmentsParamsSchema } from './get-attachments.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { GET_ATTACHMENTS_TOOL_METADATA } from './get-attachments.metadata.js';
 
 /**
  * Инструмент для получения списка файлов задачи
@@ -34,15 +33,7 @@ export class GetAttachmentsTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_attachments', MCP_TOOL_PREFIX),
-    description: '[Issues/Attachments] Получить список файлов задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'attachments',
-    priority: ToolPriority.HIGH,
-    tags: ['attachments', 'read', 'files', 'documents'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = GET_ATTACHMENTS_TOOL_METADATA;
 
   private readonly definition = new GetAttachmentsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/thumbnail/get-thumbnail.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/thumbnail/get-thumbnail.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetThumbnailTool } from './get-thumbnail.tool.js';
+import { GET_THUMBNAIL_TOOL_METADATA } from './get-thumbnail.metadata.js';
 
 /**
  * Definition для GetThumbnailTool
@@ -20,7 +20,7 @@ import { GetThumbnailTool } from './get-thumbnail.tool.js';
  */
 export class GetThumbnailDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetThumbnailTool.METADATA;
+    return GET_THUMBNAIL_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/thumbnail/get-thumbnail.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/thumbnail/get-thumbnail.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для GetThumbnailTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для GetThumbnailTool
+ */
+export const GET_THUMBNAIL_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_thumbnail', MCP_TOOL_PREFIX),
+  description: '[Issues/Attachments] Получить миниатюру изображения',
+  category: ToolCategory.ISSUES,
+  subcategory: 'attachments',
+  priority: ToolPriority.NORMAL,
+  tags: ['attachments', 'read', 'thumbnail', 'images', 'preview'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/thumbnail/get-thumbnail.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/thumbnail/get-thumbnail.tool.ts
@@ -8,7 +8,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,7 @@ import { GetThumbnailDefinition } from './get-thumbnail.definition.js';
 import { GetThumbnailParamsSchema } from './get-thumbnail.schema.js';
 import { writeFile } from 'node:fs/promises';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { GET_THUMBNAIL_TOOL_METADATA } from './get-thumbnail.metadata.js';
 
 /**
  * Инструмент для получения миниатюры изображения
@@ -37,15 +36,7 @@ export class GetThumbnailTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_thumbnail', MCP_TOOL_PREFIX),
-    description: '[Issues/Attachments] Получить миниатюру изображения',
-    category: ToolCategory.ISSUES,
-    subcategory: 'attachments',
-    priority: ToolPriority.NORMAL,
-    tags: ['attachments', 'read', 'thumbnail', 'images', 'preview'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = GET_THUMBNAIL_TOOL_METADATA;
 
   private readonly definition = new GetThumbnailDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/upload/upload-attachment.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/upload/upload-attachment.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UploadAttachmentTool } from './upload-attachment.tool.js';
+import { UPLOAD_ATTACHMENT_TOOL_METADATA } from './upload-attachment.metadata.js';
 
 /**
  * Definition для UploadAttachmentTool
@@ -20,7 +20,7 @@ import { UploadAttachmentTool } from './upload-attachment.tool.js';
  */
 export class UploadAttachmentDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UploadAttachmentTool.METADATA;
+    return UPLOAD_ATTACHMENT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/upload/upload-attachment.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/upload/upload-attachment.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для UploadAttachmentTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для UploadAttachmentTool
+ */
+export const UPLOAD_ATTACHMENT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('upload_attachment', MCP_TOOL_PREFIX),
+  description: '[Issues/Attachments] Загрузить файл в задачу',
+  category: ToolCategory.ISSUES,
+  subcategory: 'attachments',
+  priority: ToolPriority.HIGH,
+  tags: ['attachments', 'write', 'upload', 'files'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/attachments/upload/upload-attachment.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/attachments/upload/upload-attachment.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -15,8 +15,7 @@ import { UploadAttachmentDefinition } from './upload-attachment.definition.js';
 import { UploadAttachmentParamsSchema } from './upload-attachment.schema.js';
 import { readFile } from 'node:fs/promises';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { UPLOAD_ATTACHMENT_TOOL_METADATA } from './upload-attachment.metadata.js';
 
 /**
  * Инструмент для загрузки файла в задачу
@@ -36,15 +35,7 @@ export class UploadAttachmentTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('upload_attachment', MCP_TOOL_PREFIX),
-    description: '[Issues/Attachments] Загрузить файл в задачу',
-    category: ToolCategory.ISSUES,
-    subcategory: 'attachments',
-    priority: ToolPriority.HIGH,
-    tags: ['attachments', 'write', 'upload', 'files'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = UPLOAD_ATTACHMENT_TOOL_METADATA;
 
   private readonly definition = new UploadAttachmentDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.definition.ts
@@ -8,7 +8,7 @@ import {
   type StaticToolMetadata,
 } from '@mcp-framework/core';
 
-import { GetIssueChangelogTool } from './get-issue-changelog.tool.js';
+import { GET_ISSUE_CHANGELOG_TOOL_METADATA } from './get-issue-changelog.metadata.js';
 
 /**
  * Definition для GetIssueChangelogTool
@@ -21,7 +21,7 @@ import { GetIssueChangelogTool } from './get-issue-changelog.tool.js';
  */
 export class GetIssueChangelogDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetIssueChangelogTool.METADATA;
+    return GET_ISSUE_CHANGELOG_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для GetIssueChangelogTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для GetIssueChangelogTool
+ */
+export const GET_ISSUE_CHANGELOG_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_issue_changelog', MCP_TOOL_PREFIX),
+  description: '[Issues/Read] История изменений задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['history', 'changelog', 'audit', 'read'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/changelog/get-issue-changelog.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,7 @@ import type { ChangelogEntryWithUnknownFields } from '@tracker_api/entities/inde
 import { GetIssueChangelogDefinition } from '@tools/api/issues/changelog/get-issue-changelog.definition.js';
 import { GetIssueChangelogParamsSchema } from '@tools/api/issues/changelog/get-issue-changelog.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+import { GET_ISSUE_CHANGELOG_TOOL_METADATA } from './get-issue-changelog.metadata.js';
 
 /**
  * Инструмент для получения истории изменений задачи
@@ -38,15 +37,7 @@ export class GetIssueChangelogTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_issue_changelog', MCP_TOOL_PREFIX),
-    description: '[Issues/Read] История изменений задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['history', 'changelog', 'audit', 'read'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = GET_ISSUE_CHANGELOG_TOOL_METADATA;
 
   private readonly definition = new GetIssueChangelogDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { CreateIssueTool } from './create-issue.tool.js';
+import { CREATE_ISSUE_TOOL_METADATA } from './create-issue.metadata.js';
 
 /**
  * Definition для CreateIssueTool
@@ -20,7 +20,7 @@ import { CreateIssueTool } from './create-issue.tool.js';
  */
 export class CreateIssueDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return CreateIssueTool.METADATA;
+    return CREATE_ISSUE_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для CreateIssueTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для CreateIssueTool
+ */
+export const CREATE_ISSUE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('create_issue', MCP_TOOL_PREFIX),
+  description: '[Issues/Write] Создать новую задачу',
+  category: ToolCategory.ISSUES,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['create', 'new', 'write', 'issue'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,8 @@ import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
 import type { CreateIssueDto } from '@tracker_api/dto/index.js';
 import { CreateIssueDefinition } from '@tools/api/issues/create/create-issue.definition.js';
 import { CreateIssueParamsSchema } from '@tools/api/issues/create/create-issue.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { CREATE_ISSUE_TOOL_METADATA } from './create-issue.metadata.js';
 
 /**
  * Инструмент для создания новой задачи
@@ -35,16 +35,7 @@ export class CreateIssueTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('create_issue', MCP_TOOL_PREFIX),
-    description: '[Issues/Write] Создать новую задачу',
-    category: ToolCategory.ISSUES,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['create', 'new', 'write', 'issue'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = CREATE_ISSUE_TOOL_METADATA;
 
   private readonly definition = new CreateIssueDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
@@ -8,7 +8,7 @@ import {
   type StaticToolMetadata,
 } from '@mcp-framework/core';
 
-import { FindIssuesTool } from './find-issues.tool.js';
+import { FIND_ISSUES_TOOL_METADATA } from './find-issues.metadata.js';
 /**
  * Definition для FindIssuesTool
  *
@@ -20,7 +20,7 @@ import { FindIssuesTool } from './find-issues.tool.js';
  */
 export class FindIssuesDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return FindIssuesTool.METADATA;
+    return FIND_ISSUES_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для FindIssuesTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для FindIssuesTool
+ */
+export const FIND_ISSUES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('find_issues', MCP_TOOL_PREFIX),
+  description: '[Issues/Read] Поиск по фильтру',
+  category: ToolCategory.ISSUES,
+  subcategory: 'read',
+  priority: ToolPriority.CRITICAL,
+  tags: ['search', 'query', 'filter', 'issues'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,7 @@ import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
 import { FindIssuesDefinition } from '@tools/api/issues/find/find-issues.definition.js';
 import { FindIssuesParamsSchema } from '@tools/api/issues/find/find-issues.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+import { FIND_ISSUES_TOOL_METADATA } from './find-issues.metadata.js';
 /**
  * Инструмент для поиска задач
  *
@@ -36,15 +35,7 @@ export class FindIssuesTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('find_issues', MCP_TOOL_PREFIX),
-    description: '[Issues/Read] Поиск по фильтру',
-    category: ToolCategory.ISSUES,
-    subcategory: 'read',
-    priority: ToolPriority.CRITICAL,
-    tags: ['search', 'query', 'filter', 'issues'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = FIND_ISSUES_TOOL_METADATA;
 
   private readonly definition = new FindIssuesDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetIssuesTool } from './get-issues.tool.js';
+import { GET_ISSUES_TOOL_METADATA } from './get-issues.metadata.js';
 /**
  * Definition для GetIssuesTool
  *
@@ -19,7 +19,7 @@ import { GetIssuesTool } from './get-issues.tool.js';
  */
 export class GetIssuesDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetIssuesTool.METADATA;
+    return GET_ISSUES_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для GetIssuesTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для GetIssuesTool
+ */
+export const GET_ISSUES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_issues', MCP_TOOL_PREFIX),
+  description: '[Issues/Read] Получить задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'read',
+  priority: ToolPriority.CRITICAL,
+  tags: ['read', 'get', 'fetch', 'issue'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/get/get-issues.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,7 @@ import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
 import { GetIssuesDefinition } from '@tools/api/issues/get/get-issues.definition.js';
 import { GetIssuesParamsSchema } from '@tools/api/issues/get/get-issues.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+import { GET_ISSUES_TOOL_METADATA } from './get-issues.metadata.js';
 /**
  * Инструмент для получения информации о задачах
  *
@@ -37,15 +36,7 @@ export class GetIssuesTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_issues', MCP_TOOL_PREFIX),
-    description: '[Issues/Read] Получить задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'read',
-    priority: ToolPriority.CRITICAL,
-    tags: ['read', 'get', 'fetch', 'issue'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = GET_ISSUES_TOOL_METADATA;
 
   private readonly definition = new GetIssuesDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/create/create-link.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/create/create-link.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { CreateLinkTool } from './create-link.tool.js';
+import { CREATE_LINK_TOOL_METADATA } from './create-link.metadata.js';
 
 /**
  * Definition для CreateLinkTool
@@ -20,7 +20,7 @@ import { CreateLinkTool } from './create-link.tool.js';
  */
 export class CreateLinkDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return CreateLinkTool.METADATA;
+    return CREATE_LINK_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/create/create-link.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/create/create-link.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для CreateLinkTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для CreateLinkTool
+ */
+export const CREATE_LINK_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('create_link', MCP_TOOL_PREFIX),
+  description: '[Issues/Links] Создать связь между задачами',
+  category: ToolCategory.ISSUES,
+  subcategory: 'links',
+  priority: ToolPriority.HIGH,
+  tags: ['links', 'write', 'create', 'relationships', 'subtasks'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/create/create-link.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/create/create-link.tool.ts
@@ -7,15 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { CreateLinkDefinition } from './create-link.definition.js';
 import { CreateLinkParamsSchema } from './create-link.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { CREATE_LINK_TOOL_METADATA } from './create-link.metadata.js';
 
 /**
  * Инструмент для создания связи между задачами
@@ -34,15 +33,7 @@ export class CreateLinkTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('create_link', MCP_TOOL_PREFIX),
-    description: '[Issues/Links] Создать связь между задачами',
-    category: ToolCategory.ISSUES,
-    subcategory: 'links',
-    priority: ToolPriority.HIGH,
-    tags: ['links', 'write', 'create', 'relationships', 'subtasks'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = CREATE_LINK_TOOL_METADATA;
 
   private readonly definition = new CreateLinkDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DeleteLinkTool } from './delete-link.tool.js';
+import { DELETE_LINK_TOOL_METADATA } from './delete-link.metadata.js';
 
 /**
  * Definition для DeleteLinkTool
@@ -20,7 +20,7 @@ import { DeleteLinkTool } from './delete-link.tool.js';
  */
 export class DeleteLinkDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DeleteLinkTool.METADATA;
+    return DELETE_LINK_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для DeleteLinkTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteLinkTool
+ */
+export const DELETE_LINK_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_link', MCP_TOOL_PREFIX),
+  description: '[Issues/Links] Удалить связь между задачами',
+  category: ToolCategory.ISSUES,
+  subcategory: 'links',
+  priority: ToolPriority.HIGH,
+  tags: ['links', 'write', 'delete', 'remove', 'relationships'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.tool.ts
@@ -7,15 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DeleteLinkDefinition } from './delete-link.definition.js';
 import { DeleteLinkParamsSchema } from './delete-link.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { DELETE_LINK_TOOL_METADATA } from './delete-link.metadata.js';
 
 /**
  * Инструмент для удаления связи между задачами
@@ -34,15 +33,7 @@ export class DeleteLinkTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('delete_link', MCP_TOOL_PREFIX),
-    description: '[Issues/Links] Удалить связь между задачами',
-    category: ToolCategory.ISSUES,
-    subcategory: 'links',
-    priority: ToolPriority.HIGH,
-    tags: ['links', 'write', 'delete', 'remove', 'relationships'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = DELETE_LINK_TOOL_METADATA;
 
   private readonly definition = new DeleteLinkDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/get/get-issue-links.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/get/get-issue-links.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetIssueLinksTool } from './get-issue-links.tool.js';
+import { GET_ISSUE_LINKS_TOOL_METADATA } from './get-issue-links.metadata.js';
 
 /**
  * Definition для GetIssueLinksTool
@@ -20,7 +20,7 @@ import { GetIssueLinksTool } from './get-issue-links.tool.js';
  */
 export class GetIssueLinksDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetIssueLinksTool.METADATA;
+    return GET_ISSUE_LINKS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/get/get-issue-links.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/get/get-issue-links.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для GetIssueLinksTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для GetIssueLinksTool
+ */
+export const GET_ISSUE_LINKS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_issue_links', MCP_TOOL_PREFIX),
+  description: '[Issues/Links] Получить связи задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'links',
+  priority: ToolPriority.HIGH,
+  tags: ['links', 'read', 'relationships', 'subtasks'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/get/get-issue-links.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/get/get-issue-links.tool.ts
@@ -7,15 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetIssueLinksDefinition } from './get-issue-links.definition.js';
 import { GetIssueLinksParamsSchema } from './get-issue-links.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { GET_ISSUE_LINKS_TOOL_METADATA } from './get-issue-links.metadata.js';
 
 /**
  * Инструмент для получения связей задачи
@@ -34,15 +33,7 @@ export class GetIssueLinksTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_issue_links', MCP_TOOL_PREFIX),
-    description: '[Issues/Links] Получить связи задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'links',
-    priority: ToolPriority.HIGH,
-    tags: ['links', 'read', 'relationships', 'subtasks'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = GET_ISSUE_LINKS_TOOL_METADATA;
 
   private readonly definition = new GetIssueLinksDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { TransitionIssueTool } from './transition-issue.tool.js';
+import { TRANSITION_ISSUE_TOOL_METADATA } from './transition-issue.metadata.js';
 
 /**
  * Definition для TransitionIssueTool
@@ -20,7 +20,7 @@ import { TransitionIssueTool } from './transition-issue.tool.js';
  */
 export class TransitionIssueDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return TransitionIssueTool.METADATA;
+    return TRANSITION_ISSUE_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для TransitionIssueTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для TransitionIssueTool
+ */
+export const TRANSITION_ISSUE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('transition_issue', MCP_TOOL_PREFIX),
+  description: '[Issues/Workflow] Выполнить переход задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'workflow',
+  priority: ToolPriority.HIGH,
+  tags: ['transition', 'status', 'workflow', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/execute/transition-issue.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,8 @@ import type { IssueWithUnknownFields } from '@tracker_api/entities/index.js';
 import type { ExecuteTransitionDto } from '@tracker_api/dto/index.js';
 import { TransitionIssueDefinition } from '@tools/api/issues/transitions/execute/transition-issue.definition.js';
 import { TransitionIssueParamsSchema } from '@tools/api/issues/transitions/execute/transition-issue.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+import { TRANSITION_ISSUE_TOOL_METADATA } from './transition-issue.metadata.js';
 
 /**
  * Инструмент для выполнения перехода задачи в другой статус
@@ -38,16 +38,7 @@ export class TransitionIssueTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('transition_issue', MCP_TOOL_PREFIX),
-    description: '[Issues/Workflow] Выполнить переход задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'workflow',
-    priority: ToolPriority.HIGH,
-    tags: ['transition', 'status', 'workflow', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = TRANSITION_ISSUE_TOOL_METADATA;
 
   private readonly definition = new TransitionIssueDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.definition.ts
@@ -8,7 +8,7 @@ import {
   type StaticToolMetadata,
 } from '@mcp-framework/core';
 
-import { GetIssueTransitionsTool } from './get-issue-transitions.tool.js';
+import { GET_ISSUE_TRANSITIONS_TOOL_METADATA } from './get-issue-transitions.metadata.js';
 
 /**
  * Definition для GetIssueTransitionsTool
@@ -21,7 +21,7 @@ import { GetIssueTransitionsTool } from './get-issue-transitions.tool.js';
  */
 export class GetIssueTransitionsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetIssueTransitionsTool.METADATA;
+    return GET_ISSUE_TRANSITIONS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для GetIssueTransitionsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+
+/**
+ * Статические метаданные для GetIssueTransitionsTool
+ */
+export const GET_ISSUE_TRANSITIONS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_issue_transitions', MCP_TOOL_PREFIX),
+  description: '[Issues/Workflow] Доступные переходы',
+  category: ToolCategory.ISSUES,
+  subcategory: 'workflow',
+  priority: ToolPriority.HIGH,
+  tags: ['transitions', 'statuses', 'workflow', 'read'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/transitions/get/get-issue-transitions.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -16,8 +16,7 @@ import type { TransitionWithUnknownFields } from '@tracker_api/entities/index.js
 import { GetIssueTransitionsDefinition } from '@tools/api/issues/transitions/get/get-issue-transitions.definition.js';
 import { GetIssueTransitionsParamsSchema } from '@tools/api/issues/transitions/get/get-issue-transitions.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../../constants.js';
+import { GET_ISSUE_TRANSITIONS_TOOL_METADATA } from './get-issue-transitions.metadata.js';
 
 /**
  * Инструмент для получения доступных переходов статусов задачи
@@ -38,15 +37,7 @@ export class GetIssueTransitionsTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_issue_transitions', MCP_TOOL_PREFIX),
-    description: '[Issues/Workflow] Доступные переходы',
-    category: ToolCategory.ISSUES,
-    subcategory: 'workflow',
-    priority: ToolPriority.HIGH,
-    tags: ['transitions', 'statuses', 'workflow', 'read'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = GET_ISSUE_TRANSITIONS_TOOL_METADATA;
 
   private readonly definition = new GetIssueTransitionsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UpdateIssueTool } from './update-issue.tool.js';
+import { UPDATE_ISSUE_TOOL_METADATA } from './update-issue.metadata.js';
 
 /**
  * Definition для UpdateIssueTool
@@ -20,7 +20,7 @@ import { UpdateIssueTool } from './update-issue.tool.js';
  */
 export class UpdateIssueDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UpdateIssueTool.METADATA;
+    return UPDATE_ISSUE_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для UpdateIssueTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для UpdateIssueTool
+ */
+export const UPDATE_ISSUE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_issue', MCP_TOOL_PREFIX),
+  description: '[Issues/Write] Обновить поля задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['update', 'edit', 'modify', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.tool.ts
@@ -7,7 +7,7 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
@@ -17,8 +17,7 @@ import type { UpdateIssueDto } from '@tracker_api/dto/index.js';
 import { UpdateIssueDefinition } from '@tools/api/issues/update/update-issue.definition.js';
 import { UpdateIssueParamsSchema } from '@tools/api/issues/update/update-issue.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+import { UPDATE_ISSUE_TOOL_METADATA } from './update-issue.metadata.js';
 
 /**
  * Инструмент для обновления задачи
@@ -38,16 +37,7 @@ export class UpdateIssueTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('update_issue', MCP_TOOL_PREFIX),
-    description: '[Issues/Write] Обновить поля задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['update', 'edit', 'modify', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = UPDATE_ISSUE_TOOL_METADATA;
 
   private readonly definition = new UpdateIssueDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/create-project.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/create-project.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { CreateProjectTool } from './create-project.tool.js';
+import { CREATE_PROJECT_TOOL_METADATA } from './create-project.metadata.js';
 
 export class CreateProjectDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return CreateProjectTool.METADATA;
+    return CREATE_PROJECT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/create-project.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/create-project.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для CreateProjectTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для CreateProjectTool
+ */
+export const CREATE_PROJECT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('create_project', MCP_TOOL_PREFIX),
+  description: '[Projects/Write] Создать новый проект',
+  category: ToolCategory.PROJECTS,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['project', 'create', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/projects/create-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/create-project.tool.ts
@@ -4,27 +4,18 @@
  * ВАЖНО: Создание проектов - администраторская операция!
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { CreateProjectDefinition } from './create-project.definition.js';
 import { CreateProjectParamsSchema } from './create-project.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
 import type { CreateProjectDto } from '@tracker_api/dto/index.js';
+import { CREATE_PROJECT_TOOL_METADATA } from './create-project.metadata.js';
 
 export class CreateProjectTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('create_project', MCP_TOOL_PREFIX),
-    description: '[Projects/Write] Создать новый проект',
-    category: ToolCategory.PROJECTS,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['project', 'create', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = CREATE_PROJECT_TOOL_METADATA;
 
   private readonly definition = new CreateProjectDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DeleteProjectTool } from './delete-project.tool.js';
+import { DELETE_PROJECT_TOOL_METADATA } from './delete-project.metadata.js';
 
 export class DeleteProjectDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DeleteProjectTool.METADATA;
+    return DELETE_PROJECT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для DeleteProjectTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteProjectTool
+ */
+export const DELETE_PROJECT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_project', MCP_TOOL_PREFIX),
+  description: '[Projects/Delete] Удалить проект',
+  category: ToolCategory.PROJECTS,
+  subcategory: 'delete',
+  priority: ToolPriority.CRITICAL,
+  tags: ['project', 'delete', 'remove'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.tool.ts
@@ -4,26 +4,17 @@
  * ВАЖНО: Удаление проектов - критическая операция! Необратима!
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DeleteProjectDefinition } from './delete-project.definition.js';
 import { DeleteProjectParamsSchema } from './delete-project.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { DELETE_PROJECT_TOOL_METADATA } from './delete-project.metadata.js';
 
 export class DeleteProjectTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('delete_project', MCP_TOOL_PREFIX),
-    description: '[Projects/Delete] Удалить проект',
-    category: ToolCategory.PROJECTS,
-    subcategory: 'delete',
-    priority: ToolPriority.CRITICAL,
-    tags: ['project', 'delete', 'remove'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = DELETE_PROJECT_TOOL_METADATA;
 
   private readonly definition = new DeleteProjectDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-project.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-project.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetProjectTool } from './get-project.tool.js';
+import { GET_PROJECT_TOOL_METADATA } from './get-project.metadata.js';
 
 export class GetProjectDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetProjectTool.METADATA;
+    return GET_PROJECT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-project.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-project.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetProjectTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для GetProjectTool
+ */
+export const GET_PROJECT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_project', MCP_TOOL_PREFIX),
+  description: '[Projects/Read] Получить параметры проекта',
+  category: ToolCategory.PROJECTS,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['project', 'read', 'details'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-project.tool.ts
@@ -2,26 +2,17 @@
  * MCP Tool для получения одного проекта в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetProjectDefinition } from './get-project.definition.js';
 import { GetProjectParamsSchema } from './get-project.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { GET_PROJECT_TOOL_METADATA } from './get-project.metadata.js';
 
 export class GetProjectTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('get_project', MCP_TOOL_PREFIX),
-    description: '[Projects/Read] Получить параметры проекта',
-    category: ToolCategory.PROJECTS,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['project', 'read', 'details'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_PROJECT_TOOL_METADATA;
 
   private readonly definition = new GetProjectDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetProjectsTool } from './get-projects.tool.js';
+import { GET_PROJECTS_TOOL_METADATA } from './get-projects.metadata.js';
 
 export class GetProjectsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetProjectsTool.METADATA;
+    return GET_PROJECTS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetProjectsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для GetProjectsTool
+ */
+export const GET_PROJECTS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_projects', MCP_TOOL_PREFIX),
+  description: '[Projects/Read] Получить список проектов',
+  category: ToolCategory.PROJECTS,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['project', 'read', 'list'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.tool.ts
@@ -2,26 +2,17 @@
  * MCP Tool для получения списка проектов в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetProjectsDefinition } from './get-projects.definition.js';
 import { GetProjectsParamsSchema } from './get-projects.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { GET_PROJECTS_TOOL_METADATA } from './get-projects.metadata.js';
 
 export class GetProjectsTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('get_projects', MCP_TOOL_PREFIX),
-    description: '[Projects/Read] Получить список проектов',
-    category: ToolCategory.PROJECTS,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['project', 'read', 'list'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_PROJECTS_TOOL_METADATA;
 
   private readonly definition = new GetProjectsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/update-project.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/update-project.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UpdateProjectTool } from './update-project.tool.js';
+import { UPDATE_PROJECT_TOOL_METADATA } from './update-project.metadata.js';
 
 export class UpdateProjectDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UpdateProjectTool.METADATA;
+    return UPDATE_PROJECT_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/update-project.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/update-project.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для UpdateProjectTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для UpdateProjectTool
+ */
+export const UPDATE_PROJECT_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_project', MCP_TOOL_PREFIX),
+  description: '[Projects/Write] Обновить проект',
+  category: ToolCategory.PROJECTS,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['project', 'update', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/projects/update-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/update-project.tool.ts
@@ -4,27 +4,18 @@
  * ВАЖНО: Обновление проектов - администраторская операция!
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { UpdateProjectDefinition } from './update-project.definition.js';
 import { UpdateProjectParamsSchema } from './update-project.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
 import type { UpdateProjectDto } from '@tracker_api/dto/index.js';
+import { UPDATE_PROJECT_TOOL_METADATA } from './update-project.metadata.js';
 
 export class UpdateProjectTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('update_project', MCP_TOOL_PREFIX),
-    description: '[Projects/Write] Обновить проект',
-    category: ToolCategory.PROJECTS,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['project', 'update', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = UPDATE_PROJECT_TOOL_METADATA;
 
   private readonly definition = new UpdateProjectDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { CreateQueueTool } from './create-queue.tool.js';
+import { CREATE_QUEUE_TOOL_METADATA } from './create-queue.metadata.js';
 
 export class CreateQueueDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return CreateQueueTool.METADATA;
+    return CREATE_QUEUE_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для CreateQueueTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для CreateQueueTool
+ */
+export const CREATE_QUEUE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('create_queue', MCP_TOOL_PREFIX),
+  description: '[Queues/Write] Создать новую очередь',
+  category: ToolCategory.QUEUES,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['queue', 'create', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.tool.ts
@@ -4,27 +4,18 @@
  * ВАЖНО: Создание очередей - администраторская операция!
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { CreateQueueDefinition } from './create-queue.definition.js';
 import { CreateQueueParamsSchema } from './create-queue.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
 import type { CreateQueueDto } from '@tracker_api/dto/index.js';
+import { CREATE_QUEUE_TOOL_METADATA } from './create-queue.metadata.js';
 
 export class CreateQueueTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('create_queue', MCP_TOOL_PREFIX),
-    description: '[Queues/Write] Создать новую очередь',
-    category: ToolCategory.QUEUES,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['queue', 'create', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = CREATE_QUEUE_TOOL_METADATA;
 
   private readonly definition = new CreateQueueDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetQueueFieldsTool } from './get-queue-fields.tool.js';
+import { GET_QUEUE_FIELDS_TOOL_METADATA } from './get-queue-fields.metadata.js';
 
 export class GetQueueFieldsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetQueueFieldsTool.METADATA;
+    return GET_QUEUE_FIELDS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetQueueFieldsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для GetQueueFieldsTool
+ */
+export const GET_QUEUE_FIELDS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_queue_fields', MCP_TOOL_PREFIX),
+  description: '[Queues/Read] Получить обязательные поля очереди',
+  category: ToolCategory.QUEUES,
+  subcategory: 'read',
+  priority: ToolPriority.NORMAL,
+  tags: ['queue', 'fields', 'read'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.tool.ts
@@ -2,26 +2,17 @@
  * MCP Tool для получения обязательных полей очереди в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetQueueFieldsDefinition } from './get-queue-fields.definition.js';
 import { GetQueueFieldsParamsSchema } from './get-queue-fields.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { GET_QUEUE_FIELDS_TOOL_METADATA } from './get-queue-fields.metadata.js';
 
 export class GetQueueFieldsTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('get_queue_fields', MCP_TOOL_PREFIX),
-    description: '[Queues/Read] Получить обязательные поля очереди',
-    category: ToolCategory.QUEUES,
-    subcategory: 'read',
-    priority: ToolPriority.NORMAL,
-    tags: ['queue', 'fields', 'read'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_QUEUE_FIELDS_TOOL_METADATA;
 
   private readonly definition = new GetQueueFieldsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetQueueTool } from './get-queue.tool.js';
+import { GET_QUEUE_TOOL_METADATA } from './get-queue.metadata.js';
 
 export class GetQueueDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetQueueTool.METADATA;
+    return GET_QUEUE_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetQueueTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для GetQueueTool
+ */
+export const GET_QUEUE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_queue', MCP_TOOL_PREFIX),
+  description: '[Queues/Read] Получить параметры очереди',
+  category: ToolCategory.QUEUES,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['queue', 'read', 'details'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.tool.ts
@@ -2,26 +2,17 @@
  * MCP Tool для получения одной очереди в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetQueueDefinition } from './get-queue.definition.js';
 import { GetQueueParamsSchema } from './get-queue.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { GET_QUEUE_TOOL_METADATA } from './get-queue.metadata.js';
 
 export class GetQueueTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('get_queue', MCP_TOOL_PREFIX),
-    description: '[Queues/Read] Получить параметры очереди',
-    category: ToolCategory.QUEUES,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['queue', 'read', 'details'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_QUEUE_TOOL_METADATA;
 
   private readonly definition = new GetQueueDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetQueuesTool } from './get-queues.tool.js';
+import { GET_QUEUES_TOOL_METADATA } from './get-queues.metadata.js';
 
 /**
  * Definition для GetQueuesTool
  */
 export class GetQueuesDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetQueuesTool.METADATA;
+    return GET_QUEUES_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetQueuesTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для GetQueuesTool
+ */
+export const GET_QUEUES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_queues', MCP_TOOL_PREFIX),
+  description: '[Queues/Read] Получить список очередей',
+  category: ToolCategory.QUEUES,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['queues', 'list', 'read'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.tool.ts
@@ -2,29 +2,20 @@
  * MCP Tool для получения списка очередей в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetQueuesDefinition } from './get-queues.definition.js';
 import { GetQueuesParamsSchema } from './get-queues.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { GET_QUEUES_TOOL_METADATA } from './get-queues.metadata.js';
 
 /**
  * Инструмент для получения списка очередей
  */
 export class GetQueuesTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('get_queues', MCP_TOOL_PREFIX),
-    description: '[Queues/Read] Получить список очередей',
-    category: ToolCategory.QUEUES,
-    subcategory: 'read',
-    priority: ToolPriority.HIGH,
-    tags: ['queues', 'list', 'read'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_QUEUES_TOOL_METADATA;
 
   private readonly definition = new GetQueuesDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { ManageQueueAccessTool } from './manage-queue-access.tool.js';
+import { MANAGE_QUEUE_ACCESS_TOOL_METADATA } from './manage-queue-access.metadata.js';
 
 export class ManageQueueAccessDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return ManageQueueAccessTool.METADATA;
+    return MANAGE_QUEUE_ACCESS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для ManageQueueAccessTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для ManageQueueAccessTool
+ */
+export const MANAGE_QUEUE_ACCESS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('manage_queue_access', MCP_TOOL_PREFIX),
+  description: '[Queues/Write] Управление доступом к очереди',
+  category: ToolCategory.QUEUES,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['queue', 'access', 'permissions', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.tool.ts
@@ -2,26 +2,17 @@
  * MCP Tool для управления доступом к очереди в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { ManageQueueAccessDefinition } from './manage-queue-access.definition.js';
 import { ManageQueueAccessParamsSchema } from './manage-queue-access.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { MANAGE_QUEUE_ACCESS_TOOL_METADATA } from './manage-queue-access.metadata.js';
 
 export class ManageQueueAccessTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('manage_queue_access', MCP_TOOL_PREFIX),
-    description: '[Queues/Write] Управление доступом к очереди',
-    category: ToolCategory.QUEUES,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['queue', 'access', 'permissions', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = MANAGE_QUEUE_ACCESS_TOOL_METADATA;
 
   private readonly definition = new ManageQueueAccessDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.definition.ts
@@ -7,11 +7,11 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UpdateQueueTool } from './update-queue.tool.js';
+import { UPDATE_QUEUE_TOOL_METADATA } from './update-queue.metadata.js';
 
 export class UpdateQueueDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UpdateQueueTool.METADATA;
+    return UPDATE_QUEUE_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для UpdateQueueTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для UpdateQueueTool
+ */
+export const UPDATE_QUEUE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_queue', MCP_TOOL_PREFIX),
+  description: '[Queues/Write] Обновить параметры очереди',
+  category: ToolCategory.QUEUES,
+  subcategory: 'write',
+  priority: ToolPriority.CRITICAL,
+  tags: ['queue', 'update', 'write'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.tool.ts
@@ -2,27 +2,18 @@
  * MCP Tool для обновления очереди в Яндекс.Трекере
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { UpdateQueueDefinition } from './update-queue.definition.js';
 import { UpdateQueueParamsSchema } from './update-queue.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
 import type { UpdateQueueDto } from '@tracker_api/dto/index.js';
+import { UPDATE_QUEUE_TOOL_METADATA } from './update-queue.metadata.js';
 
 export class UpdateQueueTool extends BaseTool<YandexTrackerFacade> {
-  static override readonly METADATA = {
-    name: buildToolName('update_queue', MCP_TOOL_PREFIX),
-    description: '[Queues/Write] Обновить параметры очереди',
-    category: ToolCategory.QUEUES,
-    subcategory: 'write',
-    priority: ToolPriority.CRITICAL,
-    tags: ['queue', 'update', 'write'],
-    isHelper: false,
-    requiresExplicitUserConsent: true,
-  } as const;
+  static override readonly METADATA = UPDATE_QUEUE_TOOL_METADATA;
 
   private readonly definition = new UpdateQueueDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { AddWorklogTool } from './add-worklog.tool.js';
+import { ADD_WORKLOG_TOOL_METADATA } from './add-worklog.metadata.js';
 
 /**
  * Definition для AddWorklogTool
  */
 export class AddWorklogDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return AddWorklogTool.METADATA;
+    return ADD_WORKLOG_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для AddWorklogTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для AddWorklogTool
+ */
+export const ADD_WORKLOG_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('add_worklog', MCP_TOOL_PREFIX),
+  description: '[Worklog/Create] Добавить запись времени к задаче',
+  category: ToolCategory.ISSUES,
+  subcategory: 'worklog',
+  priority: ToolPriority.HIGH,
+  tags: ['worklog', 'add', 'create', 'time', 'log'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.tool.ts
@@ -8,14 +8,14 @@
  * - Автоматическая конвертация duration в ISO 8601
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { AddWorklogDefinition } from '@tools/api/worklog/add/add-worklog.definition.js';
 import { AddWorklogParamsSchema } from '@tools/api/worklog/add/add-worklog.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { ADD_WORKLOG_TOOL_METADATA } from './add-worklog.metadata.js';
 
 /**
  * Инструмент для добавления записи времени к задаче
@@ -29,16 +29,7 @@ export class AddWorklogTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('add_worklog', MCP_TOOL_PREFIX),
-    description: '[Worklog/Create] Добавить запись времени к задаче',
-    category: ToolCategory.ISSUES,
-    subcategory: 'worklog',
-    priority: ToolPriority.HIGH,
-    tags: ['worklog', 'add', 'create', 'time', 'log'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = ADD_WORKLOG_TOOL_METADATA;
 
   private readonly definition = new AddWorklogDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/delete/delete-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/delete/delete-worklog.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { DeleteWorklogTool } from './delete-worklog.tool.js';
+import { DELETE_WORKLOG_TOOL_METADATA } from './delete-worklog.metadata.js';
 
 /**
  * Definition для DeleteWorklogTool
  */
 export class DeleteWorklogDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DeleteWorklogTool.METADATA;
+    return DELETE_WORKLOG_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/delete/delete-worklog.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/delete/delete-worklog.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для DeleteWorklogTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для DeleteWorklogTool
+ */
+export const DELETE_WORKLOG_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_worklog', MCP_TOOL_PREFIX),
+  description: '[Worklog/Delete] Удалить запись времени задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'worklog',
+  priority: ToolPriority.HIGH,
+  tags: ['worklog', 'delete', 'remove', 'time'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/delete/delete-worklog.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/delete/delete-worklog.tool.ts
@@ -7,14 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DeleteWorklogDefinition } from '@tools/api/worklog/delete/delete-worklog.definition.js';
 import { DeleteWorklogParamsSchema } from '@tools/api/worklog/delete/delete-worklog.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { DELETE_WORKLOG_TOOL_METADATA } from './delete-worklog.metadata.js';
 
 /**
  * Инструмент для удаления записи времени
@@ -28,16 +28,7 @@ export class DeleteWorklogTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('delete_worklog', MCP_TOOL_PREFIX),
-    description: '[Worklog/Delete] Удалить запись времени задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'worklog',
-    priority: ToolPriority.HIGH,
-    tags: ['worklog', 'delete', 'remove', 'time'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = DELETE_WORKLOG_TOOL_METADATA;
 
   private readonly definition = new DeleteWorklogDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { GetWorklogsTool } from './get-worklogs.tool.js';
+import { GET_WORKLOGS_TOOL_METADATA } from './get-worklogs.metadata.js';
 
 /**
  * Definition для GetWorklogsTool
  */
 export class GetWorklogsDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return GetWorklogsTool.METADATA;
+    return GET_WORKLOGS_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для GetWorklogsTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для GetWorklogsTool
+ */
+export const GET_WORKLOGS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_worklogs', MCP_TOOL_PREFIX),
+  description: '[Worklog/Read] Получить записи времени задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'worklog',
+  priority: ToolPriority.HIGH,
+  tags: ['worklog', 'get', 'list', 'read', 'time'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.tool.ts
@@ -7,14 +7,14 @@
  * - Валидация через Zod
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { GetWorklogsDefinition } from '@tools/api/worklog/get/get-worklogs.definition.js';
 import { GetWorklogsParamsSchema } from '@tools/api/worklog/get/get-worklogs.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { GET_WORKLOGS_TOOL_METADATA } from './get-worklogs.metadata.js';
 
 /**
  * Инструмент для получения записей времени задачи
@@ -28,16 +28,7 @@ export class GetWorklogsTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_worklogs', MCP_TOOL_PREFIX),
-    description: '[Worklog/Read] Получить записи времени задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'worklog',
-    priority: ToolPriority.HIGH,
-    tags: ['worklog', 'get', 'list', 'read', 'time'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = GET_WORKLOGS_TOOL_METADATA;
 
   private readonly definition = new GetWorklogsDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.definition.ts
@@ -7,14 +7,14 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { UpdateWorklogTool } from './update-worklog.tool.js';
+import { UPDATE_WORKLOG_TOOL_METADATA } from './update-worklog.metadata.js';
 
 /**
  * Definition для UpdateWorklogTool
  */
 export class UpdateWorklogDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return UpdateWorklogTool.METADATA;
+    return UPDATE_WORKLOG_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Метаданные для UpdateWorklogTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+/**
+ * Статические метаданные для UpdateWorklogTool
+ */
+export const UPDATE_WORKLOG_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_worklog', MCP_TOOL_PREFIX),
+  description: '[Worklog/Update] Обновить запись времени задачи',
+  category: ToolCategory.ISSUES,
+  subcategory: 'worklog',
+  priority: ToolPriority.HIGH,
+  tags: ['worklog', 'update', 'edit', 'modify', 'time'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.tool.ts
@@ -8,14 +8,14 @@
  * - Автоматическая конвертация duration в ISO 8601
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { UpdateWorklogDefinition } from '@tools/api/worklog/update/update-worklog.definition.js';
 import { UpdateWorklogParamsSchema } from '@tools/api/worklog/update/update-worklog.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../../constants.js';
+
+import { UPDATE_WORKLOG_TOOL_METADATA } from './update-worklog.metadata.js';
 
 /**
  * Инструмент для обновления записи времени
@@ -29,16 +29,7 @@ export class UpdateWorklogTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('update_worklog', MCP_TOOL_PREFIX),
-    description: '[Worklog/Update] Обновить запись времени задачи',
-    category: ToolCategory.ISSUES,
-    subcategory: 'worklog',
-    priority: ToolPriority.HIGH,
-    tags: ['worklog', 'update', 'edit', 'modify', 'time'],
-    isHelper: false,
-    requiresExplicitUserConsent: false,
-  } as const;
+  static override readonly METADATA = UPDATE_WORKLOG_TOOL_METADATA;
 
   private readonly definition = new UpdateWorklogDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.definition.ts
@@ -6,11 +6,11 @@
 
 import type { ToolDefinition, StaticToolMetadata } from '@mcp-framework/core';
 import { BaseToolDefinition } from '@mcp-framework/core';
-import { DemoTool } from './demo.tool.js';
+import { DEMO_TOOL_METADATA } from './demo.metadata.js';
 
 export class DemoDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return DemoTool.METADATA;
+    return DEMO_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для DemoTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для DemoTool
+ */
+export const DEMO_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('demo', MCP_TOOL_PREFIX),
+  description: '[Helpers/Demo] Тестовый инструмент',
+  category: ToolCategory.HELPERS,
+  subcategory: 'demo',
+  priority: ToolPriority.LOW,
+  tags: ['demo', 'example', 'test'],
+  isHelper: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/demo/demo.tool.ts
@@ -9,29 +9,20 @@
  * 3. Всё остальное происходит АВТОМАТИЧЕСКИ
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { DemoDefinition } from './demo.definition.js';
 import { DemoParamsSchema } from './demo.schema.js';
 
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+import { DEMO_TOOL_METADATA } from './demo.metadata.js';
 
 export class DemoTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('demo', MCP_TOOL_PREFIX),
-    description: '[Helpers/Demo] Тестовый инструмент',
-    category: ToolCategory.HELPERS,
-    subcategory: 'demo',
-    priority: ToolPriority.LOW,
-    tags: ['demo', 'example', 'test'],
-    isHelper: true,
-  } as const;
+  static override readonly METADATA = DEMO_TOOL_METADATA;
 
   private readonly definition = new DemoDefinition();
 

--- a/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { IssueUrlTool } from './issue-url.tool.js';
+import { ISSUE_URL_TOOL_METADATA } from './issue-url.metadata.js';
 
 /**
  * Definition для IssueUrlTool
@@ -19,7 +19,7 @@ import { IssueUrlTool } from './issue-url.tool.js';
  */
 export class IssueUrlDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return IssueUrlTool.METADATA;
+    return ISSUE_URL_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для IssueUrlTool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - definition.ts импортирует metadata (не tool)
+ * - tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+/**
+ * Статические метаданные для IssueUrlTool
+ */
+export const ISSUE_URL_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_issue_urls', MCP_TOOL_PREFIX),
+  description: '[Helpers/URL] URL задачи',
+  category: ToolCategory.HELPERS,
+  subcategory: 'url',
+  priority: ToolPriority.NORMAL,
+  tags: ['url', 'link', 'helper'],
+  isHelper: true,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/helpers/issue-url/issue-url.tool.ts
@@ -8,14 +8,14 @@
  * - Batch-режим: обработка нескольких задач одновременно
  */
 
-import { BaseTool, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import { IssueUrlDefinition } from '@tools/helpers/issue-url/issue-url.definition.js';
 import { IssueUrlParamsSchema } from '@tools/helpers/issue-url/issue-url.schema.js';
-import { buildToolName } from '@mcp-framework/core';
-import { MCP_TOOL_PREFIX } from '../../../constants.js';
+
+import { ISSUE_URL_TOOL_METADATA } from './issue-url.metadata.js';
 
 /**
  * Инструмент для получения URL задач
@@ -31,15 +31,7 @@ export class IssueUrlTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('get_issue_urls', MCP_TOOL_PREFIX),
-    description: '[Helpers/URL] URL задачи',
-    category: ToolCategory.HELPERS,
-    subcategory: 'url',
-    priority: ToolPriority.NORMAL,
-    tags: ['url', 'link', 'helper'],
-    isHelper: true,
-  } as const;
+  static override readonly METADATA = ISSUE_URL_TOOL_METADATA;
 
   private readonly definition = new IssueUrlDefinition();
   private readonly TRACKER_BASE_URL = 'https://tracker.yandex.ru';
@@ -48,7 +40,7 @@ export class IssueUrlTool extends BaseTool<YandexTrackerFacade> {
     return this.definition.build();
   }
 
-  async execute(params: ToolCallParams): Promise<ToolResult> {
+  execute(params: ToolCallParams): Promise<ToolResult> {
     // 1. Валидация параметров через BaseTool
     const validation = this.validateParams(params, IssueUrlParamsSchema);
     if (!validation.success) {

--- a/packages/servers/yandex-tracker/src/tools/ping.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/ping.definition.ts
@@ -7,7 +7,7 @@ import {
   type ToolDefinition,
   type StaticToolMetadata,
 } from '@mcp-framework/core';
-import { PingTool } from './ping.tool.js';
+import { PING_TOOL_METADATA } from './ping.metadata.js';
 
 /**
  * Definition для PingTool
@@ -19,7 +19,7 @@ import { PingTool } from './ping.tool.js';
  */
 export class PingDefinition extends BaseToolDefinition {
   protected getStaticMetadata(): StaticToolMetadata {
-    return PingTool.METADATA;
+    return PING_TOOL_METADATA;
   }
 
   build(): ToolDefinition {

--- a/packages/servers/yandex-tracker/src/tools/ping.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/ping.metadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Метаданные для Ping Tool
+ *
+ * Вынесены в отдельный файл для разрыва циркулярной зависимости:
+ * - ping.definition.ts импортирует metadata (не tool)
+ * - ping.tool.ts импортирует metadata (не definition для METADATA)
+ *
+ * Это разрывает цикл: definition → tool → definition
+ */
+
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '../constants.js';
+
+/**
+ * Статические метаданные для Ping Tool
+ */
+export const PING_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('ping', MCP_TOOL_PREFIX),
+  description: '[System/Health] Проверка доступности сервера',
+  category: ToolCategory.SYSTEM,
+  subcategory: 'health',
+  priority: ToolPriority.NORMAL,
+  tags: ['ping', 'health', 'status'],
+  isHelper: false,
+} as const;

--- a/packages/servers/yandex-tracker/src/tools/ping.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/ping.tool.ts
@@ -7,12 +7,12 @@
  * - Получение информации о текущем пользователе
  */
 
-import { BaseTool, ToolCategory, ToolPriority, buildToolName } from '@mcp-framework/core';
+import { BaseTool } from '@mcp-framework/core';
 import type { ToolDefinition } from '@mcp-framework/core';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { YandexTrackerFacade } from '@tracker_api/facade/index.js';
-import { MCP_TOOL_PREFIX } from '../constants.js';
 import { PingDefinition } from './ping.definition.js';
+import { PING_TOOL_METADATA } from './ping.metadata.js';
 
 /**
  * Ping инструмент для диагностики подключения
@@ -21,15 +21,7 @@ export class PingTool extends BaseTool<YandexTrackerFacade> {
   /**
    * Статические метаданные для compile-time индексации
    */
-  static override readonly METADATA = {
-    name: buildToolName('ping', MCP_TOOL_PREFIX),
-    description: '[System/Health] Проверка доступности сервера',
-    category: ToolCategory.SYSTEM,
-    subcategory: 'health',
-    priority: ToolPriority.NORMAL,
-    tags: ['ping', 'health', 'status'],
-    isHelper: false,
-  } as const;
+  static override readonly METADATA = PING_TOOL_METADATA;
 
   private readonly definition = new PingDefinition();
 


### PR DESCRIPTION
…adata паттерн

Проблема:
- 30 циркулярных зависимостей (definition ↔ tool)
- Definition импортировал Tool для доступа к Tool.METADATA
- Tool импортировал Definition и создавал new Definition()
- Цикл: definition → tool → definition

Решение:
- Вынести METADATA в отдельные *.metadata.ts файлы
- Definition и Tool импортируют metadata независимо
- Разрыв циркулярности: metadata ← definition и tool

Изменения:
- Создано 49 *.metadata.ts файлов для всех tools
- Обновлены все *.definition.ts (импорт METADATA вместо Tool)
- Обновлены все *.tool.ts (импорт METADATA, удалены неиспользуемые импорты)
- Добавлены скрипты автоматизации рефакторинга и очистки
- Исправлен async/await issue в issue-url.tool.ts

Результат:
- 0 циркулярных зависимостей (было 30)
- Все тесты проходят: 1443/1443
- Build успешен
- Архитектура улучшена (SRP, четкое разделение ответственности)

🤖 Generated with Claude Code