### PR TITLE
Add field parameter to agent instructions

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/create/create-issue.definition.ts
@@ -148,7 +148,7 @@ export class CreateIssueDefinition extends BaseToolDefinition {
    */
   private buildFieldsParam(): Record<string, unknown> {
     return this.buildArrayParam(
-      'Фильтр полей ответа (опционально, по умолчанию все). ' +
+      'Фильтр полей ответа (опционально, по умолчанию все). Указывайте только нужные поля для экономии токенов. ' +
         'Основные: key, summary, description, status, assignee, createdAt.',
       this.buildStringParam('Имя поля', {
         minLength: 1,

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
@@ -203,7 +203,7 @@ export class FindIssuesDefinition extends BaseToolDefinition {
    */
   private buildFieldsParam(): Record<string, unknown> {
     return this.buildArrayParam(
-      'Фильтр полей ответа (опционально, по умолчанию все). ' +
+      'Фильтр полей ответа (опционально, по умолчанию все). Указывайте только нужные поля для экономии токенов. ' +
         'Основные: key, summary, description, status, priority, assignee, author, createdAt, updatedAt. ' +
         'Вложенные (dot-notation): assignee.login, status.key, queue.key.',
       this.buildStringParam('Имя поля', {

--- a/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/update/update-issue.definition.ts
@@ -172,7 +172,7 @@ export class UpdateIssueDefinition extends BaseToolDefinition {
    */
   private buildFieldsParam(): Record<string, unknown> {
     return this.buildArrayParam(
-      'Фильтр полей ответа (опционально, по умолчанию все). ' +
+      'Фильтр полей ответа (опционально, по умолчанию все). Указывайте только нужные поля для экономии токенов. ' +
         'Основные: key, summary, description, status, assignee, priority, type, updatedAt. ' +
         'Вложенные (dot-notation): assignee.login, status.key.',
       this.buildStringParam('Имя поля', {

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/add/add-worklog.definition.ts
@@ -80,7 +80,7 @@ export class AddWorklogDefinition extends BaseToolDefinition {
   private buildFieldsParam(): Record<string, unknown> {
     return this.buildArrayParam(
       '⚠️ ОБЯЗАТЕЛЬНЫЙ. Список полей, которые нужно вернуть в ответе. ' +
-        'Сокращает объем ответа, возвращая только нужные поля.',
+        'Указывайте только нужные поля для экономии токенов.',
       {
         items: { type: 'string' },
         examples: [

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/update/update-worklog.definition.ts
@@ -84,7 +84,7 @@ export class UpdateWorklogDefinition extends BaseToolDefinition {
   private buildFieldsParam(): Record<string, unknown> {
     return this.buildArrayParam(
       '⚠️ ОБЯЗАТЕЛЬНЫЙ. Список полей, которые нужно вернуть в ответе. ' +
-        'Сокращает объем ответа, возвращая только нужные поля.',
+        'Указывайте только нужные поля для экономии токенов.',
       {
         items: { type: 'string' },
         examples: [


### PR DESCRIPTION
Детали:
- Добавлена короткая инструкция "Указывайте только нужные поля для экономии токенов" в 5 tools
- find-issues: критично, может возвращать много задач
- create-issue, update-issue: для единообразия с другими tools
- worklog/add, worklog/update: унифицировано описание с "Указывайте..." вместо "Сокращает..."
- Остальные 22 tools уже имеют подобные инструкции

Преимущества:
- Агенты будут явно понимать необходимость экономии контекста
- Единообразие формулировок во всех tools с параметром fields
- Особенно важно для find-issues, который может возвращать большие объемы данных

🤖 Generated with Claude Code