### PR TITLE
Disable search tools in eager mode

### DIFF
--- a/packages/servers/yandex-tracker/tests/integration/tools/helpers/search/search-tools.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/helpers/search/search-tools.tool.integration.test.ts
@@ -22,8 +22,11 @@ describe('search-tools integration tests', () => {
 
   beforeEach(async () => {
     // Создаём MCP клиент с тестовой конфигурацией
+    // ВАЖНО: search_tools доступен только в lazy mode
     client = await createTestClient({
       logLevel: 'silent', // Отключаем логи в тестах
+      toolDiscoveryMode: 'lazy', // search_tools требует lazy mode
+      essentialTools: ['fr_yandex_tracker_ping', 'search_tools'],
     });
   });
 


### PR DESCRIPTION
Детали:
- SearchToolsTool теперь регистрируется только в lazy mode
- В eager mode Claude видит все инструменты, поэтому search_tools избыточен
- Добавлены тесты для проверки недоступности search_tools в eager mode
- Обновлены существующие тесты для явного указания lazy mode

Изменения:
- container.ts: условная регистрация SearchEngine и SearchToolsTool
- container.test.ts: новые тесты для eager/lazy режимов
- search-tools.tool.integration.test.ts: явное указание lazy mode

🤖 Generated with Claude Code