### PR TITLE
Continue MCP required fields planning

### DIFF
--- a/.agentic-planning/plan_mcp_required_fields/README.md
+++ b/.agentic-planning/plan_mcp_required_fields/README.md
@@ -79,7 +79,7 @@
 ### Этап 2: Реализация (Parallel)
 - [x] 2.1 Checklists (3 tools) - ✅ Завершено
 - [x] 2.2 Comments (3 tools) - ✅ Завершено
-- [ ] 2.3 Components (3 tools)
+- [x] 2.3 Components (3 tools) - ✅ Завершено
 - [ ] 2.4 Attachments (2 tools)
 - [ ] 2.5 Links (2 tools)
 - [ ] 2.6 Projects (4 tools)
@@ -92,7 +92,7 @@
 ### Этап 4: Документация
 - [ ] 4.1 Documentation
 
-**Итого tools:** 6/27 завершено (22%)
+**Итого tools:** 9/27 завершено (33%)
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.definition.ts
@@ -29,8 +29,9 @@ export class CreateComponentDefinition extends BaseToolDefinition {
           description: this.buildDescriptionParam(),
           lead: this.buildLeadParam(),
           assignAuto: this.buildAssignAutoParam(),
+          fields: this.buildFieldsParam(),
         },
-        required: ['queueId', 'name'],
+        required: ['queueId', 'name', 'fields'],
       },
     };
   }
@@ -38,7 +39,8 @@ export class CreateComponentDefinition extends BaseToolDefinition {
   private buildDescription(): string {
     return (
       'Создать новый компонент в очереди. ' +
-      'Требует указания очереди и названия компонента. ' +
+      'Требует указания очереди, названия компонента и fields. ' +
+      'Параметр fields определяет, какие поля компонента вернуть в ответе (например: ["id", "name"]). ' +
       '\n\n' +
       'Для: создания нового компонента для группировки задач. ' +
       '\n' +
@@ -73,6 +75,26 @@ export class CreateComponentDefinition extends BaseToolDefinition {
   private buildAssignAutoParam(): Record<string, unknown> {
     return this.buildBooleanParam(
       'Автоматически назначать задачи руководителю компонента (опционально).'
+    );
+  }
+
+  private buildFieldsParam(): Record<string, unknown> {
+    return this.buildArrayParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Фильтр полей ответа. ' +
+        'Указывайте только необходимые поля для экономии токенов. ' +
+        '\n\n' +
+        'Доступные поля: id, name, description, lead, queue, assignAuto.',
+      this.buildStringParam('Имя поля', {
+        minLength: 1,
+        examples: ['id', 'name', 'description', 'lead'],
+      }),
+      {
+        minItems: 1,
+        examples: [
+          ['id', 'name'],
+          ['id', 'name', 'description', 'lead'],
+        ],
+      }
     );
   }
 }

--- a/packages/servers/yandex-tracker/src/tools/api/components/create-component.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/create-component.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для создания компонента
@@ -32,6 +33,12 @@ export const CreateComponentParamsSchema = z.object({
    * Автоматическое назначение задач (опционально)
    */
   assignAuto: z.boolean().optional(),
+
+  /**
+   * Массив полей для возврата в результате (обязательный)
+   * Примеры: ['id', 'name'], ['id', 'name', 'description', 'lead.login']
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.definition.ts
@@ -25,8 +25,9 @@ export class GetComponentsDefinition extends BaseToolDefinition {
         type: 'object',
         properties: {
           queueId: this.buildQueueIdParam(),
+          fields: this.buildFieldsParam(),
         },
-        required: ['queueId'],
+        required: ['queueId', 'fields'],
       },
     };
   }
@@ -34,7 +35,8 @@ export class GetComponentsDefinition extends BaseToolDefinition {
   private buildDescription(): string {
     return (
       'Получить список компонентов очереди. ' +
-      'Возвращает все компоненты с их параметрами. ' +
+      'Требует указания queueId и fields. ' +
+      'Параметр fields определяет, какие поля компонентов вернуть в ответе (например: ["id", "name"]). ' +
       '\n\n' +
       'Для: просмотра компонентов очереди, управления компонентами. ' +
       '\n' +
@@ -46,5 +48,25 @@ export class GetComponentsDefinition extends BaseToolDefinition {
     return this.buildStringParam('ID или ключ очереди (обязательно).', {
       examples: ['QUEUE', '1'],
     });
+  }
+
+  private buildFieldsParam(): Record<string, unknown> {
+    return this.buildArrayParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Фильтр полей ответа. ' +
+        'Указывайте только необходимые поля для экономии токенов. ' +
+        '\n\n' +
+        'Доступные поля: id, name, description, lead, queue, assignAuto.',
+      this.buildStringParam('Имя поля', {
+        minLength: 1,
+        examples: ['id', 'name', 'description', 'lead'],
+      }),
+      {
+        minItems: 1,
+        examples: [
+          ['id', 'name'],
+          ['id', 'name', 'description', 'lead'],
+        ],
+      }
+    );
   }
 }

--- a/packages/servers/yandex-tracker/src/tools/api/components/get-components.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/get-components.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для получения списка компонентов очереди
@@ -12,6 +13,12 @@ export const GetComponentsParamsSchema = z.object({
    * ID или ключ очереди
    */
   queueId: z.string().min(1, 'Queue ID обязателен'),
+
+  /**
+   * Массив полей для возврата в результате (обязательный)
+   * Примеры: ['id', 'name'], ['id', 'name', 'description', 'lead.login']
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.definition.ts
@@ -29,8 +29,9 @@ export class UpdateComponentDefinition extends BaseToolDefinition {
           description: this.buildDescriptionParam(),
           lead: this.buildLeadParam(),
           assignAuto: this.buildAssignAutoParam(),
+          fields: this.buildFieldsParam(),
         },
-        required: ['componentId'],
+        required: ['componentId', 'fields'],
       },
     };
   }
@@ -38,7 +39,9 @@ export class UpdateComponentDefinition extends BaseToolDefinition {
   private buildDescription(): string {
     return (
       'Обновить параметры компонента. ' +
+      'Требует указания componentId и fields. ' +
       'Можно изменить название, описание, руководителя или настройку автоназначения. ' +
+      'Параметр fields определяет, какие поля компонента вернуть в ответе (например: ["id", "name"]). ' +
       '\n\n' +
       'Для: изменения существующего компонента. ' +
       '\n' +
@@ -73,6 +76,26 @@ export class UpdateComponentDefinition extends BaseToolDefinition {
   private buildAssignAutoParam(): Record<string, unknown> {
     return this.buildBooleanParam(
       'Автоматически назначать задачи руководителю компонента (опционально).'
+    );
+  }
+
+  private buildFieldsParam(): Record<string, unknown> {
+    return this.buildArrayParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Фильтр полей ответа. ' +
+        'Указывайте только необходимые поля для экономии токенов. ' +
+        '\n\n' +
+        'Доступные поля: id, name, description, lead, queue, assignAuto.',
+      this.buildStringParam('Имя поля', {
+        minLength: 1,
+        examples: ['id', 'name', 'description', 'lead'],
+      }),
+      {
+        minItems: 1,
+        examples: [
+          ['id', 'name'],
+          ['id', 'name', 'description', 'lead'],
+        ],
+      }
     );
   }
 }

--- a/packages/servers/yandex-tracker/src/tools/api/components/update-component.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/components/update-component.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для обновления компонента
@@ -32,6 +33,12 @@ export const UpdateComponentParamsSchema = z.object({
    * Автоматическое назначение задач (опционально)
    */
   assignAuto: z.boolean().optional(),
+
+  /**
+   * Массив полей для возврата в результате (обязательный)
+   * Примеры: ['id', 'name'], ['id', 'name', 'description', 'lead.login']
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/tests/helpers/workflow-client.ts
+++ b/packages/servers/yandex-tracker/tests/helpers/workflow-client.ts
@@ -18,10 +18,10 @@ export class WorkflowClient {
     summary: string;
     description?: string;
   }): Promise<string> {
-    const result = await this.client.callTool(
-      buildToolName('create_issue', MCP_TOOL_PREFIX),
-      params
-    );
+    const result = await this.client.callTool(buildToolName('create_issue', MCP_TOOL_PREFIX), {
+      ...params,
+      fields: ['key'],
+    });
 
     if (result.isError) {
       throw new Error(`Failed to create issue: ${result.content[0]?.text}`);
@@ -37,6 +37,7 @@ export class WorkflowClient {
   async getIssue(issueKey: string): Promise<unknown> {
     const result = await this.client.callTool(buildToolName('get_issues', MCP_TOOL_PREFIX), {
       issueKeys: [issueKey],
+      fields: ['key', 'summary', 'status', 'description'],
     });
 
     if (result.isError) {
@@ -54,6 +55,7 @@ export class WorkflowClient {
     const result = await this.client.callTool(buildToolName('update_issue', MCP_TOOL_PREFIX), {
       issueKey,
       ...updates,
+      fields: ['key'],
     });
 
     if (result.isError) {
@@ -68,6 +70,7 @@ export class WorkflowClient {
     const result = await this.client.callTool(buildToolName('transition_issue', MCP_TOOL_PREFIX), {
       issueKey,
       transitionId,
+      fields: ['key', 'status'],
     });
 
     if (result.isError) {
@@ -81,6 +84,7 @@ export class WorkflowClient {
   async findIssues(query: string): Promise<unknown[]> {
     const result = await this.client.callTool(buildToolName('find_issues', MCP_TOOL_PREFIX), {
       query,
+      fields: ['key', 'summary', 'status'],
     });
 
     if (result.isError) {
@@ -99,6 +103,7 @@ export class WorkflowClient {
       buildToolName('get_issue_changelog', MCP_TOOL_PREFIX),
       {
         issueKey,
+        fields: ['id', 'updatedAt', 'updatedBy'],
       }
     );
 
@@ -116,7 +121,7 @@ export class WorkflowClient {
   async getTransitions(issueKey: string): Promise<unknown[]> {
     const result = await this.client.callTool(
       buildToolName('get_issue_transitions', MCP_TOOL_PREFIX),
-      { issueKey }
+      { issueKey, fields: ['id', 'display'] }
     );
 
     if (result.isError) {

--- a/packages/servers/yandex-tracker/tests/tools/api/components/create-component.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/create-component.tool.test.ts
@@ -39,11 +39,13 @@ describe('CreateComponentTool', () => {
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toContain('queueId');
       expect(definition.inputSchema.required).toContain('name');
+      expect(definition.inputSchema.required).toContain('fields');
       expect(definition.inputSchema.properties?.['queueId']).toBeDefined();
       expect(definition.inputSchema.properties?.['name']).toBeDefined();
       expect(definition.inputSchema.properties?.['description']).toBeDefined();
       expect(definition.inputSchema.properties?.['lead']).toBeDefined();
       expect(definition.inputSchema.properties?.['assignAuto']).toBeDefined();
+      expect(definition.inputSchema.properties?.['fields']).toBeDefined();
     });
   });
 
@@ -64,6 +66,7 @@ describe('CreateComponentTool', () => {
       it('должен вернуть ошибку если queueId не указан', async () => {
         const result = await tool.execute({
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -78,6 +81,7 @@ describe('CreateComponentTool', () => {
       it('должен вернуть ошибку если name не указан', async () => {
         const result = await tool.execute({
           queueId: 'TEST',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -93,6 +97,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: '',
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -108,6 +113,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: '',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -126,6 +132,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -144,6 +151,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -171,12 +179,14 @@ describe('CreateComponentTool', () => {
           data: {
             component: { id: string; name: string };
             message: string;
+            fieldsReturned: string[];
           };
         };
         expect(parsed.success).toBe(true);
         expect(parsed.data.component.id).toBe('123');
         expect(parsed.data.component.name).toBe('Test Component');
         expect(parsed.data.message).toContain('успешно создан');
+        expect(parsed.data.fieldsReturned).toEqual(['id', 'name']);
       });
 
       it('должен создать компонент с описанием', async () => {
@@ -190,6 +200,7 @@ describe('CreateComponentTool', () => {
           queueId: 'PROJ',
           name: 'Backend',
           description: 'Backend services',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -219,6 +230,7 @@ describe('CreateComponentTool', () => {
           queueId: 'PROJ',
           name: 'Frontend',
           lead: 'user-login',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -249,6 +261,7 @@ describe('CreateComponentTool', () => {
           queueId: 'PROJ',
           name: 'Mobile',
           assignAuto: true,
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -282,6 +295,7 @@ describe('CreateComponentTool', () => {
           description: 'Full description',
           lead: 'admin',
           assignAuto: true,
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -312,6 +326,7 @@ describe('CreateComponentTool', () => {
           queueId: 'TEST',
           name: 'No Auto',
           assignAuto: false,
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -333,6 +348,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Duplicate',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -353,6 +369,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'NOTEXIST',
           name: 'Test',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -371,6 +388,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -390,6 +408,7 @@ describe('CreateComponentTool', () => {
           queueId: 'TEST',
           name: 'Test Component',
           lead: 'invalid-user',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -408,6 +427,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -426,6 +446,7 @@ describe('CreateComponentTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Test Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);

--- a/packages/servers/yandex-tracker/tests/tools/api/components/get-components.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/get-components.tool.test.ts
@@ -38,7 +38,9 @@ describe('GetComponentsTool', () => {
       expect(definition.description).toContain('список компонентов');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toContain('queueId');
+      expect(definition.inputSchema.required).toContain('fields');
       expect(definition.inputSchema.properties?.['queueId']).toBeDefined();
+      expect(definition.inputSchema.properties?.['fields']).toBeDefined();
     });
   });
 
@@ -57,7 +59,7 @@ describe('GetComponentsTool', () => {
       });
 
       it('должен вернуть ошибку для пустого queueId', async () => {
-        const result = await tool.execute({ queueId: '' });
+        const result = await tool.execute({ queueId: '', fields: ['id', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -75,7 +77,7 @@ describe('GetComponentsTool', () => {
         ];
         vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getComponents).toHaveBeenCalledWith({
@@ -93,7 +95,7 @@ describe('GetComponentsTool', () => {
         ];
         vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
 
-        const result = await tool.execute({ queueId: 'MYQUEUE' });
+        const result = await tool.execute({ queueId: 'MYQUEUE', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getComponents).toHaveBeenCalledWith({
@@ -113,18 +115,20 @@ describe('GetComponentsTool', () => {
             components: unknown[];
             count: number;
             queueId: string;
+            fieldsReturned: string[];
           };
         };
         expect(parsed.success).toBe(true);
         expect(parsed.data.components).toHaveLength(3);
         expect(parsed.data.count).toBe(3);
         expect(parsed.data.queueId).toBe('MYQUEUE');
+        expect(parsed.data.fieldsReturned).toEqual(['id', 'name']);
       });
 
       it('должен обработать пустой список компонентов', async () => {
         vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue([]);
 
-        const result = await tool.execute({ queueId: 'EMPTY' });
+        const result = await tool.execute({ queueId: 'EMPTY', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockLogger.info).toHaveBeenCalledWith('Список компонентов получен', {
@@ -159,7 +163,7 @@ describe('GetComponentsTool', () => {
         ];
         vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
 
-        const result = await tool.execute({ queueId: 'PROJECT' });
+        const result = await tool.execute({ queueId: 'PROJECT', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -177,7 +181,7 @@ describe('GetComponentsTool', () => {
         const mockComponents = [createComponentFixture({ id: '1', name: 'Single Component' })];
         vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
 
-        const result = await tool.execute({ queueId: 'SINGLE' });
+        const result = await tool.execute({ queueId: 'SINGLE', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -198,7 +202,7 @@ describe('GetComponentsTool', () => {
         );
         vi.mocked(mockTrackerFacade.getComponents).mockResolvedValue(mockComponents);
 
-        const result = await tool.execute({ queueId: 'LARGE' });
+        const result = await tool.execute({ queueId: 'LARGE', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -218,7 +222,7 @@ describe('GetComponentsTool', () => {
         const error = new Error('Queue not found');
         vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'NOTEXIST' });
+        const result = await tool.execute({ queueId: 'NOTEXIST', fields: ['id', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -235,7 +239,7 @@ describe('GetComponentsTool', () => {
         const error = new Error('Network timeout');
         vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -250,7 +254,7 @@ describe('GetComponentsTool', () => {
         const error = new Error('Permission denied');
         vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'RESTRICTED' });
+        const result = await tool.execute({ queueId: 'RESTRICTED', fields: ['id', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -265,7 +269,7 @@ describe('GetComponentsTool', () => {
         const error = new Error('API Error: 500 Internal Server Error');
         vi.mocked(mockTrackerFacade.getComponents).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {

--- a/packages/servers/yandex-tracker/tests/tools/api/components/update-component.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/components/update-component.tool.test.ts
@@ -38,11 +38,13 @@ describe('UpdateComponentTool', () => {
       expect(definition.description).toContain('параметры компонента');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toContain('componentId');
+      expect(definition.inputSchema.required).toContain('fields');
       expect(definition.inputSchema.properties?.['componentId']).toBeDefined();
       expect(definition.inputSchema.properties?.['name']).toBeDefined();
       expect(definition.inputSchema.properties?.['description']).toBeDefined();
       expect(definition.inputSchema.properties?.['lead']).toBeDefined();
       expect(definition.inputSchema.properties?.['assignAuto']).toBeDefined();
+      expect(definition.inputSchema.properties?.['fields']).toBeDefined();
     });
   });
 
@@ -61,7 +63,7 @@ describe('UpdateComponentTool', () => {
       });
 
       it('должен вернуть ошибку для пустого componentId', async () => {
-        const result = await tool.execute({ componentId: '' });
+        const result = await tool.execute({ componentId: '', fields: ['id', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -76,7 +78,7 @@ describe('UpdateComponentTool', () => {
         const mockComponent = createComponentFixture({ id: '123' });
         vi.mocked(mockTrackerFacade.updateComponent).mockResolvedValue(mockComponent);
 
-        const result = await tool.execute({ componentId: '123' });
+        const result = await tool.execute({ componentId: '123', fields: ['id', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.updateComponent).toHaveBeenCalledWith({
@@ -92,6 +94,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           name: '',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -115,6 +118,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           name: 'Updated Component',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -159,6 +163,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           description: 'New description',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -185,6 +190,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           lead: 'new-lead',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -214,6 +220,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           assignAuto: true,
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -246,6 +253,7 @@ describe('UpdateComponentTool', () => {
           name: 'Updated',
           description: 'Updated description',
           lead: 'admin',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -280,6 +288,7 @@ describe('UpdateComponentTool', () => {
           description: 'Full description',
           lead: 'newlead',
           assignAuto: true,
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -309,6 +318,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           assignAuto: false,
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -331,6 +341,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           description: '',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -352,6 +363,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: 'NOTEXIST',
           name: 'New Name',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -372,6 +384,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           name: 'New Name',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -390,6 +403,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           lead: 'invalid-user',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -408,6 +422,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           description: 'New description',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -426,6 +441,7 @@ describe('UpdateComponentTool', () => {
         const result = await tool.execute({
           componentId: '123',
           name: 'New Name',
+          fields: ['id', 'name'],
         });
 
         expect(result.isError).toBe(true);


### PR DESCRIPTION
…ents tools

Обновлены 3 tools из категории Components:
- create_component: добавлен обязательный fields параметр
- get_components: добавлен обязательный fields параметр
- update_component: добавлен обязательный fields параметр

Детали:
- Schema: добавлен FieldsSchema (обязательный, без .optional())
- Tool: используется ResponseFieldFilter.filter() для фильтрации ответов
- Definition: обновлены описания и required fields
- Тесты: добавлен параметр fields во все тесты (66 passed)
- WorkflowClient: обновлен для передачи fields во все вызовы

Прогресс плана: 9/27 tools завершено (33%)

🤖 Generated with Claude Code