### PR TITLE
Fix npm validate command missing dependency

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     { "path": "./packages/framework/infrastructure" },
     { "path": "./packages/framework/core" },
     { "path": "./packages/framework/search" },
-    { "path": "./packages/servers/yandex-tracker" },
-    { "path": "./src/cli" }
+    { "path": "./packages/servers/yandex-tracker" }
   ]
 }


### PR DESCRIPTION
Детали:
- Удалена ссылка на несуществующую директорию ./src/cli из references
- CLI теперь находится в packages/servers/yandex-tracker/src/cli
- Исправлено предупреждение vite-tsconfig-paths при запуске тестов
- npm run validate:quiet теперь проходит без ошибок

🤖 Generated with Claude Code