### PR TITLE
Complete MCP required fields planning stage 2.8

### DIFF
--- a/.agentic-planning/plan_mcp_required_fields/README.md
+++ b/.agentic-planning/plan_mcp_required_fields/README.md
@@ -84,7 +84,7 @@
 - [x] 2.5 Links (2 tools) - ✅ Завершено
 - [x] 2.6 Projects (4 tools) - ✅ Завершено
 - [ ] 2.7 Queues (6 tools)
-- [ ] 2.8 Worklogs (3 tools)
+- [x] 2.8 Worklogs (3 tools) - ✅ Завершено
 
 ### Этап 3: Валидация
 - [ ] 3.1 Validation
@@ -92,7 +92,7 @@
 ### Этап 4: Документация
 - [ ] 4.1 Documentation
 
-**Итого tools:** 17/27 завершено (63%)
+**Итого tools:** 20/27 завершено (74%)
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.definition.ts
@@ -28,8 +28,9 @@ export class AddWorklogDefinition extends BaseToolDefinition {
           start: this.buildStartParam(),
           duration: this.buildDurationParam(),
           comment: this.buildCommentParam(),
+          fields: this.buildFieldsParam(),
         },
-        required: ['issueId', 'start', 'duration'],
+        required: ['issueId', 'start', 'duration', 'fields'],
       },
     };
   }
@@ -72,6 +73,20 @@ export class AddWorklogDefinition extends BaseToolDefinition {
       'Опциональный комментарий к записи времени (описание выполненной работы).',
       {
         examples: ['Работал над реализацией API', 'Тестирование и отладка'],
+      }
+    );
+  }
+
+  private buildFieldsParam(): Record<string, unknown> {
+    return this.buildArrayParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Список полей, которые нужно вернуть в ответе. ' +
+        'Сокращает объем ответа, возвращая только нужные поля.',
+      {
+        items: { type: 'string' },
+        examples: [
+          ['id', 'duration', 'comment'],
+          ['id', 'start', 'createdBy'],
+        ],
       }
     );
   }

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.schema.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { IssueKeySchema } from '../../../../common/schemas/index.js';
+import { IssueKeySchema, FieldsSchema } from '../../../../common/schemas/index.js';
 
 /**
  * Схема параметров для добавления записи времени
@@ -31,6 +31,11 @@ export const AddWorklogParamsSchema = z.object({
    * Комментарий к записи времени (опционально)
    */
   comment: z.string().optional(),
+
+  /**
+   * Поля, которые нужно вернуть (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.definition.ts
@@ -25,8 +25,9 @@ export class GetWorklogsDefinition extends BaseToolDefinition {
         type: 'object',
         properties: {
           issueId: this.buildIssueIdParam(),
+          fields: this.buildFieldsParam(),
         },
-        required: ['issueId'],
+        required: ['issueId', 'fields'],
       },
     };
   }
@@ -46,5 +47,19 @@ export class GetWorklogsDefinition extends BaseToolDefinition {
     return this.buildStringParam('⚠️ ОБЯЗАТЕЛЬНЫЙ. Идентификатор или ключ задачи.', {
       examples: ['TEST-123', 'PROJ-456'],
     });
+  }
+
+  private buildFieldsParam(): Record<string, unknown> {
+    return this.buildArrayParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Список полей, которые нужно вернуть в ответе. ' +
+        'Сокращает объем ответа, возвращая только нужные поля.',
+      {
+        items: { type: 'string' },
+        examples: [
+          ['id', 'duration', 'comment'],
+          ['id', 'start', 'createdBy'],
+        ],
+      }
+    );
   }
 }

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.schema.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { IssueKeySchema } from '../../../../common/schemas/index.js';
+import { IssueKeySchema, FieldsSchema } from '../../../../common/schemas/index.js';
 
 /**
  * Схема параметров для получения записей времени
@@ -13,6 +13,11 @@ export const GetWorklogsParamsSchema = z.object({
    * Идентификатор или ключ задачи (обязательно)
    */
   issueId: IssueKeySchema.describe('Issue ID or key (e.g., TEST-123)'),
+
+  /**
+   * Поля, которые нужно вернуть (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.definition.ts
@@ -29,8 +29,9 @@ export class UpdateWorklogDefinition extends BaseToolDefinition {
           start: this.buildStartParam(),
           duration: this.buildDurationParam(),
           comment: this.buildCommentParam(),
+          fields: this.buildFieldsParam(),
         },
-        required: ['issueId', 'worklogId'],
+        required: ['issueId', 'worklogId', 'fields'],
       },
     };
   }
@@ -78,5 +79,19 @@ export class UpdateWorklogDefinition extends BaseToolDefinition {
     return this.buildStringParam('Опциональный новый комментарий к записи времени.', {
       examples: ['Обновленный комментарий', 'Исправлено описание работы'],
     });
+  }
+
+  private buildFieldsParam(): Record<string, unknown> {
+    return this.buildArrayParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Список полей, которые нужно вернуть в ответе. ' +
+        'Сокращает объем ответа, возвращая только нужные поля.',
+      {
+        items: { type: 'string' },
+        examples: [
+          ['id', 'duration', 'comment'],
+          ['id', 'start', 'createdBy'],
+        ],
+      }
+    );
   }
 }

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.schema.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { IssueKeySchema } from '../../../../common/schemas/index.js';
+import { IssueKeySchema, FieldsSchema } from '../../../../common/schemas/index.js';
 
 /**
  * Схема параметров для обновления записи времени
@@ -36,6 +36,11 @@ export const UpdateWorklogParamsSchema = z.object({
    * Комментарий к записи времени (опционально)
    */
   comment: z.string().optional(),
+
+  /**
+   * Поля, которые нужно вернуть (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**


### PR DESCRIPTION
… tools

Детали:
- add_worklog: добавлен fields в schema, tool, definition
- get_worklogs: добавлен fields в schema, tool, definition
- update_worklog: добавлен fields в schema, tool, definition
- Все schemas обновлены: fields: FieldsSchema (обязательный)
- Все tools используют ResponseFieldFilter.filter() для фильтрации
- Все definitions обновлены с buildFieldsParam() и fields в required
- Обновлен прогресс плана: 20/27 tools завершено (74%)

Прогресс: 20/27 tools завершено (74%)
Часть плана: .agentic-planning/plan_mcp_required_fields/2.8_worklogs_parallel.md

🤖 Generated with Claude Code