### PR TITLE
Continue batch operations implementation stage 2.1

### DIFF
--- a/.agentic-planning/plan_batch_operations/2.3_delete_link_batch_parallel.md
+++ b/.agentic-planning/plan_batch_operations/2.3_delete_link_batch_parallel.md
@@ -8,12 +8,12 @@
 
 ## ✅ Чек-лист
 
-- [ ] Обновить schema для массива links
-- [ ] Batch operation: executeMany()
-- [ ] Tool: unified batch result
-- [ ] Facade/service methods
-- [ ] Unit-тесты
-- [ ] Валидация и коммит
+- [x] Обновить schema для массива links
+- [x] Batch operation: executeMany()
+- [x] Tool: unified batch result (ручная обработка void)
+- [x] Facade/service methods
+- [x] Unit-тесты
+- [x] Валидация и коммит
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/issues/links/delete/delete-link.schema.ts
@@ -6,18 +6,31 @@ import { z } from 'zod';
 import { IssueKeySchema } from '#common/schemas/index.js';
 
 /**
- * Схема параметров для удаления связи
+ * Схема параметров для удаления связи (batch-режим)
+ *
+ * Паттерн POST/DELETE операций: Input Pattern - индивидуальные параметры
+ * Каждая задача имеет свои параметры (issueId, linkId)
  */
 export const DeleteLinkParamsSchema = z.object({
   /**
-   * Ключ или ID задачи
+   * Массив связей для удаления с индивидуальными параметрами
    */
-  issueId: IssueKeySchema,
+  links: z
+    .array(
+      z.object({
+        /**
+         * Идентификатор или ключ задачи (обязательно)
+         */
+        issueId: IssueKeySchema.describe('Issue ID or key (e.g., TEST-123)'),
 
-  /**
-   * ID связи для удаления
-   */
-  linkId: z.string().min(1, 'linkId не может быть пустым'),
+        /**
+         * ID связи для удаления (обязательно)
+         */
+        linkId: z.string().min(1, 'linkId не может быть пустым'),
+      })
+    )
+    .min(1, 'Массив links должен содержать минимум 1 элемент')
+    .describe('Array of links to delete'),
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/services/issue-link.service.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/services/issue-link.service.ts
@@ -25,6 +25,7 @@ import { CreateLinkOperation } from '#tracker_api/api_operations/link/create-lin
 import { DeleteLinkOperation } from '#tracker_api/api_operations/link/delete-link.operation.js';
 import type { LinkWithUnknownFields } from '#tracker_api/entities/link.entity.js';
 import type { CreateLinkDto } from '#tracker_api/dto/link/create-link.dto.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
 
 @injectable()
 export class IssueLinkService {
@@ -60,5 +61,16 @@ export class IssueLinkService {
    */
   async deleteLink(issueId: string, linkId: string): Promise<void> {
     return this.deleteOp.execute(issueId, linkId);
+  }
+
+  /**
+   * Удаляет связи из нескольких задач параллельно
+   * @param links - массив связей для удаления с индивидуальными параметрами
+   * @returns массив результатов в формате BatchResult
+   */
+  async deleteLinksMany(
+    links: Array<{ issueId: string; linkId: string }>
+  ): Promise<BatchResult<string, void>> {
+    return this.deleteOp.executeMany(links);
   }
 }

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -399,6 +399,17 @@ export class YandexTrackerFacade {
     return this.issueLinkService.deleteLink(issueId, linkId);
   }
 
+  /**
+   * Удаляет связи из нескольких задач параллельно
+   * @param links - массив связей для удаления с индивидуальными параметрами
+   * @returns массив результатов в формате BatchResult
+   */
+  async deleteLinksMany(
+    links: Array<{ issueId: string; linkId: string }>
+  ): Promise<BatchResult<string, void>> {
+    return this.issueLinkService.deleteLinksMany(links);
+  }
+
   // === Comment Methods ===
 
   /**

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/link/delete-link.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/link/delete-link.operation.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IHttpClient } from '@mcp-framework/infrastructure/http/client/i-http-client.interface.js';
 import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-manager.interface.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
+import type { ServerConfig } from '#config';
 import { DeleteLinkOperation } from '#tracker_api/api_operations/link/delete-link.operation.js';
 
 describe('DeleteLinkOperation', () => {
@@ -9,6 +10,7 @@ describe('DeleteLinkOperation', () => {
   let mockHttpClient: IHttpClient;
   let mockCacheManager: CacheManager;
   let mockLogger: Logger;
+  let mockConfig: ServerConfig;
 
   beforeEach(() => {
     mockHttpClient = {
@@ -35,7 +37,12 @@ describe('DeleteLinkOperation', () => {
       debug: vi.fn(),
     } as unknown as Logger;
 
-    operation = new DeleteLinkOperation(mockHttpClient, mockCacheManager, mockLogger);
+    mockConfig = {
+      maxBatchSize: 100,
+      maxConcurrentRequests: 5,
+    } as ServerConfig;
+
+    operation = new DeleteLinkOperation(mockHttpClient, mockCacheManager, mockLogger, mockConfig);
   });
 
   describe('execute', () => {
@@ -125,6 +132,115 @@ describe('DeleteLinkOperation', () => {
       await operation.execute('PROJ-2', 'link-b');
 
       expect(mockHttpClient.delete).toHaveBeenCalledTimes(2);
+      expect(mockCacheManager.delete).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('executeMany', () => {
+    it('should delete multiple links in parallel', async () => {
+      vi.mocked(mockHttpClient.delete).mockResolvedValue(undefined);
+
+      const links = [
+        { issueId: 'TEST-1', linkId: 'link1' },
+        { issueId: 'TEST-2', linkId: 'link2' },
+        { issueId: 'TEST-3', linkId: 'link3' },
+      ];
+
+      const result = await operation.executeMany(links);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].status).toBe('fulfilled');
+      expect(result[0].key).toBe('TEST-1:link1');
+      expect(result[1].status).toBe('fulfilled');
+      expect(result[1].key).toBe('TEST-2:link2');
+      expect(result[2].status).toBe('fulfilled');
+      expect(result[2].key).toBe('TEST-3:link3');
+
+      // Проверяем, что все API вызовы были сделаны
+      expect(mockHttpClient.delete).toHaveBeenCalledTimes(3);
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/v3/issues/TEST-1/links/link1');
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/v3/issues/TEST-2/links/link2');
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/v3/issues/TEST-3/links/link3');
+    });
+
+    it('should handle partial failures (some succeed, some fail)', async () => {
+      vi.mocked(mockHttpClient.delete)
+        .mockResolvedValueOnce(undefined) // TEST-1:link1 - success
+        .mockRejectedValueOnce(new Error('Link not found')) // TEST-2:link2 - fail
+        .mockResolvedValueOnce(undefined); // TEST-3:link3 - success
+
+      const links = [
+        { issueId: 'TEST-1', linkId: 'link1' },
+        { issueId: 'TEST-2', linkId: 'link2' },
+        { issueId: 'TEST-3', linkId: 'link3' },
+      ];
+
+      const result = await operation.executeMany(links);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].status).toBe('fulfilled');
+      expect(result[0].key).toBe('TEST-1:link1');
+      expect(result[1].status).toBe('rejected');
+      expect(result[1].key).toBe('TEST-2:link2');
+      if (result[1].status === 'rejected') {
+        expect(result[1].reason.message).toBe('Link not found');
+      }
+      expect(result[2].status).toBe('fulfilled');
+      expect(result[2].key).toBe('TEST-3:link3');
+    });
+
+    it('should handle empty array', async () => {
+      const result = await operation.executeMany([]);
+
+      expect(result).toHaveLength(0);
+      expect(mockHttpClient.delete).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith('DeleteLinkOperation: пустой массив связей');
+    });
+
+    it('should delete links from same issue with different link IDs', async () => {
+      vi.mocked(mockHttpClient.delete).mockResolvedValue(undefined);
+
+      const links = [
+        { issueId: 'TEST-100', linkId: 'link1' },
+        { issueId: 'TEST-100', linkId: 'link2' },
+        { issueId: 'TEST-100', linkId: 'link3' },
+      ];
+
+      const result = await operation.executeMany(links);
+
+      expect(result).toHaveLength(3);
+      expect(result.every((r) => r.status === 'fulfilled')).toBe(true);
+      expect(result[0].key).toBe('TEST-100:link1');
+      expect(result[1].key).toBe('TEST-100:link2');
+      expect(result[2].key).toBe('TEST-100:link3');
+    });
+
+    it('should log batch operation info', async () => {
+      vi.mocked(mockHttpClient.delete).mockResolvedValue(undefined);
+
+      const links = [
+        { issueId: 'TEST-1', linkId: 'link1' },
+        { issueId: 'TEST-2', linkId: 'link2' },
+      ];
+
+      await operation.executeMany(links);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Удаление 2 связей параллельно: TEST-1/link1, TEST-2/link2'
+      );
+    });
+
+    it('should invalidate cache for all deleted links', async () => {
+      vi.mocked(mockHttpClient.delete).mockResolvedValue(undefined);
+
+      const links = [
+        { issueId: 'TEST-1', linkId: 'link1' },
+        { issueId: 'TEST-2', linkId: 'link2' },
+      ];
+
+      await operation.executeMany(links);
+
+      // Кеш должен быть инвалидирован для каждой задачи
       expect(mockCacheManager.delete).toHaveBeenCalledTimes(2);
     });
   });


### PR DESCRIPTION
Детали:
- Обновлена schema для массива links (Input Pattern)
- Реализован DeleteLinkOperation.executeMany() с ParallelExecutor
- Ручная обработка void результатов (BatchResultProcessor не поддерживает)
- Добавлены deleteLinksMany() в IssueLinkService и YandexTrackerFacade
- Обновлены unit и integration тесты для batch формата
- Ключ результата: "issueId:linkId"

Результат:
- DELETE операции возвращают void
- Unified batch result format
- Parallel execution для множественного удаления связей

🤖 Generated with Claude Code