### PR TITLE
Update batch GET operations unit tests

### DIFF
--- a/.agentic-planning/plan_batch_operations/1.2_get_issue_links_batch_parallel.md
+++ b/.agentic-planning/plan_batch_operations/1.2_get_issue_links_batch_parallel.md
@@ -15,7 +15,7 @@
 - [x] 5. Обновить facade и service methods
 - [x] 6. Написать unit-тесты (operation tests)
 - [x] 7. Обновить integration tests
-- [ ] 8. Обновить tool unit tests (TODO: отложено)
+- [x] 8. Обновить tool unit tests
 - [x] 9. Коммит изменений
 
 ---
@@ -29,6 +29,7 @@
 5. **Facade & Service**: обновлены сигнатуры методов
 6. **Operation tests**: все тесты обновлены и проходят
 7. **Integration tests**: обновлены для batch API
+8. **Tool unit tests**: обновлены по образцу get-comments.tool.test.ts (commit TBD)
 
 ---
 
@@ -105,7 +106,7 @@ export const GetIssueLinksParamsSchema = z.object({
 ✅ Facade и service methods обновлены
 ✅ Operation unit-тесты написаны и проходят
 ✅ Integration tests обновлены
-⏸️  Tool unit tests (отложено для отдельного PR)
+✅ Tool unit tests обновлены
 ✅ Изменения закоммичены
 
 ---

--- a/packages/servers/yandex-tracker/tests/tools/api/issues/links/get/get-issue-links.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/issues/links/get/get-issue-links.tool.test.ts
@@ -6,18 +6,17 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GetIssueLinksTool } from '#tools/api/issues/links/get/index.js';
 import type { YandexTrackerFacade } from '#tracker_api/facade/yandex-tracker.facade.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/index.js';
+import type { LinkWithUnknownFields } from '#tracker_api/entities/index.js';
 import { buildToolName } from '@mcp-framework/core';
 import { MCP_TOOL_PREFIX } from '#constants';
-import {
-  createLinkListFixture,
-  createSubtaskLinkFixture,
-  createRelatesLinkFixture,
-} from '#helpers/link.fixture.js';
+import { createLinkListFixture } from '#helpers/link.fixture.js';
 
 describe('GetIssueLinksTool', () => {
   let mockTrackerFacade: YandexTrackerFacade;
   let mockLogger: Logger;
   let tool: GetIssueLinksTool;
+
+  const mockLinks: LinkWithUnknownFields[] = createLinkListFixture(3);
 
   beforeEach(() => {
     mockTrackerFacade = {
@@ -35,11 +34,26 @@ describe('GetIssueLinksTool', () => {
   });
 
   describe('getDefinition', () => {
-    it('должен вернуть корректное определение инструмента', () => {
+    it('должен иметь корректное имя yandex_tracker_get_issue_links', () => {
       const definition = tool.getDefinition();
 
       expect(definition.name).toBe(buildToolName('get_issue_links', MCP_TOOL_PREFIX));
+    });
+
+    it('должен иметь корректную категорию', () => {
+      expect(GetIssueLinksTool.METADATA.category).toBe('issues');
+      expect(GetIssueLinksTool.METADATA.subcategory).toBe('links');
+    });
+
+    it('должен иметь корректное описание', () => {
+      const definition = tool.getDefinition();
+
       expect(definition.description).toContain('Получить связи');
+    });
+
+    it('должен иметь корректную схему с обязательными полями', () => {
+      const definition = tool.getDefinition();
+
       expect(definition.inputSchema.type).toBe('object');
       expect(definition.inputSchema.required).toEqual(['issueIds', 'fields']);
       expect(definition.inputSchema.properties?.['issueIds']).toBeDefined();
@@ -48,8 +62,8 @@ describe('GetIssueLinksTool', () => {
   });
 
   describe('Validation', () => {
-    it('должен требовать параметр issueId', async () => {
-      const result = await tool.execute({});
+    it('должен требовать параметр issueIds', async () => {
+      const result = await tool.execute({ fields: ['id', 'type'] });
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -60,193 +74,351 @@ describe('GetIssueLinksTool', () => {
       expect(parsed.message).toContain('валидации');
     });
 
-    it('должен отклонить пустой issueId', async () => {
-      const result = await tool.execute({ issueId: '', fields: ['id', 'type'] });
+    it('должен требовать параметр fields', async () => {
+      const result = await tool.execute({ issueIds: ['TEST-123'] });
 
       expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        message: string;
+      };
+      expect(parsed.success).toBe(false);
+      expect(parsed.message).toContain('валидации');
+    });
+
+    it('должен отклонить пустой массив issueIds', async () => {
+      const result = await tool.execute({ issueIds: [], fields: ['id', 'type'] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('валидации');
+    });
+
+    it('должен принять корректные параметры', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+      ]);
+
+      const result = await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
+      });
+
+      expect(result.isError).toBeUndefined();
     });
   });
 
   describe('Operation calls', () => {
-    it('должен вызвать getIssueLinks с корректным параметром', async () => {
-      const mockLinks = createLinkListFixture(3);
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
+    it('должен вызвать getIssueLinks с корректными параметрами', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+      ]);
 
-      await tool.execute({ issueId: 'TEST-123', fields: ['id', 'type', 'object'] });
+      await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
+      });
 
-      expect(mockTrackerFacade.getIssueLinks).toHaveBeenCalledWith('TEST-123');
+      expect(mockTrackerFacade.getIssueLinks).toHaveBeenCalledWith(['TEST-123']);
     });
 
-    it('должен вернуть успешный результат со списком связей', async () => {
-      const mockLinks = createLinkListFixture(2);
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
+    it('должен вернуть unified batch result', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+      ]);
 
-      const result = await tool.execute({ issueId: 'TEST-123', fields: ['id', 'type'] });
+      const result = await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
+      });
 
       expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content[0]?.text || '{}') as {
         success: boolean;
         data: {
-          issueId: string;
-          linksCount: number;
-          links: Array<{
-            id: string;
-            type: { id: string };
+          total: number;
+          successful: Array<{
+            issueId: string;
+            links: LinkWithUnknownFields[];
+            count: number;
+          }>;
+          failed: Array<{ issueId: string; error: string }>;
+          fieldsReturned: string[];
+        };
+      };
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(1);
+      expect(parsed.data.successful).toHaveLength(1);
+      expect(parsed.data.failed).toHaveLength(0);
+      expect(parsed.data.successful[0].issueId).toBe('TEST-123');
+      expect(parsed.data.successful[0].count).toBe(3);
+      expect(parsed.data.fieldsReturned).toEqual(['id', 'type']);
+    });
+
+    it('должен вернуть пустой массив для задачи без связей', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: [],
+        },
+      ]);
+
+      const result = await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          total: number;
+          successful: Array<{
+            count: number;
+          }>;
+          failed: unknown[];
+        };
+      };
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(1);
+      expect(parsed.data.successful).toHaveLength(1);
+      expect(parsed.data.failed).toHaveLength(0);
+      expect(parsed.data.successful[0].count).toBe(0);
+    });
+
+    it('должен обработать batch результаты для нескольких задач', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+        {
+          status: 'fulfilled',
+          key: 'TEST-456',
+          index: 1,
+          value: [],
+        },
+      ]);
+
+      const result = await tool.execute({
+        issueIds: ['TEST-123', 'TEST-456'],
+        fields: ['id', 'type'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          total: number;
+          successful: Array<{
+            issueId: string;
+            count: number;
+          }>;
+        };
+      };
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.successful).toHaveLength(2);
+      expect(parsed.data.successful[0].issueId).toBe('TEST-123');
+      expect(parsed.data.successful[0].count).toBe(3);
+      expect(parsed.data.successful[1].issueId).toBe('TEST-456');
+      expect(parsed.data.successful[1].count).toBe(0);
+    });
+
+    it('должен фильтровать поля в результатах', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+      ]);
+
+      const result = await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          successful: Array<{
+            links: Array<{
+              id: string;
+              type: unknown;
+            }>;
           }>;
           fieldsReturned: string[];
         };
       };
-      expect(parsed.data.issueId).toBe('TEST-123');
-      expect(parsed.data.linksCount).toBe(2);
-      expect(parsed.data.links).toHaveLength(2);
+      expect(parsed.data.successful[0].links[0]).toHaveProperty('id');
+      expect(parsed.data.successful[0].links[0]).toHaveProperty('type');
+      expect(parsed.data.successful[0].links[0]).not.toHaveProperty('createdBy');
       expect(parsed.data.fieldsReturned).toEqual(['id', 'type']);
     });
+  });
 
-    it('должен вернуть пустой массив когда нет связей', async () => {
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([]);
+  describe('Logging', () => {
+    it('должен логировать начало batch операции', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+      ]);
 
-      const result = await tool.execute({ issueId: 'TEST-456', fields: ['id', 'type'] });
-
-      expect(result.isError).toBeUndefined();
-      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
-        success: boolean;
-        data: {
-          linksCount: number;
-          links: unknown[];
-        };
-      };
-      expect(parsed.data.linksCount).toBe(0);
-      expect(parsed.data.links).toEqual([]);
-    });
-
-    it('должен включить все поля связи в ответ', async () => {
-      const mockLinks = [createSubtaskLinkFixture()];
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
-
-      const result = await tool.execute({
-        issueId: 'TEST-100',
-        fields: ['id', 'type', 'direction', 'object', 'createdBy', 'createdAt'],
+      await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
       });
 
-      expect(result.isError).toBeUndefined();
-      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
-        success: boolean;
-        data: {
-          links: Array<{
-            id: string;
-            type: { id: string; inward: string; outward: string };
-            direction: string;
-            object: { id: string; key: string; display: string };
-            createdBy: { id: string; display: string };
-            createdAt: string;
-          }>;
-        };
-      };
-      expect(parsed.data.links[0]).toHaveProperty('id');
-      expect(parsed.data.links[0]).toHaveProperty('type');
-      expect(parsed.data.links[0]).toHaveProperty('direction');
-      expect(parsed.data.links[0]).toHaveProperty('object');
-      expect(parsed.data.links[0]).toHaveProperty('createdBy');
-      expect(parsed.data.links[0]).toHaveProperty('createdAt');
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Получение связей'),
+        expect.objectContaining({
+          itemsCount: 1,
+          fields: 2,
+        })
+      );
     });
 
-    it('должен обработать связи разных типов', async () => {
-      const mockLinks = [
-        createSubtaskLinkFixture({ id: 'link1' }),
-        createRelatesLinkFixture({ id: 'link2' }),
-      ];
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
+    it('должен логировать результаты batch операции', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+        {
+          status: 'fulfilled',
+          key: 'TEST-456',
+          index: 1,
+          value: [],
+        },
+      ]);
 
-      const result = await tool.execute({ issueId: 'TEST-200', fields: ['id', 'type'] });
-
-      expect(result.isError).toBeUndefined();
-      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
-        success: boolean;
-        data: {
-          links: Array<{ type: { id: string } }>;
-        };
-      };
-      expect(parsed.data.links[0]!.type.id).toBe('subtask');
-      expect(parsed.data.links[1]!.type.id).toBe('relates');
-    });
-
-    it('должен включить updatedBy и updatedAt если они есть', async () => {
-      const mockLinks = [
-        createSubtaskLinkFixture({
-          updatedBy: {
-            self: 'https://api.tracker.yandex.net/v3/users/123',
-            id: '123',
-            display: 'Updater',
-          },
-          updatedAt: '2025-01-19T12:00:00.000+0000',
-        }),
-      ];
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
-
-      const result = await tool.execute({
-        issueId: 'TEST-300',
-        fields: ['id', 'updatedBy', 'updatedAt'],
+      await tool.execute({
+        issueIds: ['TEST-123', 'TEST-456'],
+        fields: ['id', 'type'],
       });
 
-      expect(result.isError).toBeUndefined();
-      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
-        success: boolean;
-        data: {
-          links: Array<{
-            updatedBy?: { id: string; display: string };
-            updatedAt?: string;
-          }>;
-        };
-      };
-      expect(parsed.data.links[0]).toHaveProperty('updatedBy');
-      expect(parsed.data.links[0]).toHaveProperty('updatedAt');
-      expect(parsed.data.links[0]!.updatedBy?.id).toBe('123');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Связи задач получены'),
+        expect.objectContaining({
+          successful: 2,
+          failed: 0,
+          fieldsCount: 2,
+        })
+      );
     });
+  });
 
-    it('должен обработать ошибку от facade', async () => {
-      const error = new Error('Failed to get links');
+  describe('Error handling', () => {
+    it('должен обработать ошибки от facade', async () => {
+      const error = new Error('API Error');
       vi.mocked(mockTrackerFacade.getIssueLinks).mockRejectedValue(error);
 
-      const result = await tool.execute({ issueId: 'TEST-123', fields: ['id', 'type'] });
+      const result = await tool.execute({
+        issueIds: ['TEST-123'],
+        fields: ['id', 'type'],
+      });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('Ошибка');
+      expect(result.content[0]?.text).toContain('Ошибка при получении связей задач');
     });
 
-    it('должен логировать информацию о получении связей', async () => {
-      const mockLinks = createLinkListFixture(5);
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
+    it('должен обработать частичные ошибки (partial failures)', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'fulfilled',
+          key: 'TEST-123',
+          index: 0,
+          value: mockLinks,
+        },
+        {
+          status: 'rejected',
+          key: 'TEST-456',
+          index: 1,
+          reason: new Error('Not found'),
+        },
+      ]);
 
-      await tool.execute({ issueId: 'TEST-789', fields: ['id', 'type', 'object'] });
-
-      expect(mockLogger.info).toHaveBeenCalledWith('Получение связей задачи TEST-789');
-      expect(mockLogger.info).toHaveBeenCalledWith('Получено 5 связей для задачи TEST-789');
-    });
-
-    it('должен работать с разными форматами ключей задач', async () => {
-      const mockLinks = createLinkListFixture(1);
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
-
-      const result = await tool.execute({ issueId: 'ABC-123', fields: ['id', 'type'] });
-
-      expect(result.isError).toBeUndefined();
-      expect(mockTrackerFacade.getIssueLinks).toHaveBeenCalledWith('ABC-123');
-    });
-
-    it('должен обработать большое количество связей', async () => {
-      const mockLinks = createLinkListFixture(100);
-      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue(mockLinks);
-
-      const result = await tool.execute({ issueId: 'TEST-999', fields: ['id', 'type'] });
+      const result = await tool.execute({
+        issueIds: ['TEST-123', 'TEST-456'],
+        fields: ['id', 'type'],
+      });
 
       expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content[0]?.text || '{}') as {
         success: boolean;
         data: {
-          linksCount: number;
+          total: number;
+          successful: unknown[];
+          failed: unknown[];
         };
       };
-      expect(parsed.data.linksCount).toBe(100);
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.successful).toHaveLength(1);
+      expect(parsed.data.failed).toHaveLength(1);
+    });
+
+    it('должен обработать полный провал всех запросов', async () => {
+      vi.mocked(mockTrackerFacade.getIssueLinks).mockResolvedValue([
+        {
+          status: 'rejected',
+          key: 'TEST-123',
+          index: 0,
+          reason: new Error('Not found'),
+        },
+        {
+          status: 'rejected',
+          key: 'TEST-456',
+          index: 1,
+          reason: new Error('Access denied'),
+        },
+      ]);
+
+      const result = await tool.execute({
+        issueIds: ['TEST-123', 'TEST-456'],
+        fields: ['id', 'type'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          total: number;
+          successful: unknown[];
+          failed: unknown[];
+        };
+      };
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.successful).toHaveLength(0);
+      expect(parsed.data.failed).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
Обновлены unit-тесты для get-issue-links.tool.test.ts по образцу get-comments.tool.test.ts:

- Использование batch API (issueIds вместо issueId)
- Тестирование unified batch result format
- Добавлены тесты для частичных ошибок (partial failures)
- Добавлены тесты для полного провала всех запросов
- Проверка фильтрации полей в batch результатах
- Проверка логирования batch операций

Прогресс плана batch_operations (1.2):
- [x] Шаг 8: Tool unit tests обновлены

🤖 Generated with Claude Code