### PR TITLE
Implement batch comments retrieval operation

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.metadata.ts
@@ -17,11 +17,11 @@ import { MCP_TOOL_PREFIX } from '#constants';
  */
 export const GET_COMMENTS_TOOL_METADATA: StaticToolMetadata = {
   name: buildToolName('get_comments', MCP_TOOL_PREFIX),
-  description: '[Comments/Read] Получить комментарии задачи',
+  description: '[Comments/Read] Получить комментарии задач (batch, пагинация)',
   category: ToolCategory.COMMENTS,
   subcategory: 'read',
   priority: ToolPriority.HIGH,
-  tags: ['comment', 'get', 'list', 'read'],
+  tags: ['comment', 'get', 'list', 'read', 'batch'],
   isHelper: false,
   requiresExplicitUserConsent: false,
 } as const;

--- a/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/comments/get/get-comments.schema.ts
@@ -3,16 +3,16 @@
  */
 
 import { z } from 'zod';
-import { IssueKeySchema, ExpandSchema, FieldsSchema } from '#common/schemas/index.js';
+import { IssueKeysSchema, ExpandSchema, FieldsSchema } from '#common/schemas/index.js';
 
 /**
  * Схема параметров для получения комментариев
  */
 export const GetCommentsParamsSchema = z.object({
   /**
-   * Идентификатор или ключ задачи (обязательно)
+   * Массив идентификаторов или ключей задач (обязательно)
    */
-  issueId: IssueKeySchema.describe('Issue ID or key (e.g., TEST-123)'),
+  issueIds: IssueKeysSchema.describe("Array of issue IDs or keys (e.g., ['TEST-123', 'TEST-456'])"),
 
   /**
    * Количество комментариев на странице (опционально)

--- a/packages/servers/yandex-tracker/src/tools/generated-index.ts
+++ b/packages/servers/yandex-tracker/src/tools/generated-index.ts
@@ -217,11 +217,11 @@ export const TOOL_SEARCH_INDEX: readonly StaticToolIndex[] = [
   {
     name: 'fr_yandex_tracker_get_comments',
     category: ToolCategory.COMMENTS,
-    tags: ['comment', 'get', 'list', 'read'],
+    tags: ['comment', 'get', 'list', 'read', 'batch'],
     isHelper: false,
     nameTokens: ['fr', 'yandex', 'tracker', 'get', 'comments'],
-    descriptionTokens: ['comments', 'read'],
-    descriptionShort: '[Comments/Read] Получить комментарии задачи',
+    descriptionTokens: ['comments', 'read', 'batch'],
+    descriptionShort: '[Comments/Read] Получить комментарии одной или нескольких задач',
   },
   {
     name: 'fr_yandex_tracker_edit_comment',

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/comment/get-comments.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/comment/get-comments.operation.ts
@@ -2,18 +2,38 @@
  * Операция получения списка комментариев задачи
  *
  * Ответственность (SRP):
- * - ТОЛЬКО получение комментариев задачи
+ * - ТОЛЬКО получение комментариев задачи (single и batch режимы)
  * - Поддержка пагинации
+ * - Параллельное выполнение через ParallelExecutor (batch режим)
  * - НЕТ добавления/редактирования/удаления комментариев
  *
  * API: GET /v3/issues/{issueId}/comments
  */
 
 import { BaseOperation } from '#tracker_api/api_operations/base-operation.js';
+import { ParallelExecutor } from '@mcp-framework/infrastructure';
 import type { GetCommentsInput } from '#tracker_api/dto/index.js';
 import type { CommentWithUnknownFields } from '#tracker_api/entities/index.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
+import type { ServerConfig } from '#config';
 
 export class GetCommentsOperation extends BaseOperation {
+  private readonly parallelExecutor: ParallelExecutor;
+
+  constructor(
+    httpClient: ConstructorParameters<typeof BaseOperation>[0],
+    cacheManager: ConstructorParameters<typeof BaseOperation>[1],
+    logger: ConstructorParameters<typeof BaseOperation>[2],
+    config: ServerConfig
+  ) {
+    super(httpClient, cacheManager, logger);
+
+    this.parallelExecutor = new ParallelExecutor(logger, {
+      maxBatchSize: config.maxBatchSize,
+      maxConcurrentRequests: config.maxConcurrentRequests,
+    });
+  }
+
   /**
    * Получает список комментариев задачи
    *
@@ -62,5 +82,45 @@ export class GetCommentsOperation extends BaseOperation {
     );
 
     return Array.isArray(comments) ? comments : [comments];
+  }
+
+  /**
+   * Получает комментарии для нескольких задач параллельно
+   *
+   * @param issueIds - массив идентификаторов задач
+   * @param input - параметры запроса (применяются ко всем задачам)
+   * @returns массив результатов в формате BatchResult
+   * @throws {Error} если количество задач превышает maxBatchSize
+   *
+   * ВАЖНО:
+   * - Параметры perPage, page, expand применяются ко всем задачам одинаково
+   * - Использует ParallelExecutor для соблюдения maxConcurrentRequests
+   * - Retry делается автоматически в HttpClient.get
+   */
+  async executeMany(
+    issueIds: string[],
+    input: GetCommentsInput = {}
+  ): Promise<BatchResult<string, CommentWithUnknownFields[]>> {
+    // Проверка на пустой массив
+    if (issueIds.length === 0) {
+      this.logger.warn('GetCommentsOperation: пустой массив идентификаторов');
+      return [];
+    }
+
+    this.logger.info(
+      `Получение комментариев для ${issueIds.length} задач параллельно: ${issueIds.join(', ')}`
+    );
+
+    // Создаём операции для каждой задачи
+    const operations = issueIds.map((issueId) => ({
+      key: issueId,
+      fn: async (): Promise<CommentWithUnknownFields[]> => {
+        // Вызываем существующий метод execute() для каждой задачи
+        return this.execute(issueId, input);
+      },
+    }));
+
+    // Выполняем через ParallelExecutor (централизованный throttling)
+    return this.parallelExecutor.executeParallel(operations, 'get comments');
   }
 }

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/services/comment.service.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/services/comment.service.ts
@@ -28,6 +28,7 @@ import type {
   GetCommentsInput,
 } from '#tracker_api/dto/index.js';
 import type { CommentWithUnknownFields } from '#tracker_api/entities/index.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
 
 @injectable()
 export class CommentService {
@@ -59,6 +60,19 @@ export class CommentService {
     input?: GetCommentsInput
   ): Promise<CommentWithUnknownFields[]> {
     return this.getCommentsOp.execute(issueId, input);
+  }
+
+  /**
+   * Получает комментарии для нескольких задач параллельно
+   * @param issueIds - массив идентификаторов задач
+   * @param input - параметры запроса (применяются ко всем задачам)
+   * @returns массив результатов в формате BatchResult
+   */
+  async getCommentsMany(
+    issueIds: string[],
+    input?: GetCommentsInput
+  ): Promise<BatchResult<string, CommentWithUnknownFields[]>> {
+    return this.getCommentsOp.executeMany(issueIds, input);
   }
 
   /**

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -102,6 +102,7 @@ import type {
   UpdateProjectParams,
   DeleteProjectParams,
 } from '#tracker_api/api_operations/index.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
 
 @injectable()
 export class YandexTrackerFacade {
@@ -420,6 +421,19 @@ export class YandexTrackerFacade {
     input?: GetCommentsInput
   ): Promise<CommentWithUnknownFields[]> {
     return this.commentService.getComments(issueId, input);
+  }
+
+  /**
+   * Получает комментарии для нескольких задач параллельно
+   * @param issueIds - массив идентификаторов задач
+   * @param input - параметры запроса (применяются ко всем задачам)
+   * @returns массив результатов в формате BatchResult
+   */
+  async getCommentsMany(
+    issueIds: string[],
+    input?: GetCommentsInput
+  ): Promise<BatchResult<string, CommentWithUnknownFields[]>> {
+    return this.commentService.getCommentsMany(issueIds, input);
   }
 
   /**

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/comments/get/get-comments.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/comments/get/get-comments.tool.integration.test.ts
@@ -25,16 +25,20 @@ describe('get-comments integration tests', () => {
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_get_comments', {
-      issueId: issueKey,
+      issueIds: [issueKey],
       fields: ['id', 'text'],
     });
 
     // Assert
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(1);
+    expect(response.data.successful).toBe(1);
     expect(response.data.comments).toBeDefined();
     expect(Array.isArray(response.data.comments)).toBe(true);
-    expect(response.data.comments.length).toBeGreaterThan(0);
+    expect(response.data.comments.length).toBe(1);
+    expect(response.data.comments[0].issueId).toBe(issueKey);
+    expect(response.data.comments[0].count).toBeGreaterThan(0);
     mockServer.assertAllRequestsDone();
   });
 
@@ -45,16 +49,19 @@ describe('get-comments integration tests', () => {
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_get_comments', {
-      issueId: issueKey,
+      issueIds: [issueKey],
       fields: ['id', 'text'],
     });
 
     // Assert
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(1);
+    expect(response.data.successful).toBe(1);
     expect(response.data.comments).toBeDefined();
     expect(Array.isArray(response.data.comments)).toBe(true);
-    expect(response.data.comments.length).toBe(0);
+    expect(response.data.comments.length).toBe(1);
+    expect(response.data.comments[0].count).toBe(0);
     mockServer.assertAllRequestsDone();
   });
 
@@ -65,12 +72,17 @@ describe('get-comments integration tests', () => {
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_get_comments', {
-      issueId: issueKey,
+      issueIds: [issueKey],
       fields: ['id', 'text'],
     });
 
     // Assert
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBeUndefined();
+    const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(1);
+    expect(response.data.failed).toBe(1);
+    expect(response.data.errors).toBeDefined();
+    expect(response.data.errors.length).toBe(1);
     mockServer.assertAllRequestsDone();
   });
 
@@ -81,7 +93,7 @@ describe('get-comments integration tests', () => {
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_get_comments', {
-      issueId: issueKey,
+      issueIds: [issueKey],
       perPage: 10,
       page: 1,
       fields: ['id', 'text'],
@@ -90,6 +102,7 @@ describe('get-comments integration tests', () => {
     // Assert
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(1);
     expect(response.data.comments).toBeDefined();
     expect(Array.isArray(response.data.comments)).toBe(true);
     mockServer.assertAllRequestsDone();
@@ -102,7 +115,7 @@ describe('get-comments integration tests', () => {
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_get_comments', {
-      issueId: issueKey,
+      issueIds: [issueKey],
       expand: ['attachments'],
       fields: ['id', 'text'],
     });
@@ -110,6 +123,7 @@ describe('get-comments integration tests', () => {
     // Assert
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(1);
     expect(response.data.comments).toBeDefined();
     expect(Array.isArray(response.data.comments)).toBe(true);
     mockServer.assertAllRequestsDone();

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/comment/get-comments.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/comment/get-comments.operation.test.ts
@@ -4,6 +4,7 @@ import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-man
 import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
 import type { CommentWithUnknownFields } from '#tracker_api/entities/index.js';
 import type { GetCommentsInput } from '#tracker_api/dto/index.js';
+import type { ServerConfig } from '#config';
 import { GetCommentsOperation } from '#tracker_api/api_operations/comment/get-comments.operation.js';
 
 describe('GetCommentsOperation', () => {
@@ -11,6 +12,7 @@ describe('GetCommentsOperation', () => {
   let mockHttpClient: IHttpClient;
   let mockCacheManager: CacheManager;
   let mockLogger: Logger;
+  let mockConfig: ServerConfig;
 
   beforeEach(() => {
     mockHttpClient = {
@@ -37,7 +39,12 @@ describe('GetCommentsOperation', () => {
       debug: vi.fn(),
     } as unknown as Logger;
 
-    operation = new GetCommentsOperation(mockHttpClient, mockCacheManager, mockLogger);
+    mockConfig = {
+      maxBatchSize: 100,
+      maxConcurrentRequests: 5,
+    } as ServerConfig;
+
+    operation = new GetCommentsOperation(mockHttpClient, mockCacheManager, mockLogger, mockConfig);
   });
 
   describe('execute', () => {
@@ -156,6 +163,127 @@ describe('GetCommentsOperation', () => {
 
       expect(mockLogger.info).toHaveBeenCalledWith('Получение комментариев задачи TEST-1');
       expect(mockLogger.info).toHaveBeenCalledWith('Получено 2 комментариев для задачи TEST-1');
+    });
+  });
+
+  describe('executeMany', () => {
+    it('should get comments for multiple issues in parallel', async () => {
+      const mockComments1: CommentWithUnknownFields[] = [
+        {
+          id: '1',
+          self: 'https://api.tracker.yandex.net/v3/issues/TEST-1/comments/1',
+          text: 'Comment 1 for TEST-1',
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v3/users/1',
+            id: '1',
+            display: 'User 1',
+          },
+          createdAt: '2025-01-18T10:00:00.000+0000',
+        },
+      ];
+
+      const mockComments2: CommentWithUnknownFields[] = [
+        {
+          id: '2',
+          self: 'https://api.tracker.yandex.net/v3/issues/TEST-2/comments/2',
+          text: 'Comment 1 for TEST-2',
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v3/users/2',
+            id: '2',
+            display: 'User 2',
+          },
+          createdAt: '2025-01-18T11:00:00.000+0000',
+        },
+      ];
+
+      vi.mocked(mockHttpClient.get)
+        .mockResolvedValueOnce(mockComments1)
+        .mockResolvedValueOnce(mockComments2);
+
+      const result = await operation.executeMany(['TEST-1', 'TEST-2']);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].status).toBe('fulfilled');
+      expect(result[0].key).toBe('TEST-1');
+      if (result[0].status === 'fulfilled') {
+        expect(result[0].value).toEqual(mockComments1);
+      }
+      expect(result[1].status).toBe('fulfilled');
+      expect(result[1].key).toBe('TEST-2');
+      if (result[1].status === 'fulfilled') {
+        expect(result[1].value).toEqual(mockComments2);
+      }
+    });
+
+    it('should handle partial failures (some succeed, some fail)', async () => {
+      const mockComments: CommentWithUnknownFields[] = [
+        {
+          id: '1',
+          self: 'https://api.tracker.yandex.net/v3/issues/TEST-1/comments/1',
+          text: 'Comment 1',
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v3/users/1',
+            id: '1',
+            display: 'User 1',
+          },
+          createdAt: '2025-01-18T10:00:00.000+0000',
+        },
+      ];
+
+      vi.mocked(mockHttpClient.get)
+        .mockResolvedValueOnce(mockComments)
+        .mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await operation.executeMany(['TEST-1', 'TEST-2']);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].status).toBe('fulfilled');
+      expect(result[0].key).toBe('TEST-1');
+      if (result[0].status === 'fulfilled') {
+        expect(result[0].value).toEqual(mockComments);
+      }
+      expect(result[1].status).toBe('rejected');
+      expect(result[1].key).toBe('TEST-2');
+      if (result[1].status === 'rejected') {
+        expect(result[1].reason.message).toBe('Not found');
+      }
+    });
+
+    it('should apply perPage and page to all issues', async () => {
+      const mockComments: CommentWithUnknownFields[] = [];
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComments);
+
+      const input: GetCommentsInput = {
+        perPage: 10,
+        page: 2,
+      };
+
+      await operation.executeMany(['TEST-1', 'TEST-2'], input);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        '/v3/issues/TEST-1/comments?perPage=10&page=2'
+      );
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        '/v3/issues/TEST-2/comments?perPage=10&page=2'
+      );
+    });
+
+    it('should return empty result for empty array', async () => {
+      const result = await operation.executeMany([]);
+
+      expect(result).toEqual([]);
+      expect(mockHttpClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should log batch operation', async () => {
+      const mockComments: CommentWithUnknownFields[] = [];
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockComments);
+
+      await operation.executeMany(['TEST-1', 'TEST-2']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Получение комментариев для 2 задач параллельно: TEST-1, TEST-2'
+      );
     });
   });
 });

--- a/packages/servers/yandex-tracker/tests/workflows/full-issue-lifecycle.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/workflows/full-issue-lifecycle.integration.test.ts
@@ -249,12 +249,13 @@ describe('Full Issue Lifecycle (Integration)', () => {
     ]);
 
     const commentsResult = await client.callTool(buildToolName('get_comments', MCP_TOOL_PREFIX), {
-      issueId: issueKey,
+      issueIds: [issueKey],
       fields: ['id', 'text'],
     });
     expect(commentsResult.isError).toBeFalsy();
     const commentsData = JSON.parse(commentsResult.content[0]!.text);
-    expect(commentsData.data.comments).toHaveLength(3);
+    expect(commentsData.data.comments).toHaveLength(1);
+    expect(commentsData.data.comments[0].count).toBe(3);
 
     // Получить чеклист
     mockServer.mockGetChecklistSuccess(issueKey, [


### PR DESCRIPTION
Реализован этап 1.1 плана batch_operations:
- Обновлена schema: issueId → issueIds (массив)
- Добавлен метод executeMany() в GetCommentsOperation с ParallelExecutor
- Добавлены методы getCommentsMany() в service и facade
- Tool обновлен для batch API с BatchResultProcessor и ResultLogger
- Обновлены metadata и description (укорочено для лимита 80 символов)
- Написаны unit-тесты для operation (executeMany) и tool
- Обновлены integration тесты для batch-формата результатов

Преимущества:
- Параллельное получение комментариев для нескольких задач
- Единый формат результатов (BatchResult) как в get-issues
- Автоматический throttling через ParallelExecutor
- Поддержка partial failures (некоторые успешны, некоторые нет)

Все тесты пройдены: 142 файла, 1793 теста ✓

🤖 Generated with Claude Code