### PR TITLE
Make perPage parameter required in find_issues

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.definition.ts
@@ -30,14 +30,14 @@ export class GetCommentsDefinition extends BaseToolDefinition {
           expand: this.buildExpandParam(),
           fields: this.buildFieldsParam(),
         },
-        required: ['issueId', 'fields'],
+        required: ['issueId', 'fields', 'perPage'],
       },
     };
   }
 
   private buildDescription(): string {
     return (
-      'Получает комментарии задачи (issueId*, fields*). Поддерживает пагинацию. ' +
+      'Получает комментарии задачи (issueId*, fields*, perPage*). Поддерживает пагинацию. ' +
       'Параметр fields определяет, какие поля каждого комментария вернуть в ответе (например: ["id", "text", "createdAt"]). ' +
       'Для добавления: add_comment, редактирования: edit_comment, удаления: delete_comment.'
     );
@@ -51,11 +51,11 @@ export class GetCommentsDefinition extends BaseToolDefinition {
 
   private buildPerPageParam(): Record<string, unknown> {
     return this.buildNumberParam(
-      'Опциональное количество комментариев на странице (по умолчанию: 50, максимум: 500).',
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Количество комментариев на странице. Запрашивайте минимально необходимое количество для экономии токенов (максимум 500).',
       {
         minimum: 1,
         maximum: 500,
-        examples: [50, 100],
+        examples: [10, 20],
       }
     );
   }

--- a/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/find/find-issues.definition.ts
@@ -41,8 +41,8 @@ export class FindIssuesDefinition extends BaseToolDefinition {
           expand: this.buildExpandParam(),
           fields: this.buildFieldsParam(),
         },
-        // fields обязателен; хотя бы один параметр поиска должен быть указан (валидация в schema)
-        required: ['fields'],
+        // fields и perPage обязательны; хотя бы один параметр поиска должен быть указан (валидация в schema)
+        required: ['fields', 'perPage'],
       },
     };
   }
@@ -53,7 +53,7 @@ export class FindIssuesDefinition extends BaseToolDefinition {
   private buildDescription(): string {
     return (
       'Ищет задачи по query (язык запросов Трекера), filter (key-value), keys, queue или filterId. ' +
-      'Параметр fields* обязателен для экономии токенов. Поддержка пагинации (perPage, page). ' +
+      'Параметры fields* и perPage* обязательны для экономии токенов. Поддержка пагинации (perPage, page). ' +
       'Для получения конкретных задач: get_issues (эффективнее).'
     );
   }
@@ -161,9 +161,9 @@ export class FindIssuesDefinition extends BaseToolDefinition {
     return {
       type: 'number',
       description:
-        'Количество результатов на странице (по умолчанию 50, рекомендуется 10-50). Используй fields для экономии токенов.',
+        '⚠️ ОБЯЗАТЕЛЬНЫЙ. Количество результатов на странице. Запрашивайте минимально необходимое количество для экономии токенов.',
       minimum: 1,
-      examples: [50],
+      examples: [10, 20],
     };
   }
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.definition.ts
@@ -27,25 +27,28 @@ export class GetProjectsDefinition extends BaseToolDefinition {
           queueId: this.buildQueueIdParam(),
           fields: this.buildFieldsParam(),
         },
-        required: ['fields'],
+        required: ['fields', 'perPage'],
       },
     };
   }
 
   private buildDescription(): string {
     return (
-      'Получает список проектов (fields*, perPage, page, expand, queueId). ' +
+      'Получает список проектов (fields*, perPage*, page, expand, queueId). ' +
       'Возвращает массив проектов. Поддержка пагинации и фильтрации. ' +
       'Для одного проекта: get_project, создания: create_project.'
     );
   }
 
   private buildPerPageParam(): Record<string, unknown> {
-    return this.buildNumberParam('Количество записей на странице (1-100, по умолчанию 50).', {
-      minimum: 1,
-      maximum: 100,
-      examples: [50],
-    });
+    return this.buildNumberParam(
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Количество проектов на странице. Запрашивайте минимально необходимое количество для экономии токенов (максимум 100).',
+      {
+        minimum: 1,
+        maximum: 100,
+        examples: [10, 20],
+      }
+    );
   }
 
   private buildPageParam(): Record<string, unknown> {

--- a/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.definition.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/queues/get-queues.definition.ts
@@ -29,7 +29,7 @@ export class GetQueuesDefinition extends BaseToolDefinition {
           expand: this.buildExpandParam(),
           fields: this.buildFieldsParam(),
         },
-        required: ['fields'],
+        required: ['fields', 'perPage'],
       },
     };
   }
@@ -37,18 +37,18 @@ export class GetQueuesDefinition extends BaseToolDefinition {
   private buildDescription(): string {
     return (
       'Получает список очередей с пагинацией. ' +
-      'Параметр fields обязателен для экономии токенов. ' +
+      'Параметры fields* и perPage* обязательны для экономии токенов. ' +
       'Для одной очереди: get_queue, создания: create_queue.'
     );
   }
 
   private buildPerPageParam(): Record<string, unknown> {
     return this.buildNumberParam(
-      'Количество очередей на странице (опционально, по умолчанию 50, максимум 100).',
+      '⚠️ ОБЯЗАТЕЛЬНЫЙ. Количество очередей на странице. Запрашивайте минимально необходимое количество для экономии токенов (максимум 100).',
       {
         minimum: 1,
         maximum: 100,
-        examples: [50],
+        examples: [10, 20],
       }
     );
   }

--- a/packages/servers/yandex-tracker/tests/tools/api/comments/get/get-comments.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/comments/get/get-comments.tool.test.ts
@@ -55,7 +55,7 @@ describe('GetCommentsTool', () => {
       const definition = tool.getDefinition();
 
       expect(definition.inputSchema.type).toBe('object');
-      expect(definition.inputSchema.required).toEqual(['issueId', 'fields']);
+      expect(definition.inputSchema.required).toEqual(['issueId', 'fields', 'perPage']);
       expect(definition.inputSchema.properties?.['issueId']).toBeDefined();
       expect(definition.inputSchema.properties?.['perPage']).toBeDefined();
       expect(definition.inputSchema.properties?.['page']).toBeDefined();

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/find/find-issues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/find/find-issues.tool.test.ts
@@ -88,7 +88,7 @@ describe('FindIssuesTool', () => {
       expect(definition.name).toBe(buildToolName('find_issues', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('Ищет задачи');
       expect(definition.inputSchema.type).toBe('object');
-      expect(definition.inputSchema.required).toEqual(['fields']);
+      expect(definition.inputSchema.required).toEqual(['fields', 'perPage']);
       expect(definition.inputSchema.properties?.['query']).toBeDefined();
       expect(definition.inputSchema.properties?.['filter']).toBeDefined();
       expect(definition.inputSchema.properties?.['keys']).toBeDefined();

--- a/packages/servers/yandex-tracker/tests/tools/api/queues/get-queues.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/queues/get-queues.tool.test.ts
@@ -37,7 +37,7 @@ describe('GetQueuesTool', () => {
       expect(definition.name).toBe(buildToolName('get_queues', MCP_TOOL_PREFIX));
       expect(definition.description).toContain('Получает список очередей');
       expect(definition.inputSchema.type).toBe('object');
-      expect(definition.inputSchema.required).toEqual(['fields']);
+      expect(definition.inputSchema.required).toEqual(['fields', 'perPage']);
       expect(definition.inputSchema.properties?.['perPage']).toBeDefined();
       expect(definition.inputSchema.properties?.['page']).toBeDefined();
       expect(definition.inputSchema.properties?.['expand']).toBeDefined();


### PR DESCRIPTION
…ацией

Детали:
- Обновлены инструменты find_issues, get_queues, get_projects, get_comments
- perPage теперь обязательный параметр с предупреждением ⚠️
- Описание параметра изменено на "Запрашивайте минимально необходимое количество для экономии токенов"
- Изменены примеры с [50] на [10, 20] для поощрения меньших запросов
- Обновлены соответствующие unit-тесты
- Проверка: get_issue_changelog не имеет параметра perPage (нет пагинации в API)

Преимущества:
- Принудительное ограничение размера ответа для экономии токенов
- Явное указание количества запрашиваемых элементов
- Предотвращение случайных запросов с дефолтными 50 элементами

🤖 Generated with Claude Code