### PR TITLE
test: обновить тесты для проверки fields в required

### DIFF
--- a/packages/servers/yandex-tracker/tests/tools/api/issues/find/find-issues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/find/find-issues.tool.test.ts
@@ -81,6 +81,22 @@ describe('FindIssuesTool', () => {
     tool = new FindIssuesTool(mockTrackerFacade, mockLogger);
   });
 
+  describe('getDefinition', () => {
+    it('должен вернуть корректное определение инструмента', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe(buildToolName('find_issues', MCP_TOOL_PREFIX));
+      expect(definition.description).toContain('Поиск задач');
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toEqual(['fields']);
+      expect(definition.inputSchema.properties?.['query']).toBeDefined();
+      expect(definition.inputSchema.properties?.['filter']).toBeDefined();
+      expect(definition.inputSchema.properties?.['keys']).toBeDefined();
+      expect(definition.inputSchema.properties?.['queue']).toBeDefined();
+      expect(definition.inputSchema.properties?.['fields']).toBeDefined();
+    });
+  });
+
   describe('Validation', () => {
     it('должен отклонить запрос без параметров поиска', async () => {
       const result = await tool.execute({});

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/get-queue.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/get-queue.tool.test.ts
@@ -37,9 +37,10 @@ describe('GetQueueTool', () => {
       expect(definition.name).toBe(buildToolName('get_queue', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('детальную информацию об одной очереди');
       expect(definition.inputSchema.type).toBe('object');
-      expect(definition.inputSchema.required).toContain('queueId');
+      expect(definition.inputSchema.required).toEqual(['queueId', 'fields']);
       expect(definition.inputSchema.properties?.['queueId']).toBeDefined();
       expect(definition.inputSchema.properties?.['expand']).toBeDefined();
+      expect(definition.inputSchema.properties?.['fields']).toBeDefined();
     });
   });
 

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/get-queues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/get-queues.tool.test.ts
@@ -37,9 +37,11 @@ describe('GetQueuesTool', () => {
       expect(definition.name).toBe(buildToolName('get_queues', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('список всех очередей');
       expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toEqual(['fields']);
       expect(definition.inputSchema.properties?.['perPage']).toBeDefined();
       expect(definition.inputSchema.properties?.['page']).toBeDefined();
       expect(definition.inputSchema.properties?.['expand']).toBeDefined();
+      expect(definition.inputSchema.properties?.['fields']).toBeDefined();
     });
   });
 


### PR DESCRIPTION
Детали:
- get-queue.tool.test.ts: обновлена проверка required на ['queueId', 'fields']
- get-queues.tool.test.ts: добавлена проверка required на ['fields']
- find-issues.tool.test.ts: добавлен тест getDefinition с проверкой required

Все тесты теперь проверяют наличие обязательного параметра fields в inputSchema.required для соответствующих GET инструментов.

🤖 Generated with Claude Code