### PR TITLE
Implement Queues tools for MCP

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/create-queue.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для создания очереди
@@ -42,6 +43,11 @@ export const CreateQueueParamsSchema = z.object({
    * Массив ID доступных типов задач (опционально)
    */
   issueTypes: z.array(z.string()).optional(),
+
+  /**
+   * Список полей для возврата (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue-fields.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для получения полей очереди
@@ -12,6 +13,11 @@ export const GetQueueFieldsParamsSchema = z.object({
    * Идентификатор или ключ очереди (обязательно)
    */
   queueId: z.string().min(1, 'Queue ID не может быть пустым'),
+
+  /**
+   * Список полей для возврата (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queue.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для получения одной очереди
@@ -17,6 +18,11 @@ export const GetQueueParamsSchema = z.object({
    * Дополнительные поля для включения в ответ (опционально)
    */
   expand: z.string().optional(),
+
+  /**
+   * Список полей для возврата (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для получения списка очередей
@@ -22,6 +23,11 @@ export const GetQueuesParamsSchema = z.object({
    * Дополнительные поля для включения в ответ (опционально)
    */
   expand: z.string().optional(),
+
+  /**
+   * Список полей для возврата (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/manage-queue-access.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для управления доступом к очереди
@@ -27,6 +28,11 @@ export const ManageQueueAccessParamsSchema = z.object({
    * Действие (обязательно)
    */
   action: z.enum(['add', 'remove']),
+
+  /**
+   * Список полей для возврата (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/update-queue.schema.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from 'zod';
+import { FieldsSchema } from '../../../common/schemas/index.js';
 
 /**
  * Схема параметров для обновления очереди
@@ -42,6 +43,11 @@ export const UpdateQueueParamsSchema = z.object({
    * Массив ID доступных типов задач (опционально)
    */
   issueTypes: z.array(z.string()).optional(),
+
+  /**
+   * Список полей для возврата (обязательно)
+   */
+  fields: FieldsSchema,
 });
 
 /**

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/create-queue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/create-queue.tool.test.ts
@@ -52,7 +52,7 @@ describe('CreateQueueTool', () => {
   describe('execute', () => {
     describe('валидация параметров (Zod)', () => {
       it('должен вернуть ошибку если обязательные поля не указаны', async () => {
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -70,6 +70,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -88,6 +89,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -106,6 +108,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -124,6 +127,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -145,6 +149,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -161,6 +166,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -174,6 +180,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -197,6 +204,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -247,6 +255,7 @@ describe('CreateQueueTool', () => {
           defaultType: '1',
           defaultPriority: '2',
           description: 'Project description',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -271,6 +280,7 @@ describe('CreateQueueTool', () => {
           defaultType: '1',
           defaultPriority: '2',
           issueTypes: ['1', '2', '3'],
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -296,6 +306,7 @@ describe('CreateQueueTool', () => {
           defaultPriority: '3',
           description: 'Full queue description',
           issueTypes: ['1', '2', '3', '4'],
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -322,6 +333,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -345,6 +357,7 @@ describe('CreateQueueTool', () => {
           lead: 'user1',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -366,6 +379,7 @@ describe('CreateQueueTool', () => {
           lead: 'invalid-user',
           defaultType: '1',
           defaultPriority: '2',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/get-queue-fields.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/get-queue-fields.tool.test.ts
@@ -49,7 +49,7 @@ describe('GetQueueFieldsTool', () => {
   describe('execute', () => {
     describe('валидация параметров (Zod)', () => {
       it('должен вернуть ошибку если queueId не указан', async () => {
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -61,7 +61,7 @@ describe('GetQueueFieldsTool', () => {
       });
 
       it('должен вернуть ошибку для пустого queueId', async () => {
-        const result = await tool.execute({ queueId: '' });
+        const result = await tool.execute({ queueId: '', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -76,7 +76,7 @@ describe('GetQueueFieldsTool', () => {
         const mockFields = createQueueFieldListFixture(3);
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue(mockFields);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueueFields).toHaveBeenCalledWith({
@@ -90,7 +90,7 @@ describe('GetQueueFieldsTool', () => {
         const mockFields = createQueueFieldListFixture(5);
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue(mockFields);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueueFields).toHaveBeenCalledWith({
@@ -120,7 +120,7 @@ describe('GetQueueFieldsTool', () => {
         const mockFields = createStandardSystemFields();
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue(mockFields);
 
-        const result = await tool.execute({ queueId: 'PROJ' });
+        const result = await tool.execute({ queueId: 'PROJ', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockLogger.info).toHaveBeenCalledWith('Поля очереди получены', {
@@ -151,7 +151,10 @@ describe('GetQueueFieldsTool', () => {
         ];
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue(mockFields);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({
+          queueId: 'TEST',
+          fields: ['id', 'key', 'name', 'required'],
+        });
 
         expect(result.isError).toBeUndefined();
 
@@ -172,7 +175,7 @@ describe('GetQueueFieldsTool', () => {
       it('должен обработать пустой список полей', async () => {
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue([]);
 
-        const result = await tool.execute({ queueId: 'EMPTY' });
+        const result = await tool.execute({ queueId: 'EMPTY', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockLogger.info).toHaveBeenCalledWith('Поля очереди получены', {
@@ -196,7 +199,7 @@ describe('GetQueueFieldsTool', () => {
         const mockFields = createQueueFieldListFixture(3);
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue(mockFields);
 
-        const result = await tool.execute({ queueId: 'queue123' });
+        const result = await tool.execute({ queueId: 'queue123', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueueFields).toHaveBeenCalledWith({
@@ -224,7 +227,10 @@ describe('GetQueueFieldsTool', () => {
         ];
         vi.mocked(mockTrackerFacade.getQueueFields).mockResolvedValue(mockFields);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({
+          queueId: 'TEST',
+          fields: ['id', 'key', 'name', 'type'],
+        });
 
         expect(result.isError).toBeUndefined();
 
@@ -247,7 +253,7 @@ describe('GetQueueFieldsTool', () => {
         const error = new Error('Queue not found');
         vi.mocked(mockTrackerFacade.getQueueFields).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'NOTEXIST' });
+        const result = await tool.execute({ queueId: 'NOTEXIST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -264,7 +270,7 @@ describe('GetQueueFieldsTool', () => {
         const error = new Error('Access denied');
         vi.mocked(mockTrackerFacade.getQueueFields).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'PRIVATE' });
+        const result = await tool.execute({ queueId: 'PRIVATE', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -279,7 +285,7 @@ describe('GetQueueFieldsTool', () => {
         const error = new Error('Network timeout');
         vi.mocked(mockTrackerFacade.getQueueFields).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -294,7 +300,7 @@ describe('GetQueueFieldsTool', () => {
         const error = new Error('Invalid response format');
         vi.mocked(mockTrackerFacade.getQueueFields).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/get-queue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/get-queue.tool.test.ts
@@ -46,7 +46,7 @@ describe('GetQueueTool', () => {
   describe('execute', () => {
     describe('валидация параметров (Zod)', () => {
       it('должен вернуть ошибку если queueId не указан', async () => {
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -58,7 +58,7 @@ describe('GetQueueTool', () => {
       });
 
       it('должен вернуть ошибку для пустого queueId', async () => {
-        const result = await tool.execute({ queueId: '' });
+        const result = await tool.execute({ queueId: '', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -73,7 +73,7 @@ describe('GetQueueTool', () => {
         const mockQueue = createQueueFixture({ key: 'TEST' });
         vi.mocked(mockTrackerFacade.getQueue).mockResolvedValue(mockQueue);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueue).toHaveBeenCalledWith({
@@ -88,7 +88,7 @@ describe('GetQueueTool', () => {
         const mockQueue = createQueueFixture({ key: 'TEST', name: 'Test Queue' });
         vi.mocked(mockTrackerFacade.getQueue).mockResolvedValue(mockQueue);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueue).toHaveBeenCalledWith({
@@ -122,7 +122,7 @@ describe('GetQueueTool', () => {
         const mockQueue = createQueueFixture({ id: 'queue123', key: 'PROJ' });
         vi.mocked(mockTrackerFacade.getQueue).mockResolvedValue(mockQueue);
 
-        const result = await tool.execute({ queueId: 'queue123' });
+        const result = await tool.execute({ queueId: 'queue123', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueue).toHaveBeenCalledWith({
@@ -147,7 +147,11 @@ describe('GetQueueTool', () => {
         const mockQueue = createQueueFixture({ key: 'TEST' });
         vi.mocked(mockTrackerFacade.getQueue).mockResolvedValue(mockQueue);
 
-        const result = await tool.execute({ queueId: 'TEST', expand: 'projects' });
+        const result = await tool.execute({
+          queueId: 'TEST',
+          expand: 'projects',
+          fields: ['id', 'key', 'name'],
+        });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueue).toHaveBeenCalledWith({
@@ -168,7 +172,10 @@ describe('GetQueueTool', () => {
         });
         vi.mocked(mockTrackerFacade.getQueue).mockResolvedValue(mockQueue);
 
-        const result = await tool.execute({ queueId: 'PROJ' });
+        const result = await tool.execute({
+          queueId: 'PROJ',
+          fields: ['id', 'key', 'name', 'description'],
+        });
 
         expect(result.isError).toBeUndefined();
 
@@ -193,7 +200,7 @@ describe('GetQueueTool', () => {
         const error = new Error('Queue not found');
         vi.mocked(mockTrackerFacade.getQueue).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'NOTEXIST' });
+        const result = await tool.execute({ queueId: 'NOTEXIST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -210,7 +217,7 @@ describe('GetQueueTool', () => {
         const error = new Error('Access denied');
         vi.mocked(mockTrackerFacade.getQueue).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'PRIVATE' });
+        const result = await tool.execute({ queueId: 'PRIVATE', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -227,7 +234,7 @@ describe('GetQueueTool', () => {
         const error = new Error('Network timeout');
         vi.mocked(mockTrackerFacade.getQueue).mockRejectedValue(error);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/get-queues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/get-queues.tool.test.ts
@@ -49,7 +49,7 @@ describe('GetQueuesTool', () => {
         const mockQueues = createQueueListFixture(3);
         vi.mocked(mockTrackerFacade.getQueues).mockResolvedValue(mockQueues);
 
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueues).toHaveBeenCalledWith({
@@ -60,7 +60,7 @@ describe('GetQueuesTool', () => {
       });
 
       it('должен вернуть ошибку для некорректного perPage (отрицательное)', async () => {
-        const result = await tool.execute({ perPage: -1 });
+        const result = await tool.execute({ perPage: -1, fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -72,7 +72,7 @@ describe('GetQueuesTool', () => {
       });
 
       it('должен вернуть ошибку для некорректного perPage (больше 100)', async () => {
-        const result = await tool.execute({ perPage: 101 });
+        const result = await tool.execute({ perPage: 101, fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -84,7 +84,7 @@ describe('GetQueuesTool', () => {
       });
 
       it('должен вернуть ошибку для некорректного page (отрицательное)', async () => {
-        const result = await tool.execute({ page: 0 });
+        const result = await tool.execute({ page: 0, fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -99,7 +99,7 @@ describe('GetQueuesTool', () => {
         const mockQueues = createQueueListFixture(10);
         vi.mocked(mockTrackerFacade.getQueues).mockResolvedValue(mockQueues);
 
-        const result = await tool.execute({ perPage: 10, page: 2 });
+        const result = await tool.execute({ perPage: 10, page: 2, fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueues).toHaveBeenCalledWith({
@@ -115,7 +115,7 @@ describe('GetQueuesTool', () => {
         const mockQueues = createQueueListFixture(3);
         vi.mocked(mockTrackerFacade.getQueues).mockResolvedValue(mockQueues);
 
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueues).toHaveBeenCalledWith({
@@ -153,7 +153,7 @@ describe('GetQueuesTool', () => {
         const mockQueues = createQueueListFixture(2);
         vi.mocked(mockTrackerFacade.getQueues).mockResolvedValue(mockQueues);
 
-        const result = await tool.execute({ expand: 'projects' });
+        const result = await tool.execute({ expand: 'projects', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueues).toHaveBeenCalledWith({
@@ -172,7 +172,7 @@ describe('GetQueuesTool', () => {
         const mockQueues = createQueueListFixture(5);
         vi.mocked(mockTrackerFacade.getQueues).mockResolvedValue(mockQueues);
 
-        const result = await tool.execute({ perPage: 5, page: 3 });
+        const result = await tool.execute({ perPage: 5, page: 3, fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.getQueues).toHaveBeenCalledWith({
@@ -195,7 +195,7 @@ describe('GetQueuesTool', () => {
       it('должен обработать пустой результат', async () => {
         vi.mocked(mockTrackerFacade.getQueues).mockResolvedValue([]);
 
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockLogger.info).toHaveBeenCalledWith('Список очередей получен', {
@@ -221,7 +221,7 @@ describe('GetQueuesTool', () => {
         const error = new Error('API Error');
         vi.mocked(mockTrackerFacade.getQueues).mockRejectedValue(error);
 
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -238,7 +238,7 @@ describe('GetQueuesTool', () => {
         const error = new Error('Network timeout');
         vi.mocked(mockTrackerFacade.getQueues).mockRejectedValue(error);
 
-        const result = await tool.execute({ perPage: 10, page: 1 });
+        const result = await tool.execute({ perPage: 10, page: 1, fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/manage-queue-access.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/manage-queue-access.tool.test.ts
@@ -51,7 +51,7 @@ describe('ManageQueueAccessTool', () => {
   describe('execute', () => {
     describe('валидация параметров (Zod)', () => {
       it('должен вернуть ошибку если обязательные поля не указаны', async () => {
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -68,6 +68,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -85,6 +86,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'invalid-role',
           subjects: ['user1'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -108,6 +110,7 @@ describe('ManageQueueAccessTool', () => {
             role,
             subjects: ['user1'],
             action: 'add',
+            fields: ['id', 'key', 'name'],
           });
 
           expect(result.isError).toBeUndefined();
@@ -120,6 +123,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: [],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -137,6 +141,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'invalid-action',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -159,6 +164,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -207,6 +213,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'remove',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -235,6 +242,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'follower',
           subjects: ['user1', 'user2', 'user3'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -271,6 +279,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'queue-lead',
           subjects: ['admin'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -293,6 +302,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'access',
           subjects: ['user1', 'user2'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -315,6 +325,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1', 'user2'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -339,6 +350,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -361,6 +373,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -381,6 +394,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['invalid-user'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -401,6 +415,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'team-member',
           subjects: ['user1'],
           action: 'add',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -421,6 +436,7 @@ describe('ManageQueueAccessTool', () => {
           role: 'queue-lead',
           subjects: ['last-lead'],
           action: 'remove',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/update-queue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/update-queue.tool.test.ts
@@ -51,7 +51,7 @@ describe('UpdateQueueTool', () => {
   describe('execute', () => {
     describe('валидация параметров (Zod)', () => {
       it('должен вернуть ошибку если queueId не указан', async () => {
-        const result = await tool.execute({});
+        const result = await tool.execute({ fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -63,7 +63,7 @@ describe('UpdateQueueTool', () => {
       });
 
       it('должен вернуть ошибку для пустого queueId', async () => {
-        const result = await tool.execute({ queueId: '' });
+        const result = await tool.execute({ queueId: '', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBe(true);
         const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -78,7 +78,7 @@ describe('UpdateQueueTool', () => {
         const mockQueue = createQueueFixture({ key: 'TEST' });
         vi.mocked(mockTrackerFacade.updateQueue).mockResolvedValue(mockQueue);
 
-        const result = await tool.execute({ queueId: 'TEST' });
+        const result = await tool.execute({ queueId: 'TEST', fields: ['id', 'key', 'name'] });
 
         expect(result.isError).toBeUndefined();
         expect(mockTrackerFacade.updateQueue).toHaveBeenCalledWith({
@@ -96,6 +96,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'Updated Queue',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -138,6 +139,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           description: 'New description',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -156,6 +158,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           lead: 'newuser',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -175,6 +178,7 @@ describe('UpdateQueueTool', () => {
           queueId: 'TEST',
           defaultType: '2',
           defaultPriority: '3',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -198,6 +202,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           issueTypes: ['1', '2', '3'],
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -223,6 +228,7 @@ describe('UpdateQueueTool', () => {
           description: 'Updated description',
           lead: 'admin',
           defaultType: '3',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -253,6 +259,7 @@ describe('UpdateQueueTool', () => {
           defaultType: '2',
           defaultPriority: '3',
           issueTypes: ['1', '2', '3', '4'],
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBeUndefined();
@@ -278,6 +285,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'NOTEXIST',
           name: 'New Name',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -298,6 +306,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           name: 'New Name',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -316,6 +325,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           lead: 'invalid-user',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);
@@ -334,6 +344,7 @@ describe('UpdateQueueTool', () => {
         const result = await tool.execute({
           queueId: 'TEST',
           description: 'New description',
+          fields: ['id', 'key', 'name'],
         });
 
         expect(result.isError).toBe(true);


### PR DESCRIPTION
Детали:
- Добавлен обязательный параметр fields в схемы всех 6 инструментов Queues API
- Реализована фильтрация ответов через ResponseFieldFilter в tool файлах
- Обновлены 82 вызова tool.execute() в 6 тестовых файлах
- Все 86 тестов успешно проходят

🤖 Generated with Claude Code