### PR TITLE
Add detailed error info from Yandex Tracker API

### DIFF
--- a/packages/framework/infrastructure/src/http/error/api-error.class.ts
+++ b/packages/framework/infrastructure/src/http/error/api-error.class.ts
@@ -1,0 +1,139 @@
+/**
+ * Класс для ошибок API
+ *
+ * Ответственность (SRP):
+ * - Extends Error для корректной работы с instanceof
+ * - Хранит все детали ошибки API (statusCode, message, errors, retryAfter)
+ * - Правильная сериализация в JSON для передачи через MCP
+ *
+ * Решает проблему:
+ * - ApiError (plain object) не работает с instanceof Error
+ * - Plain object превращается в "[object Object]" при String()
+ * - Детали ошибки теряются при передаче через Promise.reject()
+ *
+ * Использование:
+ * - ErrorMapper возвращает ApiErrorClass вместо plain ApiError
+ * - ParallelExecutor корректно обрабатывает через instanceof
+ * - BatchResultProcessor сохраняет полную информацию
+ * - BaseTool.formatError() передает все детали в MCP client
+ */
+
+import type { HttpStatusCode } from '../../types.js';
+
+/**
+ * Расширенная информация об ошибке API
+ *
+ * Используется в toJSON() для передачи всех деталей клиенту
+ */
+export interface ApiErrorDetails {
+  /** HTTP статус-код */
+  statusCode: number;
+  /** Сообщение об ошибке */
+  message: string;
+  /** Детализированные ошибки по полям (для 400 ошибок) */
+  errors?: Record<string, string[]> | undefined;
+  /** Время ожидания перед повторной попыткой (в секундах, для 429 ошибок) */
+  retryAfter?: number | undefined;
+}
+
+/**
+ * Класс ошибки API (extends Error)
+ *
+ * Generic Error class для всех HTTP ошибок от API Яндекс.Трекера.
+ * Сохраняет statusCode, детали по полям, retryAfter для rate limiting.
+ *
+ * @example
+ * ```typescript
+ * // 404 Not Found
+ * throw new ApiErrorClass(404, "Issue not found");
+ *
+ * // 400 Bad Request с деталями по полям
+ * throw new ApiErrorClass(400, "Validation failed", {
+ *   summary: ["Required field"],
+ *   assignee: ["Invalid user ID"]
+ * });
+ *
+ * // 429 Rate Limiting
+ * throw new ApiErrorClass(429, "Rate limit exceeded", undefined, 60);
+ * ```
+ */
+export class ApiErrorClass extends Error {
+  /**
+   * HTTP статус-код ошибки
+   */
+  readonly statusCode: HttpStatusCode;
+
+  /**
+   * Детализированные ошибки по полям (для 400 ошибок)
+   *
+   * @example
+   * {
+   *   "summary": ["Required field", "Too long"],
+   *   "assignee": ["Invalid user ID"]
+   * }
+   */
+  readonly errors?: Record<string, string[]> | undefined;
+
+  /**
+   * Время ожидания перед повторной попыткой (в секундах, для 429 ошибок)
+   */
+  readonly retryAfter?: number | undefined;
+
+  constructor(
+    statusCode: HttpStatusCode,
+    message: string,
+    errors?: Record<string, string[]>,
+    retryAfter?: number
+  ) {
+    super(message);
+
+    // Устанавливаем правильное имя для Error
+    this.name = 'ApiErrorClass';
+
+    // Сохраняем все детали ошибки
+    this.statusCode = statusCode;
+    this.errors = errors;
+    this.retryAfter = retryAfter;
+
+    // Сохраняем правильный stack trace (для Node.js)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiErrorClass);
+    }
+  }
+
+  /**
+   * Сериализация в JSON для передачи через MCP
+   *
+   * Этот метод вызывается автоматически при JSON.stringify()
+   *
+   * @returns Объект с всеми деталями ошибки
+   *
+   * @example
+   * ```typescript
+   * const error = new ApiErrorClass(404, "Not found");
+   * JSON.stringify(error);
+   * // {"statusCode": 404, "message": "Not found"}
+   * ```
+   */
+  toJSON(): ApiErrorDetails {
+    // Создаем объект динамически, чтобы избежать проблем с exactOptionalPropertyTypes
+    return {
+      statusCode: this.statusCode,
+      message: this.message,
+      ...(this.errors !== undefined && { errors: this.errors }),
+      ...(this.retryAfter !== undefined && { retryAfter: this.retryAfter }),
+    };
+  }
+
+  /**
+   * Строковое представление ошибки
+   *
+   * Используется при console.log() и String()
+   *
+   * @returns Строка в формате "ApiErrorClass [statusCode]: message"
+   */
+  override toString(): string {
+    return `${this.name} [${this.statusCode}]: ${this.message}`;
+  }
+}

--- a/packages/framework/infrastructure/src/http/error/error-mapper.ts
+++ b/packages/framework/infrastructure/src/http/error/error-mapper.ts
@@ -1,27 +1,31 @@
 /**
- * Преобразователь ошибок Axios в ApiError
+ * Преобразователь ошибок Axios в ApiErrorClass
  *
  * Ответственность (SRP):
- * - ТОЛЬКО преобразование AxiosError → ApiError
+ * - ТОЛЬКО преобразование AxiosError → ApiErrorClass
  * - ТОЛЬКО извлечение информации из ответа API
  * - Специальная обработка rate limiting (429)
  *
  * НЕ отвечает за:
  * - Retry логику (делегируется RetryHandler)
  * - Логирование (делегируется вызывающему коду)
+ *
+ * ОБНОВЛЕНО:
+ * - Возвращает ApiErrorClass (extends Error) вместо plain ApiError
+ * - Решает проблему потери деталей ошибки при передаче через Promise.reject()
  */
 
 import type { AxiosError } from 'axios';
-import type { ApiError } from '../../types.js';
 import { HttpStatusCode } from '../../types.js';
+import { ApiErrorClass } from './api-error.class.js';
 
 export class ErrorMapper {
   /**
-   * Преобразует AxiosError в ApiError
+   * Преобразует AxiosError в ApiErrorClass
    * @param error - ошибка Axios
-   * @returns структурированная ошибка API
+   * @returns структурированная ошибка API (extends Error)
    */
-  static mapAxiosError(error: AxiosError): ApiError {
+  static mapAxiosError(error: AxiosError): ApiErrorClass {
     // Случай 1: Сервер вернул ответ с ошибкой
     if (error.response) {
       return this.mapResponseError(error);
@@ -29,50 +33,39 @@ export class ErrorMapper {
 
     // Случай 2: Запрос был отправлен, но нет ответа
     if (error.request) {
-      return {
-        statusCode: HttpStatusCode.NETWORK_ERROR,
-        message: 'Нет ответа от сервера. Проверьте подключение к интернету.',
-      };
+      return new ApiErrorClass(
+        HttpStatusCode.NETWORK_ERROR,
+        'Нет ответа от сервера. Проверьте подключение к интернету.'
+      );
     }
 
     // Случай 3: Ошибка при настройке запроса
-    return {
-      statusCode: HttpStatusCode.NETWORK_ERROR,
-      message: error.message || 'Неизвестная ошибка',
-    };
+    return new ApiErrorClass(HttpStatusCode.NETWORK_ERROR, error.message || 'Неизвестная ошибка');
   }
 
   /**
    * Обрабатывает ошибку с ответом от сервера
    */
-  private static mapResponseError(error: AxiosError): ApiError {
+  private static mapResponseError(error: AxiosError): ApiErrorClass {
     const data = error.response?.data as Record<string, unknown> | undefined;
 
     if (!data || !error.response) {
-      return {
-        statusCode: error.response?.status ?? 0,
-        message: error.message,
-      };
+      return new ApiErrorClass(error.response?.status ?? 0, error.message);
     }
 
     // Специальная обработка rate limiting (429 ошибка)
-
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     if (error.response.status === HttpStatusCode.TOO_MANY_REQUESTS) {
       return this.mapRateLimitError(error);
     }
 
     // Извлекаем сообщение об ошибке из различных форматов ответа
-    // Используем || для fallback chain (пропускаем пустые строки из API)
     const errorMessages = data['errorMessages'] as string[] | undefined;
-
-    const message = errorMessages?.[0] || (data['message'] as string) || error.message;
+    const dataMessage = data['message'] as string | undefined;
+    const message = (errorMessages?.[0]) ?? dataMessage ?? error.message;
     const errors = data['errors'] as Record<string, string[]> | undefined;
 
-    return {
-      statusCode: error.response.status,
-      message,
-      ...(errors && { errors }),
-    };
+    return new ApiErrorClass(error.response.status, message, errors);
   }
 
   /**
@@ -80,9 +73,9 @@ export class ErrorMapper {
    * Извлекает информацию о времени ожидания из заголовка Retry-After
    *
    * @param error - Axios ошибка с 429 статусом
-   * @returns ApiError с обязательным retryAfter
+   * @returns ApiErrorClass с обязательным retryAfter
    */
-  private static mapRateLimitError(error: AxiosError): ApiError {
+  private static mapRateLimitError(error: AxiosError): ApiErrorClass {
     const retryAfterHeader = error.response?.headers['retry-after'] as string | undefined;
     let retryAfter = 60; // Значение по умолчанию: 60 секунд
 
@@ -93,10 +86,11 @@ export class ErrorMapper {
       }
     }
 
-    return {
-      statusCode: HttpStatusCode.TOO_MANY_REQUESTS,
-      message: `Rate limit exceeded. Retry after ${retryAfter} seconds.`,
-      retryAfter,
-    };
+    return new ApiErrorClass(
+      HttpStatusCode.TOO_MANY_REQUESTS,
+      `Rate limit exceeded. Retry after ${retryAfter} seconds.`,
+      undefined,
+      retryAfter
+    );
   }
 }

--- a/packages/framework/infrastructure/src/http/error/index.ts
+++ b/packages/framework/infrastructure/src/http/error/index.ts
@@ -3,3 +3,5 @@
  */
 
 export { ErrorMapper } from './error-mapper.js';
+export { ApiErrorClass } from './api-error.class.js';
+export type { ApiErrorDetails } from './api-error.class.js';

--- a/packages/framework/infrastructure/src/http/index.ts
+++ b/packages/framework/infrastructure/src/http/index.ts
@@ -18,3 +18,5 @@ export { RetryHandler } from './retry/retry-handler.js';
 
 // Error
 export { ErrorMapper } from './error/error-mapper.js';
+export { ApiErrorClass } from './error/api-error.class.js';
+export type { ApiErrorDetails } from './error/api-error.class.js';

--- a/packages/framework/infrastructure/tests/http/error/api-error.class.test.ts
+++ b/packages/framework/infrastructure/tests/http/error/api-error.class.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Тесты для ApiErrorClass
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ApiErrorClass } from '@mcp-framework/infrastructure/http/error/api-error.class.js';
+import { HttpStatusCode } from '@mcp-framework/infrastructure/types.js';
+
+describe('ApiErrorClass', () => {
+  describe('Конструктор', () => {
+    it('должен создать экземпляр с минимальными параметрами', () => {
+      const error = new ApiErrorClass(404, 'Not Found');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiErrorClass);
+      expect(error.statusCode).toBe(404);
+      expect(error.message).toBe('Not Found');
+      expect(error.name).toBe('ApiErrorClass');
+      expect(error.errors).toBeUndefined();
+      expect(error.retryAfter).toBeUndefined();
+    });
+
+    it('должен создать экземпляр с полями errors', () => {
+      const errors = {
+        summary: ['Required field', 'Too long'],
+        assignee: ['Invalid user ID'],
+      };
+      const error = new ApiErrorClass(400, 'Validation failed', errors);
+
+      expect(error.statusCode).toBe(400);
+      expect(error.message).toBe('Validation failed');
+      expect(error.errors).toEqual(errors);
+      expect(error.retryAfter).toBeUndefined();
+    });
+
+    it('должен создать экземпляр с retryAfter (429 ошибка)', () => {
+      const error = new ApiErrorClass(
+        HttpStatusCode.TOO_MANY_REQUESTS,
+        'Rate limit exceeded',
+        undefined,
+        60
+      );
+
+      expect(error.statusCode).toBe(429);
+      expect(error.message).toBe('Rate limit exceeded');
+      expect(error.errors).toBeUndefined();
+      expect(error.retryAfter).toBe(60);
+    });
+
+    it('должен создать экземпляр со всеми параметрами', () => {
+      const errors = { field: ['Error'] };
+      const error = new ApiErrorClass(400, 'Bad Request', errors, 120);
+
+      expect(error.statusCode).toBe(400);
+      expect(error.message).toBe('Bad Request');
+      expect(error.errors).toEqual(errors);
+      expect(error.retryAfter).toBe(120);
+    });
+  });
+
+  describe('instanceof Error', () => {
+    it('должен работать с instanceof Error', () => {
+      const error = new ApiErrorClass(500, 'Internal Server Error');
+
+      expect(error instanceof Error).toBe(true);
+      expect(error instanceof ApiErrorClass).toBe(true);
+    });
+
+    it('должен работать с try-catch', () => {
+      try {
+        throw new ApiErrorClass(403, 'Forbidden');
+      } catch (error) {
+        expect(error instanceof Error).toBe(true);
+        expect(error instanceof ApiErrorClass).toBe(true);
+        expect((error as ApiErrorClass).statusCode).toBe(403);
+      }
+    });
+
+    it('должен сохранять stack trace', () => {
+      const error = new ApiErrorClass(500, 'Error');
+
+      expect(error.stack).toBeDefined();
+      expect(error.stack).toContain('ApiErrorClass');
+    });
+  });
+
+  describe('toJSON()', () => {
+    it('должен сериализовать минимальные поля', () => {
+      const error = new ApiErrorClass(404, 'Not Found');
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        statusCode: 404,
+        message: 'Not Found',
+      });
+    });
+
+    it('должен сериализовать с errors', () => {
+      const errors = {
+        summary: ['Required'],
+        assignee: ['Invalid'],
+      };
+      const error = new ApiErrorClass(400, 'Bad Request', errors);
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        statusCode: 400,
+        message: 'Bad Request',
+        errors,
+      });
+    });
+
+    it('должен сериализовать с retryAfter', () => {
+      const error = new ApiErrorClass(429, 'Rate limit', undefined, 60);
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        statusCode: 429,
+        message: 'Rate limit',
+        retryAfter: 60,
+      });
+    });
+
+    it('должен сериализовать все поля', () => {
+      const errors = { field: ['Error'] };
+      const error = new ApiErrorClass(400, 'Bad Request', errors, 30);
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        statusCode: 400,
+        message: 'Bad Request',
+        errors,
+        retryAfter: 30,
+      });
+    });
+
+    it('должен работать с JSON.stringify()', () => {
+      const error = new ApiErrorClass(404, 'Not Found');
+      const jsonString = JSON.stringify(error);
+      const parsed = JSON.parse(jsonString);
+
+      expect(parsed).toEqual({
+        statusCode: 404,
+        message: 'Not Found',
+      });
+    });
+  });
+
+  describe('toString()', () => {
+    it('должен возвращать строку с форматом "ApiErrorClass [statusCode]: message"', () => {
+      const error = new ApiErrorClass(404, 'Not Found');
+
+      expect(error.toString()).toBe('ApiErrorClass [404]: Not Found');
+    });
+
+    it('должен работать с String()', () => {
+      const error = new ApiErrorClass(500, 'Internal Server Error');
+
+      expect(String(error)).toBe('ApiErrorClass [500]: Internal Server Error');
+    });
+
+    it('должен работать для всех статус-кодов', () => {
+      const testCases = [
+        { statusCode: 400, message: 'Bad Request' },
+        { statusCode: 401, message: 'Unauthorized' },
+        { statusCode: 403, message: 'Forbidden' },
+        { statusCode: 404, message: 'Not Found' },
+        { statusCode: 429, message: 'Too Many Requests' },
+        { statusCode: 500, message: 'Internal Server Error' },
+      ];
+
+      testCases.forEach(({ statusCode, message }) => {
+        const error = new ApiErrorClass(statusCode, message);
+        expect(error.toString()).toBe(`ApiErrorClass [${statusCode}]: ${message}`);
+      });
+    });
+  });
+
+  describe('Promise rejection', () => {
+    it('должен корректно передаваться через Promise.reject()', async () => {
+      const originalError = new ApiErrorClass(404, 'Not Found', { field: ['Error'] });
+
+      try {
+        await Promise.reject(originalError);
+         
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiErrorClass);
+        expect((error as ApiErrorClass).statusCode).toBe(404);
+        expect((error as ApiErrorClass).message).toBe('Not Found');
+        expect((error as ApiErrorClass).errors).toEqual({ field: ['Error'] });
+      }
+    });
+
+    it('НЕ должен превращаться в "[object Object]" при String()', () => {
+      const error = new ApiErrorClass(404, 'Not Found');
+
+      // Это была проблема с plain object ApiError
+      expect(String(error)).not.toBe('[object Object]');
+      expect(String(error)).toBe('ApiErrorClass [404]: Not Found');
+    });
+  });
+
+  describe('Граничные случаи', () => {
+    it('должен работать с пустым сообщением', () => {
+      const error = new ApiErrorClass(400, '');
+
+      expect(error.message).toBe('');
+      expect(error.toString()).toBe('ApiErrorClass [400]: ');
+    });
+
+    it('должен работать с очень длинным сообщением', () => {
+      const longMessage = 'a'.repeat(1000);
+      const error = new ApiErrorClass(400, longMessage);
+
+      expect(error.message).toBe(longMessage);
+      expect(error.message.length).toBe(1000);
+    });
+
+    it('должен работать с пустым объектом errors', () => {
+      const error = new ApiErrorClass(400, 'Bad Request', {});
+
+      expect(error.errors).toEqual({});
+      expect(error.toJSON().errors).toEqual({});
+    });
+
+    it('должен работать с retryAfter = 0', () => {
+      const error = new ApiErrorClass(429, 'Rate limit', undefined, 0);
+
+      expect(error.retryAfter).toBe(0);
+      expect(error.toJSON().retryAfter).toBe(0);
+    });
+
+    it('должен работать с большим retryAfter', () => {
+      const error = new ApiErrorClass(429, 'Rate limit', undefined, 3600);
+
+      expect(error.retryAfter).toBe(3600);
+      expect(error.toJSON().retryAfter).toBe(3600);
+    });
+  });
+
+  describe('Сравнение с обычным Error', () => {
+    it('должен иметь все свойства Error', () => {
+      const error = new ApiErrorClass(500, 'Error');
+
+      // Проверяем, что ApiErrorClass имеет все основные свойства Error
+      expect(error.name).toBeDefined();
+      expect(error.message).toBeDefined();
+      expect(error.stack).toBeDefined();
+
+      // Проверяем типы
+      expect(typeof error.name).toBe('string');
+      expect(typeof error.message).toBe('string');
+      expect(typeof error.stack).toBe('string');
+    });
+
+    it('должен отличаться от обычного Error дополнительными полями', () => {
+      const apiError = new ApiErrorClass(404, 'Not Found');
+      const regularError = new Error('Not Found');
+
+      // ApiErrorClass имеет дополнительные поля
+      expect('statusCode' in apiError).toBe(true);
+      expect('statusCode' in regularError).toBe(false);
+    });
+  });
+});

--- a/packages/framework/infrastructure/tests/http/error/error-mapper.test.ts
+++ b/packages/framework/infrastructure/tests/http/error/error-mapper.test.ts
@@ -1,11 +1,15 @@
 /**
  * Тесты для ErrorMapper
+ *
+ * ОБНОВЛЕНО:
+ * - Проверяет, что возвращается ApiErrorClass (extends Error), а не plain object
+ * - Проверяет instanceof Error для всех результатов
+ * - Проверяет toJSON() сериализацию
  */
 
 import { describe, it, expect } from 'vitest';
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { ErrorMapper } from '@mcp-framework/infrastructure/http/error/error-mapper.js';
-import type { ApiError } from '@mcp-framework/infrastructure/types.js';
+import { ErrorMapper, ApiErrorClass } from '@mcp-framework/infrastructure';
 
 /**
  * Вспомогательная функция для создания мок AxiosError
@@ -54,8 +58,11 @@ describe('ErrorMapper', () => {
           }),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
+        // НОВОЕ: Проверяем, что результат - это ApiErrorClass (extends Error)
+        expect(result).toBeInstanceOf(Error);
+        expect(result).toBeInstanceOf(ApiErrorClass);
         expect(result.statusCode).toBe(400);
         expect(result.message).toBe('Неверный запрос');
       });
@@ -67,7 +74,7 @@ describe('ErrorMapper', () => {
           }),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(401);
         expect(result.message).toBe('Не авторизован'); // Берёт первое сообщение
@@ -79,7 +86,7 @@ describe('ErrorMapper', () => {
           response: createAxiosResponse(404, {}),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(404);
         expect(result.message).toBe('Not Found'); // Использует error.message
@@ -96,7 +103,7 @@ describe('ErrorMapper', () => {
           }),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(500);
         expect(result.message).toBe('Внутренняя ошибка сервера');
@@ -112,7 +119,7 @@ describe('ErrorMapper', () => {
           response: createAxiosResponse(503, undefined),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(503);
         expect(result.message).toBe('Generic error');
@@ -126,7 +133,7 @@ describe('ErrorMapper', () => {
           }),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(400);
         expect(result.message).toBe('Fallback message');
@@ -141,7 +148,7 @@ describe('ErrorMapper', () => {
           }),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.message).toBe('Actual message');
       });
@@ -156,7 +163,7 @@ describe('ErrorMapper', () => {
 
         const axiosError = createAxiosError({ response });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(429);
         expect(result.message).toBe('Rate limit exceeded. Retry after 60 seconds.');
@@ -173,7 +180,7 @@ describe('ErrorMapper', () => {
           }),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(429);
         expect(result.message).toBe('Rate limit exceeded. Retry after 60 seconds.');
@@ -191,7 +198,7 @@ describe('ErrorMapper', () => {
 
         const axiosError = createAxiosError({ response });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(429);
         expect(result.message).toBe('Rate limit exceeded. Retry after 60 seconds.');
@@ -208,7 +215,7 @@ describe('ErrorMapper', () => {
 
         const axiosError = createAxiosError({ response });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(429);
         expect(result.message).toBe('Rate limit exceeded. Retry after 60 seconds.');
@@ -226,7 +233,7 @@ describe('ErrorMapper', () => {
           // response: undefined - не передаем, если нет ответа
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(0);
         expect(result.message).toBe('Нет ответа от сервера. Проверьте подключение к интернету.');
@@ -240,7 +247,7 @@ describe('ErrorMapper', () => {
           // response: undefined - не передаем, если нет ответа
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(0);
         expect(result.message).toBe('Нет ответа от сервера. Проверьте подключение к интернету.');
@@ -254,7 +261,7 @@ describe('ErrorMapper', () => {
           // request: undefined, response: undefined - не передаем, если нет
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(0);
         expect(result.message).toBe('Invalid URL');
@@ -266,7 +273,7 @@ describe('ErrorMapper', () => {
           // request: undefined, response: undefined - не передаем, если нет
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(0);
         expect(result.message).toBe('Неизвестная ошибка');
@@ -280,7 +287,7 @@ describe('ErrorMapper', () => {
           response: createAxiosResponse(500, null),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(500);
         expect(result.message).toBe('Error');
@@ -292,7 +299,7 @@ describe('ErrorMapper', () => {
           response: createAxiosResponse(500, 'Plain string error'),
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         expect(result.statusCode).toBe(500);
         expect(result.message).toBe('Error');
@@ -307,11 +314,152 @@ describe('ErrorMapper', () => {
           response,
         });
 
-        const result: ApiError = ErrorMapper.mapAxiosError(axiosError);
+        const result = ErrorMapper.mapAxiosError(axiosError);
 
         // Когда status undefined, используется response?.status ?? 0
         expect(result.statusCode).toBeUndefined();
         expect(result.message).toBe('No status');
+      });
+    });
+
+    describe('НОВОЕ: Интеграция с ApiErrorClass', () => {
+      it('должен возвращать ApiErrorClass (extends Error) вместо plain object', () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(404, {
+            message: 'Not Found',
+          }),
+        });
+
+        const result = ErrorMapper.mapAxiosError(axiosError);
+
+        // КРИТИЧЕСКАЯ ПРОВЕРКА: результат должен быть instanceof Error
+        expect(result).toBeInstanceOf(Error);
+        expect(result).toBeInstanceOf(ApiErrorClass);
+        expect(result.name).toBe('ApiErrorClass');
+      });
+
+      it('НЕ должен превращаться в "[object Object]" при String()', () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(404, {
+            message: 'Not Found',
+          }),
+        });
+
+        const result = ErrorMapper.mapAxiosError(axiosError);
+
+        // Это была критическая проблема с plain object ApiError
+        expect(String(result)).not.toBe('[object Object]');
+        expect(String(result)).toBe('ApiErrorClass [404]: Not Found');
+      });
+
+      it('должен корректно передаваться через Promise.reject()', async () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(500, {
+            message: 'Internal Server Error',
+            errors: { field: ['Error message'] },
+          }),
+        });
+
+        const error = ErrorMapper.mapAxiosError(axiosError);
+
+        try {
+          await Promise.reject(error);
+           
+        } catch (caught) {
+          // КРИТИЧЕСКАЯ ПРОВЕРКА: все детали должны сохраниться
+          expect(caught).toBeInstanceOf(ApiErrorClass);
+          expect((caught as ApiErrorClass).statusCode).toBe(500);
+          expect((caught as ApiErrorClass).message).toBe('Internal Server Error');
+          expect((caught as ApiErrorClass).errors).toEqual({ field: ['Error message'] });
+        }
+      });
+
+      it('должен иметь работающий toJSON() метод', () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(400, {
+            message: 'Bad Request',
+            errors: {
+              summary: ['Required field'],
+              assignee: ['Invalid user'],
+            },
+          }),
+        });
+
+        const result = ErrorMapper.mapAxiosError(axiosError);
+        const json = result.toJSON();
+
+        expect(json).toEqual({
+          statusCode: 400,
+          message: 'Bad Request',
+          errors: {
+            summary: ['Required field'],
+            assignee: ['Invalid user'],
+          },
+        });
+      });
+
+      it('должен сериализоваться через JSON.stringify()', () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(404, {
+            message: 'Not Found',
+          }),
+        });
+
+        const result = ErrorMapper.mapAxiosError(axiosError);
+        const jsonString = JSON.stringify(result);
+        const parsed = JSON.parse(jsonString);
+
+        expect(parsed).toEqual({
+          statusCode: 404,
+          message: 'Not Found',
+        });
+      });
+
+      it('должен сохранять retryAfter для 429 ошибок', () => {
+        const response = createAxiosResponse(429, {});
+        response.headers = { 'retry-after': '120' };
+
+        const axiosError = createAxiosError({ response });
+        const result = ErrorMapper.mapAxiosError(axiosError);
+
+        expect(result).toBeInstanceOf(ApiErrorClass);
+        expect(result.statusCode).toBe(429);
+        expect(result.retryAfter).toBe(120);
+
+        const json = result.toJSON();
+        expect(json.retryAfter).toBe(120);
+      });
+
+      it('должен работать с try-catch блоками', () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(403, {
+            message: 'Forbidden',
+          }),
+        });
+
+        const error = ErrorMapper.mapAxiosError(axiosError);
+
+        try {
+          throw error;
+        } catch (caught) {
+          expect(caught instanceof Error).toBe(true);
+          expect(caught instanceof ApiErrorClass).toBe(true);
+          expect((caught as ApiErrorClass).statusCode).toBe(403);
+          expect((caught as ApiErrorClass).message).toBe('Forbidden');
+        }
+      });
+
+      it('должен сохранять stack trace', () => {
+        const axiosError = createAxiosError({
+          response: createAxiosResponse(500, {
+            message: 'Error',
+          }),
+        });
+
+        const result = ErrorMapper.mapAxiosError(axiosError);
+
+        expect(result.stack).toBeDefined();
+        expect(result.stack).toContain('ApiErrorClass');
       });
     });
   });


### PR DESCRIPTION
…CP responses

ПРОБЛЕМА:
Детали ошибок от Яндекс.Трекер API терялись при передаче через MCP клиенту. ApiError (plain object) превращался в "[object Object]" при Promise.reject(), так как не был instanceof Error.

Клиент получал:
- error: "[object Object]" ❌
- Без statusCode, errors, retryAfter

РЕШЕНИЕ:
Создан ApiErrorClass extends Error для сохранения всех деталей ошибки.

ИЗМЕНЕНИЯ:

1. Infrastructure (@mcp-framework/infrastructure):
   - Создан ApiErrorClass extends Error с полями: * statusCode (HTTP код) * message (текст ошибки) * errors (детали по полям для 400) * retryAfter (для 429 rate limiting)
   - Добавлены методы toJSON() и toString()
   - ErrorMapper возвращает ApiErrorClass вместо plain object
   - Создан ApiErrorDetails interface для типизации

2. Core (@mcp-framework/core):
   - BatchResultProcessor сохраняет полную информацию через toJSON()
   - BaseTool.formatError() передает statusCode/errors/retryAfter в MCP
   - Изменен тип failed.error: ApiErrorDetails | string

3. Тесты:
   - Добавлены unit тесты для ApiErrorClass (24 теста)
   - Обновлены тесты ErrorMapper с проверкой instanceof Error
   - Добавлены integration тесты для полного потока ошибок

ТЕПЕРЬ КЛИЕНТ ПОЛУЧАЕТ:
{
  "success": false,
  "message": "Ошибка при получении задач",
  "error": {
    "statusCode": 404,
    "message": "Issue not found"
  }
}

Для batch операций:
{
  "errors": [
    {
      "key": "QUEUE-123",
      "error": {
        "statusCode": 404,
        "message": "Not Found",
        "errors": { "field": ["Invalid"] }
      }
    }
  ]
}

ТЕСТЫ:
- infrastructure: 244 passed ✓
- core: 173 passed ✓
- search: 135 passed ✓ Итого: 552 теста прошли успешно

🤖 Generated with Claude Code