### PR TITLE
Complete stage 2.3 of tool migration plan

### DIFF
--- a/.agentic-planning/plan_full_tool_migration/README.md
+++ b/.agentic-planning/plan_full_tool_migration/README.md
@@ -214,12 +214,12 @@ npm test -- my-tool.smoke.test.ts
 | 1.5 Helpers | ✅ Завершён | 100% | 3 tools |
 | 2.1 Issues | ⏳ Ожидает | 0% | 9 tools (parallel) |
 | 2.2 Queues | ⏳ Ожидает | 0% | 6 tools (parallel) |
-| 2.3 Projects | ⏳ Ожидает | 0% | 5 tools (parallel) |
+| 2.3 Projects | ✅ Завершён | 100% | 5 tools (parallel) |
 | 3.1 Bulk-change | ⏳ Ожидает | 0% | 4 tools |
 | 4.1 Cleanup | ⏳ Ожидает | 0% | Удаление .definition.ts |
 | 4.2 Validation | ⏳ Ожидает | 0% | Финальная проверка |
 
-**Итого:** 19/47 инструментов мигрировано (40.4%)
+**Итого:** 24/47 инструментов мигрировано (51.1%)
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tools/api/projects/create-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/create-project.tool.ts
@@ -18,10 +18,21 @@ import { CREATE_PROJECT_TOOL_METADATA } from './create-project.metadata.js';
 export class CreateProjectTool extends BaseTool<YandexTrackerFacade> {
   static override readonly METADATA = CREATE_PROJECT_TOOL_METADATA;
 
-  private readonly definition = new CreateProjectDefinition();
+  /**
+   * Автоматическая генерация definition из Zod schema
+   * Это исключает возможность несоответствия schema ↔ definition
+   */
+  protected override getParamsSchema(): typeof CreateProjectParamsSchema {
+    return CreateProjectParamsSchema;
+  }
 
+  /**
+   * @deprecated Используется автогенерация через getParamsSchema()
+   */
   protected buildDefinition(): ToolDefinition {
-    return this.definition.build();
+    // Fallback для обратной совместимости (не используется если getParamsSchema() определен)
+    const definition = new CreateProjectDefinition();
+    return definition.build();
   }
 
   async execute(params: ToolCallParams): Promise<ToolResult> {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/delete-project.tool.ts
@@ -16,10 +16,21 @@ import { DELETE_PROJECT_TOOL_METADATA } from './delete-project.metadata.js';
 export class DeleteProjectTool extends BaseTool<YandexTrackerFacade> {
   static override readonly METADATA = DELETE_PROJECT_TOOL_METADATA;
 
-  private readonly definition = new DeleteProjectDefinition();
+  /**
+   * Автоматическая генерация definition из Zod schema
+   * Это исключает возможность несоответствия schema ↔ definition
+   */
+  protected override getParamsSchema(): typeof DeleteProjectParamsSchema {
+    return DeleteProjectParamsSchema;
+  }
 
+  /**
+   * @deprecated Используется автогенерация через getParamsSchema()
+   */
   protected buildDefinition(): ToolDefinition {
-    return this.definition.build();
+    // Fallback для обратной совместимости (не используется если getParamsSchema() определен)
+    const definition = new DeleteProjectDefinition();
+    return definition.build();
   }
 
   async execute(params: ToolCallParams): Promise<ToolResult> {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-project.tool.ts
@@ -15,10 +15,21 @@ import { GET_PROJECT_TOOL_METADATA } from './get-project.metadata.js';
 export class GetProjectTool extends BaseTool<YandexTrackerFacade> {
   static override readonly METADATA = GET_PROJECT_TOOL_METADATA;
 
-  private readonly definition = new GetProjectDefinition();
+  /**
+   * Автоматическая генерация definition из Zod schema
+   * Это исключает возможность несоответствия schema ↔ definition
+   */
+  protected override getParamsSchema(): typeof GetProjectParamsSchema {
+    return GetProjectParamsSchema;
+  }
 
+  /**
+   * @deprecated Используется автогенерация через getParamsSchema()
+   */
   protected buildDefinition(): ToolDefinition {
-    return this.definition.build();
+    // Fallback для обратной совместимости (не используется если getParamsSchema() определен)
+    const definition = new GetProjectDefinition();
+    return definition.build();
   }
 
   async execute(params: ToolCallParams): Promise<ToolResult> {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/get-projects.tool.ts
@@ -15,10 +15,21 @@ import { GET_PROJECTS_TOOL_METADATA } from './get-projects.metadata.js';
 export class GetProjectsTool extends BaseTool<YandexTrackerFacade> {
   static override readonly METADATA = GET_PROJECTS_TOOL_METADATA;
 
-  private readonly definition = new GetProjectsDefinition();
+  /**
+   * Автоматическая генерация definition из Zod schema
+   * Это исключает возможность несоответствия schema ↔ definition
+   */
+  protected override getParamsSchema(): typeof GetProjectsParamsSchema {
+    return GetProjectsParamsSchema;
+  }
 
+  /**
+   * @deprecated Используется автогенерация через getParamsSchema()
+   */
   protected buildDefinition(): ToolDefinition {
-    return this.definition.build();
+    // Fallback для обратной совместимости (не используется если getParamsSchema() определен)
+    const definition = new GetProjectsDefinition();
+    return definition.build();
   }
 
   async execute(params: ToolCallParams): Promise<ToolResult> {

--- a/packages/servers/yandex-tracker/src/tools/api/projects/update-project.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/projects/update-project.tool.ts
@@ -18,10 +18,21 @@ import { UPDATE_PROJECT_TOOL_METADATA } from './update-project.metadata.js';
 export class UpdateProjectTool extends BaseTool<YandexTrackerFacade> {
   static override readonly METADATA = UPDATE_PROJECT_TOOL_METADATA;
 
-  private readonly definition = new UpdateProjectDefinition();
+  /**
+   * Автоматическая генерация definition из Zod schema
+   * Это исключает возможность несоответствия schema ↔ definition
+   */
+  protected override getParamsSchema(): typeof UpdateProjectParamsSchema {
+    return UpdateProjectParamsSchema;
+  }
 
+  /**
+   * @deprecated Используется автогенерация через getParamsSchema()
+   */
   protected buildDefinition(): ToolDefinition {
-    return this.definition.build();
+    // Fallback для обратной совместимости (не используется если getParamsSchema() определен)
+    const definition = new UpdateProjectDefinition();
+    return definition.build();
   }
 
   async execute(params: ToolCallParams): Promise<ToolResult> {

--- a/packages/servers/yandex-tracker/tests/tools/api/projects/create-project.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/projects/create-project.tool.test.ts
@@ -35,7 +35,7 @@ describe('CreateProjectTool', () => {
       const definition = tool.getDefinition();
 
       expect(definition.name).toBe(buildToolName('create_project', MCP_TOOL_PREFIX));
-      expect(definition.description).toContain('Создаёт проект');
+      expect(definition.description).toContain('[Projects/Write] Создать новый проект');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toEqual(['key', 'name', 'lead', 'fields']);
       expect(definition.inputSchema.properties?.['key']).toBeDefined();

--- a/packages/servers/yandex-tracker/tests/tools/api/projects/delete-project.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/projects/delete-project.tool.test.ts
@@ -34,7 +34,7 @@ describe('DeleteProjectTool', () => {
       const definition = tool.getDefinition();
 
       expect(definition.name).toBe(buildToolName('delete_project', MCP_TOOL_PREFIX));
-      expect(definition.description).toContain('Удаляет проект');
+      expect(definition.description).toContain('[Projects/Delete] Удалить проект');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toContain('projectId');
       expect(definition.inputSchema.properties?.['projectId']).toBeDefined();

--- a/packages/servers/yandex-tracker/tests/tools/api/projects/get-project.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/projects/get-project.tool.test.ts
@@ -35,7 +35,7 @@ describe('GetProjectTool', () => {
       const definition = tool.getDefinition();
 
       expect(definition.name).toBe(buildToolName('get_project', MCP_TOOL_PREFIX));
-      expect(definition.description).toContain('Получает детали');
+      expect(definition.description).toContain('[Projects/Read] Получить параметры проекта');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toContain('projectId');
       expect(definition.inputSchema.properties?.['projectId']).toBeDefined();

--- a/packages/servers/yandex-tracker/tests/tools/api/projects/get-projects.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/projects/get-projects.tool.test.ts
@@ -35,7 +35,7 @@ describe('GetProjectsTool', () => {
       const definition = tool.getDefinition();
 
       expect(definition.name).toBe(buildToolName('get_projects', MCP_TOOL_PREFIX));
-      expect(definition.description).toContain('Получает список проектов');
+      expect(definition.description).toContain('[Projects/Read] Получить список проектов');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.properties?.['perPage']).toBeDefined();
       expect(definition.inputSchema.properties?.['page']).toBeDefined();

--- a/packages/servers/yandex-tracker/tests/tools/api/projects/update-project.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/projects/update-project.tool.test.ts
@@ -35,7 +35,7 @@ describe('UpdateProjectTool', () => {
       const definition = tool.getDefinition();
 
       expect(definition.name).toBe(buildToolName('update_project', MCP_TOOL_PREFIX));
-      expect(definition.description).toContain('Обновляет проект');
+      expect(definition.description).toContain('[Projects/Write] Обновить проект');
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toContain('projectId');
       expect(definition.inputSchema.properties?.['projectId']).toBeDefined();


### PR DESCRIPTION
Мигрировано 5 инструментов Projects на автогенерацию MCP definition из Zod schema:
- create-project: добавлен getParamsSchema(), buildDefinition() помечен deprecated
- update-project: добавлен getParamsSchema(), buildDefinition() помечен deprecated
- delete-project: добавлен getParamsSchema(), buildDefinition() помечен deprecated
- get-project: добавлен getParamsSchema(), buildDefinition() помечен deprecated
- get-projects: добавлен getParamsSchema(), buildDefinition() помечен deprecated

Обновлены тесты для новых descriptions из metadata (добавлены префиксы категорий).

Прогресс миграции: 24/47 инструментов (51.1%)

🤖 Generated with Claude Code