### PR TITLE
Refactor tool registry with filter service

### DIFF
--- a/.agentic-planning/plan_architecture_execution/2.2_tool_registry_sequential.md
+++ b/.agentic-planning/plan_architecture_execution/2.2_tool_registry_sequential.md
@@ -57,12 +57,12 @@
 
 См. [CONSOLIDATED_EXECUTION_PLAN.md](../plan_architecture_analysis/CONSOLIDATED_EXECUTION_PLAN.md) секция "[F2.1]"
 
-- [ ] Создать директорию tool-registry/
-- [ ] Extract ToolFilterService (~150 строк)
-- [ ] Extract ToolSorter (~80 строк)
-- [ ] Update ToolRegistry (delegate) (~150 строк)
-- [ ] Update tests
-- [ ] Validate
+- [x] Создать директорию tool-registry/ ✅
+- [x] Extract ToolFilterService (~220 строк) ✅
+- [x] Extract ToolSorter (~90 строк) ✅
+- [x] Update ToolRegistry (delegate) (~300 строк) ✅
+- [x] Update tests ✅
+- [x] Validate ✅ (contract tests: 21/21 passed, validate:quiet: 16/16 tasks successful)
 
 ---
 

--- a/packages/framework/core/src/index.ts
+++ b/packages/framework/core/src/index.ts
@@ -9,4 +9,4 @@ export * from './definition/index.js';
 export * from './utils/index.js';
 
 // Registry
-export * from './tool-registry.js';
+export * from './tool-registry/index.js';

--- a/packages/framework/core/src/tool-registry/index.ts
+++ b/packages/framework/core/src/tool-registry/index.ts
@@ -1,0 +1,9 @@
+/**
+ * ToolRegistry - публичный API
+ */
+
+export { ToolRegistry } from './tool-registry.js';
+export { ToolFilterService } from './tool-filter.service.js';
+export { ToolSorter } from './tool-sorter.js';
+export type { ToolConstructor } from './types.js';
+export { PRIORITY_ORDER } from './types.js';

--- a/packages/framework/core/src/tool-registry/tool-filter.service.ts
+++ b/packages/framework/core/src/tool-registry/tool-filter.service.ts
@@ -1,0 +1,204 @@
+/**
+ * Сервис для фильтрации инструментов
+ *
+ * Ответственность (SRP):
+ * - Фильтрация tools по категориям и подкатегориям
+ * - Применение позитивных и негативных фильтров
+ * - Валидация запрошенных категорий
+ * - Логирование фильтрации
+ */
+
+import type { Logger, ParsedCategoryFilter } from '@mcp-framework/infrastructure';
+import type { BaseTool } from '../tools/base/index.js';
+
+/**
+ * Сервис для фильтрации tools
+ */
+export class ToolFilterService {
+  constructor(private readonly logger: Logger) {}
+
+  /**
+   * Фильтрация по категориям (позитивный фильтр)
+   *
+   * @param tools - Массив tools
+   * @param filter - Фильтр категорий
+   * @returns Отфильтрованный массив
+   */
+  filterByCategories(tools: BaseTool[], filter: ParsedCategoryFilter): BaseTool[] {
+    // Если includeAll = true, возвращаем все инструменты
+    if (filter.includeAll) {
+      return tools;
+    }
+
+    // Валидация запрошенных категорий
+    this.validateCategories(tools, filter);
+
+    // Фильтрация
+    const filtered = tools.filter((tool) => {
+      const toolClass = tool.constructor as typeof BaseTool;
+      const metadata = toolClass.METADATA;
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!metadata?.category) {
+        // Инструменты без категории всегда включены (backwards compatibility)
+        return true;
+      }
+
+      const category = metadata.category;
+      const subcategory = metadata.subcategory;
+
+      // Проверка 1: категория без подкатегории (включает все подкатегории)
+      if (filter.categories.has(category)) {
+        return true;
+      }
+
+      // Проверка 2: категория с конкретными подкатегориями
+      if (subcategory && filter.categoriesWithSubcategories.has(category)) {
+        const allowedSubcategories = filter.categoriesWithSubcategories.get(category);
+        if (allowedSubcategories) {
+          return allowedSubcategories.has(subcategory);
+        }
+      }
+
+      return false;
+    });
+
+    // Логирование фильтрации
+    this.logger.info('Tools filtered by categories', {
+      totalTools: tools.length,
+      filteredTools: filtered.length,
+      categories: Array.from(filter.categories),
+      categoriesWithSubcategories: Array.from(filter.categoriesWithSubcategories.entries()).map(
+        ([cat, subcats]) => ({ category: cat, subcategories: Array.from(subcats) })
+      ),
+    });
+
+    return filtered;
+  }
+
+  /**
+   * Применить негативный фильтр (исключение отключенных групп)
+   *
+   * @param tools - Список инструментов
+   * @param disabledFilter - Фильтр отключенных категорий/подкатегорий
+   * @returns Отфильтрованный список инструментов
+   */
+  applyDisabledFilter(tools: BaseTool[], disabledFilter: ParsedCategoryFilter): BaseTool[] {
+    const filtered = tools.filter((tool) => {
+      const toolClass = tool.constructor as typeof BaseTool;
+      const metadata = toolClass.METADATA;
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!metadata?.category) {
+        // Инструменты без категории всегда включены
+        return true;
+      }
+
+      const category = metadata.category;
+      const subcategory = metadata.subcategory;
+
+      // Проверка 1: категория полностью отключена
+      if (disabledFilter.categories.has(category)) {
+        return false;
+      }
+
+      // Проверка 2: подкатегория отключена
+      if (subcategory && disabledFilter.categoriesWithSubcategories.has(category)) {
+        const disabledSubcategories = disabledFilter.categoriesWithSubcategories.get(category);
+        if (disabledSubcategories?.has(subcategory)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    // Логирование отключенных групп
+    this.logger.info('✂️  Применён фильтр отключенных групп', {
+      disabledCategories: Array.from(disabledFilter.categories),
+      disabledCategoriesWithSubcategories: Array.from(
+        disabledFilter.categoriesWithSubcategories.entries()
+      ).map(([cat, subcats]) => ({
+        category: cat,
+        subcategories: Array.from(subcats),
+      })),
+      totalToolsAfterFilter: filtered.length,
+    });
+
+    return filtered;
+  }
+
+  /**
+   * Валидация запрошенных категорий
+   *
+   * Логирует warnings для неизвестных категорий/подкатегорий
+   *
+   * @param tools - Массив tools
+   * @param filter - Фильтр категорий
+   */
+  // eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity, max-statements
+  private validateCategories(tools: BaseTool[], filter: ParsedCategoryFilter): void {
+    // Собираем известные категории и подкатегории
+    const knownCategories = new Set<string>();
+    const knownSubcategories = new Map<string, Set<string>>();
+
+    for (const tool of tools) {
+      const toolClass = tool.constructor as typeof BaseTool;
+      const metadata = toolClass.METADATA;
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/prefer-optional-chain
+      if (metadata && metadata.category) {
+        knownCategories.add(metadata.category);
+
+        if (metadata.subcategory) {
+          let subcategories = knownSubcategories.get(metadata.category);
+          if (!subcategories) {
+            subcategories = new Set();
+            knownSubcategories.set(metadata.category, subcategories);
+          }
+          subcategories.add(metadata.subcategory);
+        }
+      }
+    }
+
+    // Валидация запрошенных категорий
+    const unknownCategories: string[] = [];
+    const unknownSubcategories: Array<{ category: string; subcategory: string }> = [];
+
+    for (const cat of filter.categories) {
+      if (!knownCategories.has(cat)) {
+        unknownCategories.push(cat);
+      }
+    }
+
+    for (const [cat, subcats] of filter.categoriesWithSubcategories.entries()) {
+      if (!knownCategories.has(cat)) {
+        unknownCategories.push(cat);
+      } else {
+        for (const subcat of subcats) {
+          if (!knownSubcategories.get(cat)?.has(subcat)) {
+            unknownSubcategories.push({ category: cat, subcategory: subcat });
+          }
+        }
+      }
+    }
+
+    // Логируем warnings для неизвестных категорий/подкатегорий
+    if (unknownCategories.length > 0) {
+      this.logger.warn('⚠️  Unknown categories in filter', {
+        unknownCategories: [...new Set(unknownCategories)],
+        knownCategories: Array.from(knownCategories),
+      });
+    }
+
+    if (unknownSubcategories.length > 0) {
+      this.logger.warn('⚠️  Unknown subcategories in filter', {
+        unknownSubcategories,
+        knownSubcategories: Array.from(knownSubcategories.entries()).map(([cat, subcats]) => ({
+          category: cat,
+          subcategories: Array.from(subcats),
+        })),
+      });
+    }
+  }
+}

--- a/packages/framework/core/src/tool-registry/tool-sorter.ts
+++ b/packages/framework/core/src/tool-registry/tool-sorter.ts
@@ -1,0 +1,88 @@
+/**
+ * Сервис для сортировки инструментов
+ *
+ * Ответственность (SRP):
+ * - Сортировка tools по приоритету
+ * - Сортировка по имени (алфавитный порядок)
+ * - Логирование распределения по приоритетам
+ */
+
+import type { Logger } from '@mcp-framework/infrastructure';
+import type { BaseTool } from '../tools/base/index.js';
+import { ToolPriority } from '../tools/base/tool-metadata.js';
+import { PRIORITY_ORDER } from './types.js';
+
+/**
+ * Сервис для сортировки tools
+ */
+export class ToolSorter {
+  constructor(private readonly logger: Logger) {}
+
+  /**
+   * Сортировка инструментов по приоритету
+   *
+   * Порядок: critical → high → normal → low → алфавит (внутри priority)
+   *
+   * @param tools - Массив инструментов
+   * @returns Отсортированный массив
+   */
+  sortByPriority(tools: BaseTool[]): BaseTool[] {
+    const sorted = tools.sort((a, b) => {
+      // Получаем priority из METADATA
+      const aClass = a.constructor as typeof BaseTool;
+      const bClass = b.constructor as typeof BaseTool;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const aPriority = aClass.METADATA?.priority ?? ToolPriority.NORMAL;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const bPriority = bClass.METADATA?.priority ?? ToolPriority.NORMAL;
+
+      const aPrio = PRIORITY_ORDER[aPriority] ?? 2; // default: normal
+      const bPrio = PRIORITY_ORDER[bPriority] ?? 2; // default: normal
+
+      // Сначала по priority
+      if (aPrio !== bPrio) {
+        return aPrio - bPrio;
+      }
+
+      // Затем по имени (алфавит)
+      return a.getDefinition().name.localeCompare(b.getDefinition().name);
+    });
+
+    // Логируем распределение по приоритетам
+    this.logPriorityDistribution(sorted);
+
+    return sorted;
+  }
+
+  /**
+   * Логирование распределения tools по приоритетам
+   *
+   * @param tools - Отсортированные tools
+   */
+  private logPriorityDistribution(tools: BaseTool[]): void {
+    const distribution = {
+      critical: this.countByPriority(tools, ToolPriority.CRITICAL),
+      high: this.countByPriority(tools, ToolPriority.HIGH),
+      normal: this.countByPriority(tools, ToolPriority.NORMAL),
+      low: this.countByPriority(tools, ToolPriority.LOW),
+    };
+
+    this.logger.debug('Tools sorted by priority', distribution);
+  }
+
+  /**
+   * Подсчет tools с конкретным приоритетом
+   *
+   * @param tools - Массив tools
+   * @param priority - Приоритет для подсчета
+   * @returns Количество tools с данным приоритетом
+   */
+  private countByPriority(tools: BaseTool[], priority: string): number {
+    return tools.filter((t) => {
+      const tClass = t.constructor as typeof BaseTool;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const toolPriority = tClass.METADATA?.priority ?? ToolPriority.NORMAL;
+      return String(toolPriority) === priority;
+    }).length;
+  }
+}

--- a/packages/framework/core/src/tool-registry/types.ts
+++ b/packages/framework/core/src/tool-registry/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Типы для ToolRegistry
+ */
+
+import type { BaseTool } from '../tools/base/index.js';
+import { ToolPriority } from '../tools/base/tool-metadata.js';
+
+/**
+ * Конструктор класса Tool для DI
+ */
+export interface ToolConstructor {
+  new (...args: any[]): BaseTool<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  name: string;
+}
+
+/**
+ * Порядок приоритетов (меньше значение = выше приоритет)
+ */
+export const PRIORITY_ORDER: Record<string, number> = {
+  [ToolPriority.CRITICAL]: 0,
+  [ToolPriority.HIGH]: 1,
+  [ToolPriority.NORMAL]: 2,
+  [ToolPriority.LOW]: 3,
+};

--- a/packages/framework/core/tests/tool-registry.contract.test.ts
+++ b/packages/framework/core/tests/tool-registry.contract.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ToolRegistry, type ToolConstructor } from '../src/tool-registry.js';
+import { ToolRegistry, type ToolConstructor } from '../src/tool-registry/index.js';
 import { BaseTool } from '../src/tools/base/base-tool.js';
 import type { Container } from 'inversify';
 import type { Logger, ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';


### PR DESCRIPTION
Детали:
- Создана директория packages/framework/core/src/tool-registry/
- ToolFilterService (~220 LOC): фильтрация tools по категориям
- ToolSorter (~90 LOC): сортировка tools по приоритету
- ToolRegistry (~300 LOC): делегирует на новые сервисы
- Использует существующий ToolPriority enum вместо дублирования
- Все contract tests (21/21) проходят
- Валидация (16/16 tasks) успешна

Benefits:
- Снижена сложность ToolRegistry (549 → 300 строк)
- Улучшена читаемость и поддерживаемость
- Сохранена вся функциональность (contract tests подтверждают)

🤖 Generated with Claude Code