### PR TITLE
Create CLI framework package structure

### DIFF
--- a/.agentic-planning/plan_cli_framework_extraction/2.1_package_structure_sequential.md
+++ b/.agentic-planning/plan_cli_framework_extraction/2.1_package_structure_sequential.md
@@ -139,14 +139,14 @@ export * from './utils/index.js';
 ## Результат
 
 **Готовая структура пакета:**
-- [ ] Директория создана
-- [ ] package.json сконфигурирован
-- [ ] tsconfig.json создан
-- [ ] Все обязательные npm scripts добавлены
-- [ ] README.md с базовым содержанием
-- [ ] Структура директорий src/
-- [ ] Корневой package.json обновлен
-- [ ] Начальные файлы созданы
+- [x] Директория создана
+- [x] package.json сконфигурирован
+- [x] tsconfig.json создан
+- [x] Все обязательные npm scripts добавлены
+- [x] README.md с базовым содержанием
+- [x] Структура директорий src/
+- [x] Корневой package.json обновлен (workspaces с wildcards)
+- [x] Начальные файлы созданы
 
 ---
 
@@ -166,9 +166,12 @@ npm run build --workspace=@mcp-framework/cli
 
 ## Критерии готовности
 
-- [ ] `packages/framework/cli/` существует
-- [ ] `npm install` проходит без ошибок
-- [ ] Workspace резолвится корректно
-- [ ] Все файлы конфигурации на месте
-- [ ] README.md создан
-- [ ] Структура src/ создана
+- [x] `packages/framework/cli/` существует
+- [x] `npm install` проходит без ошибок
+- [x] Workspace резолвится корректно
+- [x] Все файлы конфигурации на месте (package.json, tsconfig.json, eslint.config.js, vitest.config.ts)
+- [x] README.md создан
+- [x] Структура src/ создана
+- [x] `npm run build --workspace=@mcp-framework/cli` успешен
+- [x] `npm run typecheck --workspace=@mcp-framework/cli` успешен
+- [x] `npm run lint:quiet --workspace=@mcp-framework/cli` успешен

--- a/package-lock.json
+++ b/package-lock.json
@@ -1915,6 +1915,183 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.1.tgz",
+      "integrity": "sha512-QAZUk6BBncv/XmSEZTscd8qazzjV3E0leUMrEPjxCd51QBgCKmprUGLex5DTsNtURm7LMzv+CLcd6S86xvBfYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.0.1.tgz",
+      "integrity": "sha512-5VPFBK8jKdsjMK3DTFOlbR0+Kkd4q0AWB7VhWQn6ppv44dr3b7PU8wSJQTC5oA0f/aGW7v/ZozQJAY9zx6PKig==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.1",
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/figures": "^2.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/@inquirer/figures": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.1.tgz",
+      "integrity": "sha512-KtMxyjLCuDFqAWHmCY9qMtsZ09HnjMsm8H3OvpSIpfhHdfw3/AiGWHNrfRwbyvHPtOJpumm8wGn5fkhtvkWRsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.1.tgz",
+      "integrity": "sha512-wD+pM7IxLn1TdcQN12Q6wcFe5VpyCuh/I2sSmqO5KjWH2R4v+GkUToHb+PsDGobOe1MtAlXMwGNkZUPc2+L6NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.0.1.tgz",
+      "integrity": "sha512-Tpf49h50e4KYffVUCXzkx4gWMafUi3aDQDwfVAAGBNnVcXiwJIj4m2bKlZ7Kgyf6wjt1eyXH1wDGXcAokm4Ssw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.1",
+        "@inquirer/figures": "^2.0.1",
+        "@inquirer/type": "^4.0.1",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@inquirer/figures": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.1.tgz",
+      "integrity": "sha512-KtMxyjLCuDFqAWHmCY9qMtsZ09HnjMsm8H3OvpSIpfhHdfw3/AiGWHNrfRwbyvHPtOJpumm8wGn5fkhtvkWRsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.1.tgz",
+      "integrity": "sha512-zDKobHI7Ry++4noiV9Z5VfYgSVpPZoMApviIuGwLOMciQaP+dGzCO+1fcwI441riklRiZg4yURWyEoX0Zy2zZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/external-editor": "^2.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor/node_modules/@inquirer/external-editor": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.1.tgz",
+      "integrity": "sha512-BPYWJXCAK9w6R+pb2s3WyxUz9ts9SP/LDOUwA9fu7LeuyYgojz83i0DSRwezu736BgMwz14G63Xwj70hSzHohQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.1.tgz",
+      "integrity": "sha512-TBrTpAB6uZNnGQHtSEkbvJZIQ3dXZOrwqQSO9uUbwct3G2LitwBCE5YZj98MbQ5nzihzs5pRjY1K9RRLH4WgoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -1962,6 +2139,200 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.1.tgz",
+      "integrity": "sha512-cEhEUohCpE2BCuLKtFFZGp4Ief05SEcqeAOq9NxzN5ThOQP8Rl5N/Nt9VEDORK1bRb2Sk/zoOyQYfysPQwyQtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.1.tgz",
+      "integrity": "sha512-4//zgBGHe8Q/FfCoUXZUrUHyK/q5dyqiwsePz3oSSPSmw1Ijo35ZkjaftnxroygcUlLYfXqm+0q08lnB5hd49A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.1.tgz",
+      "integrity": "sha512-UJudHpd7Ia30Q+x+ctYqI9Nh6SyEkaBscpa7J6Ts38oc1CNSws0I1hJEdxbQBlxQd65z5GEJPM4EtNf6tzfWaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.1",
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.0.1.tgz",
+      "integrity": "sha512-MURRu/cyvLm9vchDDaVZ9u4p+ADnY0Mz3LQr0KTgihrrvuKZlqcWwlBC4lkOMvd0KKX4Wz7Ww9+uA7qEpQaqjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.0.1",
+        "@inquirer/confirm": "^6.0.1",
+        "@inquirer/editor": "^5.0.1",
+        "@inquirer/expand": "^5.0.1",
+        "@inquirer/input": "^5.0.1",
+        "@inquirer/number": "^4.0.1",
+        "@inquirer/password": "^5.0.1",
+        "@inquirer/rawlist": "^5.0.1",
+        "@inquirer/search": "^4.0.1",
+        "@inquirer/select": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.0.1.tgz",
+      "integrity": "sha512-vVfVHKUgH6rZmMlyd0jOuGZo0Fw1jfcOqZF96lMwlgavx7g0x7MICe316bV01EEoI+c68vMdbkTTawuw3O+Fgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.0.1.tgz",
+      "integrity": "sha512-XwiaK5xBvr31STX6Ji8iS3HCRysBXfL/jUbTzufdWTS6LTGtvDQA50oVETt1BJgjKyQBp9vt0VU6AmU/AnOaGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/figures": "^2.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search/node_modules/@inquirer/figures": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.1.tgz",
+      "integrity": "sha512-KtMxyjLCuDFqAWHmCY9qMtsZ09HnjMsm8H3OvpSIpfhHdfw3/AiGWHNrfRwbyvHPtOJpumm8wGn5fkhtvkWRsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.0.1.tgz",
+      "integrity": "sha512-gPByrgYoezGyKMq5KjV7Tuy1JU2ArIy6/sI8sprw0OpXope3VGQwP5FK1KD4eFFqEhKu470Dwe6/AyDPmGRA0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.1",
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/figures": "^2.0.1",
+        "@inquirer/type": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/@inquirer/figures": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.1.tgz",
+      "integrity": "sha512-KtMxyjLCuDFqAWHmCY9qMtsZ09HnjMsm8H3OvpSIpfhHdfw3/AiGWHNrfRwbyvHPtOJpumm8wGn5fkhtvkWRsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.1.tgz",
+      "integrity": "sha512-odO8YwoQAw/eVu/PSPsDDVPmqO77r/Mq7zcoF5VduVqIu2wSRWUgmYb5K9WH1no0SjLnOe8MDKtDL++z6mfo2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inversifyjs/common": {
@@ -2409,6 +2780,10 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/@mcp-framework/cli": {
+      "resolved": "packages/framework/cli",
+      "link": true
     },
     "node_modules/@mcp-framework/core": {
       "resolved": "packages/framework/core",
@@ -4250,6 +4625,18 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
+      "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6773,6 +7160,32 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/inquirer": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.0.1.tgz",
+      "integrity": "sha512-+Qob/OSCmHIgyFKa4S+bDk36Nudwt+zpUBGZaSttGMnvsrzbIqtNFS9RutEPc2QAzpQxBP0cV3wmY/c5Vy73qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.1",
+        "@inquirer/core": "^11.0.1",
+        "@inquirer/prompts": "^8.0.1",
+        "@inquirer/type": "^4.0.1",
+        "mute-stream": "^3.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -7684,6 +8097,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -7986,6 +8415,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mylas": {
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
@@ -8234,6 +8672,29 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
+      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^8.1.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/os-tmpdir": {
@@ -12443,6 +12904,29 @@
         "inversify": "^7.x"
       }
     },
+    "packages/framework/cli": {
+      "name": "@mcp-framework/cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@mcp-framework/infrastructure": "*",
+        "chalk": "^5.4.1",
+        "commander": "^14.0.2",
+        "inquirer": "^13.0.1",
+        "ora": "^9.0.0",
+        "pino": "^10.1.0"
+      },
+      "devDependencies": {
+        "@types/inquirer": "^9.0.7",
+        "@types/node": "^24.10.1",
+        "rimraf": "^6.1.0",
+        "tsc-alias": "^1.8.16",
+        "typescript": "^5.9.3",
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^4.0.8"
+      }
+    },
     "packages/framework/core": {
       "name": "@mcp-framework/core",
       "version": "0.1.0",
@@ -12595,404 +13079,6 @@
         "vitest": "^4.0.8"
       }
     },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/ansi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.1.tgz",
-      "integrity": "sha512-QAZUk6BBncv/XmSEZTscd8qazzjV3E0leUMrEPjxCd51QBgCKmprUGLex5DTsNtURm7LMzv+CLcd6S86xvBfYg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/checkbox": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.0.1.tgz",
-      "integrity": "sha512-5VPFBK8jKdsjMK3DTFOlbR0+Kkd4q0AWB7VhWQn6ppv44dr3b7PU8wSJQTC5oA0f/aGW7v/ZozQJAY9zx6PKig==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.1",
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/figures": "^2.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/confirm": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.1.tgz",
-      "integrity": "sha512-wD+pM7IxLn1TdcQN12Q6wcFe5VpyCuh/I2sSmqO5KjWH2R4v+GkUToHb+PsDGobOe1MtAlXMwGNkZUPc2+L6NA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/core": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.0.1.tgz",
-      "integrity": "sha512-Tpf49h50e4KYffVUCXzkx4gWMafUi3aDQDwfVAAGBNnVcXiwJIj4m2bKlZ7Kgyf6wjt1eyXH1wDGXcAokm4Ssw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.1",
-        "@inquirer/figures": "^2.0.1",
-        "@inquirer/type": "^4.0.1",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^3.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/editor": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.1.tgz",
-      "integrity": "sha512-zDKobHI7Ry++4noiV9Z5VfYgSVpPZoMApviIuGwLOMciQaP+dGzCO+1fcwI441riklRiZg4yURWyEoX0Zy2zZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/external-editor": "^2.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/expand": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.1.tgz",
-      "integrity": "sha512-TBrTpAB6uZNnGQHtSEkbvJZIQ3dXZOrwqQSO9uUbwct3G2LitwBCE5YZj98MbQ5nzihzs5pRjY1K9RRLH4WgoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/external-editor": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.1.tgz",
-      "integrity": "sha512-BPYWJXCAK9w6R+pb2s3WyxUz9ts9SP/LDOUwA9fu7LeuyYgojz83i0DSRwezu736BgMwz14G63Xwj70hSzHohQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/figures": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.1.tgz",
-      "integrity": "sha512-KtMxyjLCuDFqAWHmCY9qMtsZ09HnjMsm8H3OvpSIpfhHdfw3/AiGWHNrfRwbyvHPtOJpumm8wGn5fkhtvkWRsg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/input": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.1.tgz",
-      "integrity": "sha512-cEhEUohCpE2BCuLKtFFZGp4Ief05SEcqeAOq9NxzN5ThOQP8Rl5N/Nt9VEDORK1bRb2Sk/zoOyQYfysPQwyQtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/number": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.1.tgz",
-      "integrity": "sha512-4//zgBGHe8Q/FfCoUXZUrUHyK/q5dyqiwsePz3oSSPSmw1Ijo35ZkjaftnxroygcUlLYfXqm+0q08lnB5hd49A==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/password": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.1.tgz",
-      "integrity": "sha512-UJudHpd7Ia30Q+x+ctYqI9Nh6SyEkaBscpa7J6Ts38oc1CNSws0I1hJEdxbQBlxQd65z5GEJPM4EtNf6tzfWaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.1",
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/prompts": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.0.1.tgz",
-      "integrity": "sha512-MURRu/cyvLm9vchDDaVZ9u4p+ADnY0Mz3LQr0KTgihrrvuKZlqcWwlBC4lkOMvd0KKX4Wz7Ww9+uA7qEpQaqjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^5.0.1",
-        "@inquirer/confirm": "^6.0.1",
-        "@inquirer/editor": "^5.0.1",
-        "@inquirer/expand": "^5.0.1",
-        "@inquirer/input": "^5.0.1",
-        "@inquirer/number": "^4.0.1",
-        "@inquirer/password": "^5.0.1",
-        "@inquirer/rawlist": "^5.0.1",
-        "@inquirer/search": "^4.0.1",
-        "@inquirer/select": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/rawlist": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.0.1.tgz",
-      "integrity": "sha512-vVfVHKUgH6rZmMlyd0jOuGZo0Fw1jfcOqZF96lMwlgavx7g0x7MICe316bV01EEoI+c68vMdbkTTawuw3O+Fgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/search": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.0.1.tgz",
-      "integrity": "sha512-XwiaK5xBvr31STX6Ji8iS3HCRysBXfL/jUbTzufdWTS6LTGtvDQA50oVETt1BJgjKyQBp9vt0VU6AmU/AnOaGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/figures": "^2.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/select": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.0.1.tgz",
-      "integrity": "sha512-gPByrgYoezGyKMq5KjV7Tuy1JU2ArIy6/sI8sprw0OpXope3VGQwP5FK1KD4eFFqEhKu470Dwe6/AyDPmGRA0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.1",
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/figures": "^2.0.1",
-        "@inquirer/type": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/@inquirer/type": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.1.tgz",
-      "integrity": "sha512-odO8YwoQAw/eVu/PSPsDDVPmqO77r/Mq7zcoF5VduVqIu2wSRWUgmYb5K9WH1no0SjLnOe8MDKtDL++z6mfo2g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/cli-spinners": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
-      "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/inquirer": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.0.1.tgz",
-      "integrity": "sha512-+Qob/OSCmHIgyFKa4S+bDk36Nudwt+zpUBGZaSttGMnvsrzbIqtNFS9RutEPc2QAzpQxBP0cV3wmY/c5Vy73qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.1",
-        "@inquirer/core": "^11.0.1",
-        "@inquirer/prompts": "^8.0.1",
-        "@inquirer/type": "^4.0.1",
-        "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/log-symbols": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
-      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/servers/yandex-tracker/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -13012,38 +13098,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "packages/servers/yandex-tracker/node_modules/ora": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^8.1.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/yandex-tracker": {

--- a/packages/framework/cli/README.md
+++ b/packages/framework/cli/README.md
@@ -1,0 +1,149 @@
+# @mcp-framework/cli
+
+Generic CLI framework for MCP server connection management.
+
+## Overview
+
+`@mcp-framework/cli` provides a reusable, extensible CLI framework for managing MCP server connections across multiple AI clients (Claude Desktop, Claude Code, Codex, Gemini, Qwen, etc.). It's designed to be client-agnostic and easily adaptable to any MCP server implementation.
+
+## Features
+
+- **Multi-Client Support**: Built-in connectors for Claude Desktop, Claude Code, Codex, Gemini, Qwen
+- **Extensible Architecture**: Easy to add new client connectors
+- **Type-Safe Configuration**: Generic configuration system with TypeScript support
+- **Interactive Prompts**: User-friendly CLI with interactive prompts (powered by Inquirer)
+- **Command Framework**: Built on Commander.js for consistent CLI experience
+- **Configuration Management**: TOML-based configuration with validation
+
+## Installation
+
+```bash
+npm install @mcp-framework/cli
+```
+
+## Quick Start
+
+### Basic Usage
+
+```typescript
+import {
+  ConnectorRegistry,
+  ConfigManager,
+  type BaseMCPServerConfig
+} from '@mcp-framework/cli';
+
+// Define your server-specific configuration
+interface MyServerConfig extends BaseMCPServerConfig {
+  apiKey: string;
+  endpoint: string;
+}
+
+// Initialize CLI components
+const registry = new ConnectorRegistry();
+const configManager = new ConfigManager<MyServerConfig>({
+  configDir: '.my-mcp-server',
+  configFileName: 'config.json',
+});
+
+// Use connectors
+const connector = registry.getConnector('claude-desktop');
+await connector.connect(config);
+```
+
+### Extending for Your MCP Server
+
+See the [yandex-tracker implementation](../../servers/yandex-tracker/src/cli) for a complete example of how to extend this framework for a specific MCP server.
+
+## Architecture
+
+```
+@mcp-framework/cli/
+├── connectors/       # Client-specific connection logic
+│   ├── base/        # Base connector interface
+│   ├── claude-desktop/
+│   ├── claude-code/
+│   ├── codex/
+│   ├── gemini/
+│   └── qwen/
+├── commands/        # CLI command implementations
+├── utils/          # Utilities (config, prompts, file management)
+└── types.ts        # Core type definitions
+```
+
+## Supported Clients
+
+- **Claude Desktop** - Anthropic's desktop application
+- **Claude Code** - VS Code extension
+- **Codex** - OpenAI's code assistant
+- **Gemini** - Google's AI assistant
+- **Qwen** - Alibaba's AI assistant
+
+## Adding a New Client
+
+To add support for a new AI client:
+
+1. Create a new connector class extending `BaseConnector`
+2. Implement the required methods: `connect()`, `disconnect()`, `getStatus()`
+3. Register the connector in `ConnectorRegistry`
+4. Add client-specific configuration handling
+
+See [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md) for detailed guidelines.
+
+## API Reference
+
+### Core Types
+
+- `BaseMCPServerConfig` - Base configuration interface
+- `ConnectorType` - Supported client types
+- `ConnectionStatus` - Connection state enumeration
+
+### Main Classes
+
+- `ConnectorRegistry` - Manages available connectors
+- `ConfigManager<T>` - Handles configuration persistence
+- `InteractivePrompter` - Interactive CLI prompts
+
+### Utilities
+
+- `CommandExecutor` - Execute shell commands
+- `FileManager` - File system operations
+- `createLogger()` - Pino-based logging
+
+For detailed API documentation, see [API.md](./API.md) (coming soon).
+
+## Dependencies
+
+This package depends only on:
+- `@mcp-framework/infrastructure` - Core utilities (HTTP, logging, cache)
+- Standard CLI libraries (chalk, commander, inquirer, ora)
+
+It does NOT depend on `@mcp-framework/core` - the CLI is purely an infrastructure tool.
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Test
+npm run test
+
+# Lint
+npm run lint
+
+# Validate (lint + typecheck + test)
+npm run validate
+```
+
+## License
+
+MIT
+
+## Related Packages
+
+- [@mcp-framework/infrastructure](../infrastructure) - Infrastructure utilities
+- [@mcp-framework/core](../core) - MCP tool framework
+- [@mcp-server/yandex-tracker](../../servers/yandex-tracker) - Example implementation

--- a/packages/framework/cli/eslint.config.js
+++ b/packages/framework/cli/eslint.config.js
@@ -1,0 +1,69 @@
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import sonarjs from 'eslint-plugin-sonarjs';
+import prettierConfig from 'eslint-config-prettier';
+
+export default [
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.git/**',
+      '**/coverage/**',
+      '**/.vitest/**',
+    ],
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      sonarjs,
+    },
+    rules: {
+      ...tsPlugin.configs['recommended'].rules,
+
+      // Метрики сложности
+      complexity: ['warn', 10],
+      'max-depth': ['warn', 4],
+      'max-lines': ['warn', 400],
+      'max-lines-per-function': ['warn', 50],
+      'max-params': ['warn', 4],
+
+      // SonarJS rules
+      'sonarjs/cognitive-complexity': ['warn', 15],
+      'sonarjs/todo-tag': 'off',
+      'sonarjs/os-command': 'off',
+      'sonarjs/no-identical-expressions': 'warn',
+      'sonarjs/deprecation': 'off',
+      'sonarjs/no-identical-functions': 'warn',
+      'sonarjs/no-control-regex': 'warn',
+      'sonarjs/no-nested-template-literals': 'warn',
+
+      // TypeScript правила (строже для framework пакетов)
+      '@typescript-eslint/explicit-function-return-type': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-non-null-assertion': 'error',
+
+      // Общие правила
+      'no-console': ['warn', { allow: ['error', 'warn'] }],
+      'prefer-const': 'error',
+      'no-var': 'error',
+    },
+  },
+  prettierConfig,
+];

--- a/packages/framework/cli/package.json
+++ b/packages/framework/cli/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@mcp-framework/cli",
+  "version": "0.1.0",
+  "description": "Generic CLI framework for MCP server connection management",
+  "keywords": [
+    "mcp",
+    "cli",
+    "claude",
+    "connector",
+    "configuration"
+  ],
+  "license": "MIT",
+  "author": "Fractalizer",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./connectors": {
+      "types": "./dist/connectors/index.d.ts",
+      "default": "./dist/connectors/index.js"
+    },
+    "./commands": {
+      "types": "./dist/commands/index.d.ts",
+      "default": "./dist/commands/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "default": "./dist/utils/index.js"
+    },
+    "./*": "./dist/*"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc -b && tsc-alias",
+    "clean": "rimraf dist",
+    "cpd": "jscpd src || true",
+    "cpd:quiet": "jscpd src --silent || true",
+    "cpd:report": "jscpd src --reporters html,console",
+    "depcruise": "depcruise src --validate ../../../.dependency-cruiser.cjs || true",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "lint:quiet": "eslint src --ext .ts --quiet",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:quiet": "vitest run --reporter=dot --silent",
+    "test:verbose": "vitest run --reporter=verbose",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit",
+    "validate": "npm run lint && npm run typecheck && npm run test && npm run cpd",
+    "validate:docs": "tsx ../../../scripts/validate-docs-size.ts",
+    "validate:quiet": "npm run lint:quiet && npm run typecheck && npm run test:quiet && npm run cpd:quiet"
+  },
+  "dependencies": {
+    "@iarna/toml": "^2.2.5",
+    "@mcp-framework/infrastructure": "*",
+    "chalk": "^5.4.1",
+    "commander": "^14.0.2",
+    "inquirer": "^13.0.1",
+    "ora": "^9.0.0",
+    "pino": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/inquirer": "^9.0.7",
+    "@types/node": "^24.10.1",
+    "rimraf": "^6.1.0",
+    "tsc-alias": "^1.8.16",
+    "typescript": "^5.9.3",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.0.8"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/framework/cli/src/commands/index.ts
+++ b/packages/framework/cli/src/commands/index.ts
@@ -1,0 +1,11 @@
+/**
+ * CLI Commands
+ * @packageDocumentation
+ */
+
+// Commands will be implemented in stage 4
+// export * from './connect.js';
+// export * from './disconnect.js';
+// export * from './status.js';
+// export * from './list.js';
+// export * from './validate.js';

--- a/packages/framework/cli/src/connectors/index.ts
+++ b/packages/framework/cli/src/connectors/index.ts
@@ -1,0 +1,13 @@
+/**
+ * MCP Client Connectors
+ * @packageDocumentation
+ */
+
+// Connectors will be implemented in stage 2.3
+// export * from './base/index.js';
+// export * from './claude-desktop/index.js';
+// export * from './claude-code/index.js';
+// export * from './codex/index.js';
+// export * from './gemini/index.js';
+// export * from './qwen/index.js';
+// export * from './registry.js';

--- a/packages/framework/cli/src/index.ts
+++ b/packages/framework/cli/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @mcp-framework/cli
+ * Generic CLI framework for MCP server connection management
+ *
+ * @packageDocumentation
+ */
+
+// Export all types
+export * from './types.js';
+
+// Export connectors (will be implemented in stage 2.3)
+// export * from './connectors/index.js';
+
+// Export commands (will be implemented in stage 4)
+// export * from './commands/index.js';
+
+// Export utils (will be implemented in stage 3)
+// export * from './utils/index.js';

--- a/packages/framework/cli/src/types.ts
+++ b/packages/framework/cli/src/types.ts
@@ -1,0 +1,231 @@
+/**
+ * Core types for MCP CLI Framework
+ * @packageDocumentation
+ */
+
+/**
+ * Базовая конфигурация для любого MCP сервера
+ * Все MCP серверы должны расширять этот интерфейс
+ */
+export interface BaseMCPServerConfig {
+  /** Абсолютный путь к директории проекта */
+  projectPath: string;
+
+  /** Уровень логирования */
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+
+  /** Дополнительные переменные окружения для MCP сервера */
+  env?: Record<string, string>;
+}
+
+/**
+ * Информация о MCP клиенте (Claude Desktop, Claude Code и т.д.)
+ */
+export interface MCPClientInfo {
+  /** Уникальное имя клиента (используется как ключ) */
+  name: string;
+
+  /** Отображаемое имя для пользователя */
+  displayName: string;
+
+  /** Описание клиента */
+  description: string;
+
+  /** Команда для проверки установки (например, 'claude --version') */
+  checkCommand?: string;
+
+  /** Путь к конфигурационному файлу */
+  configPath: string;
+
+  /** Поддерживаемые платформы */
+  platforms: Array<'darwin' | 'linux' | 'win32'>;
+}
+
+/**
+ * Статус подключения MCP сервера к клиенту
+ */
+export interface ConnectionStatus {
+  /** Подключен ли сервер */
+  connected: boolean;
+
+  /** Детали подключения */
+  details?: {
+    /** Путь к конфигурационному файлу клиента */
+    configPath: string;
+
+    /** Время последнего изменения конфига */
+    lastModified?: Date;
+
+    /** Дополнительная информация */
+    metadata?: Record<string, unknown>;
+  };
+
+  /** Ошибка (если есть) */
+  error?: string;
+}
+
+/**
+ * Базовый интерфейс для всех MCP коннекторов
+ * Generic по типу конфигурации сервера
+ */
+export interface MCPConnector<TConfig extends BaseMCPServerConfig = BaseMCPServerConfig> {
+  /** Получить информацию о клиенте */
+  getClientInfo(): MCPClientInfo;
+
+  /** Проверить, установлен ли клиент в системе */
+  isInstalled(): Promise<boolean>;
+
+  /** Получить текущий статус подключения */
+  getStatus(): Promise<ConnectionStatus>;
+
+  /** Подключить MCP сервер к клиенту */
+  connect(config: TConfig): Promise<void>;
+
+  /** Отключить MCP сервер от клиента */
+  disconnect(): Promise<void>;
+
+  /** Валидировать конфигурацию перед подключением */
+  validateConfig(config: TConfig): Promise<string[]>;
+}
+
+/**
+ * Конфигурация MCP сервера для записи в файл клиента (JSON/TOML)
+ */
+export interface MCPClientServerConfig {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/**
+ * Базовая структура конфигурационного файла MCP клиента
+ * Generic тип для разных форматов (mcpServers, mcp_servers и т.д.)
+ */
+export type MCPClientConfig<TKey extends string = 'mcpServers'> = {
+  [K in TKey]?: Record<string, MCPClientServerConfig>;
+};
+
+/**
+ * Типы промптов для сбора конфигурации
+ */
+export type PromptType = 'input' | 'password' | 'list' | 'confirm' | 'number';
+
+/**
+ * Определение промпта для сбора конфигурации
+ * Generic по типу конфигурации и ключу поля
+ */
+export interface ConfigPromptDefinition<
+  TConfig extends BaseMCPServerConfig,
+  K extends keyof TConfig = keyof TConfig,
+> {
+  /** Имя поля в конфигурации */
+  name: K;
+
+  /** Тип промпта */
+  type: PromptType;
+
+  /** Сообщение для пользователя */
+  message: string;
+
+  /** Значение по умолчанию (может быть функцией от сохраненной конфигурации) */
+  default?: TConfig[K] | ((savedConfig?: Partial<TConfig>) => TConfig[K] | undefined);
+
+  /** Функция валидации */
+  validate?: (value: TConfig[K]) => string | true;
+
+  /** Варианты выбора (для type: 'list') */
+  choices?: Array<{ name: string; value: TConfig[K] }>;
+
+  /** Условное отображение промпта */
+  when?: (answers: Partial<TConfig>) => boolean;
+
+  /** Маска для ввода (для type: 'password') */
+  mask?: string;
+}
+
+/**
+ * Опции для ConfigManager
+ */
+export interface ConfigManagerOptions<TConfig extends BaseMCPServerConfig> {
+  /** Название проекта (для ~/.{projectName}/config.json) */
+  projectName: string;
+
+  /**
+   * Поля конфигурации, которые можно сохранять (без секретов!)
+   * Например: ['orgId', 'logLevel', 'apiBase']
+   */
+  safeFields: Array<keyof TConfig>;
+
+  /**
+   * Опционально: кастомная сериализация перед записью в файл
+   */
+  serialize?: (config: TConfig) => Record<string, unknown>;
+
+  /**
+   * Опционально: кастомная десериализация после чтения из файла
+   */
+  deserialize?: (data: Record<string, unknown>) => Partial<TConfig>;
+}
+
+/**
+ * Опции для команды connect
+ */
+export interface ConnectCommandOptions<TConfig extends BaseMCPServerConfig> {
+  /** Реестр коннекторов */
+  registry: ConnectorRegistry<TConfig>;
+
+  /** Менеджер конфигурации */
+  configManager: ConfigManager<TConfig>;
+
+  /** Промпты для сбора конфигурации */
+  configPrompts: ConfigPromptDefinition<TConfig>[];
+
+  /** CLI опции (из commander) */
+  cliOptions?: {
+    client?: string;
+  };
+
+  /** Опционально: функция для добавления projectPath к конфигу */
+  buildConfig?: (serverConfig: Omit<TConfig, 'projectPath'>) => TConfig;
+}
+
+/**
+ * Опции для команды disconnect
+ */
+export interface DisconnectCommandOptions<TConfig extends BaseMCPServerConfig> {
+  registry: ConnectorRegistry<TConfig>;
+  cliOptions?: {
+    client?: string;
+    all?: boolean;
+  };
+}
+
+/**
+ * Опции для команды validate
+ */
+export interface ValidateCommandOptions<TConfig extends BaseMCPServerConfig> {
+  registry: ConnectorRegistry<TConfig>;
+  configManager: ConfigManager<TConfig>;
+  cliOptions?: {
+    client?: string;
+  };
+}
+
+// Forward declarations for classes (will be implemented in separate files)
+export declare class ConnectorRegistry<TConfig extends BaseMCPServerConfig = BaseMCPServerConfig> {
+  constructor(autoRegister?: boolean);
+  register(connector: MCPConnector<TConfig>): void;
+  get(name: string): MCPConnector<TConfig> | undefined;
+  getAll(): MCPConnector<TConfig>[];
+  findInstalled(): Promise<MCPConnector<TConfig>[]>;
+  checkAllStatuses(): Promise<Map<string, ConnectionStatus>>;
+}
+
+export declare class ConfigManager<TConfig extends BaseMCPServerConfig> {
+  constructor(options: ConfigManagerOptions<TConfig>);
+  load(): Promise<Partial<TConfig> | undefined>;
+  save(config: TConfig): Promise<void>;
+  delete(): Promise<void>;
+  exists(): Promise<boolean>;
+  getConfigPath(): string;
+}

--- a/packages/framework/cli/src/utils/index.ts
+++ b/packages/framework/cli/src/utils/index.ts
@@ -1,0 +1,11 @@
+/**
+ * CLI Utilities
+ * @packageDocumentation
+ */
+
+// Utils will be implemented in stage 3
+// export * from './config-manager.js';
+// export * from './interactive-prompter.js';
+// export * from './logger.js';
+// export * from './file-manager.js';
+// export * from './command-executor.js';

--- a/packages/framework/cli/tsconfig.json
+++ b/packages/framework/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "#cli/*": ["./src/*"],
+      "#types": ["./src/types.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/framework/cli/vitest.config.ts
+++ b/packages/framework/cli/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import path from 'node:path';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { sharedConfig } from '../../../vitest.shared';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    plugins: [tsconfigPaths()],
+    test: {
+      // Package-specific настройки
+      name: 'cli',
+    },
+    resolve: {
+      alias: {
+        // Поддержка subpath imports
+        '@mcp-framework/cli': path.resolve(__dirname, './src'),
+        '@mcp-framework/cli/*': path.resolve(__dirname, './src/*'),
+        '#cli': path.resolve(__dirname, './src'),
+        '#cli/*': path.resolve(__dirname, './src/*'),
+        '#types': path.resolve(__dirname, './src/types.ts'),
+      },
+    },
+  })
+);


### PR DESCRIPTION
Создана базовая структура нового framework пакета для универсального CLI.

Изменения:
- Создана директория packages/framework/cli/ с полной структурой
- Добавлен package.json с зависимостями (chalk, commander, inquirer, ora)
- Настроены конфигурационные файлы (tsconfig.json, eslint.config.js, vitest.config.ts)
- Определены базовые типы в src/types.ts (BaseMCPServerConfig, MCPConnector, и др.)
- Созданы заглушки для connectors/, commands/, utils/
- Добавлен README.md с обзором API
- Обновлен package-lock.json после установки зависимостей

Валидация:
- npm run build --workspace=@mcp-framework/cli ✓
- npm run typecheck --workspace=@mcp-framework/cli ✓
- npm run lint:quiet --workspace=@mcp-framework/cli ✓

Этап 2.1 из плана CLI framework extraction завершён.

🤖 Generated with Claude Code