### PR TITLE
Continue batch operations plan stage 2.3

### DIFF
--- a/.agentic-planning/plan_batch_operations/3.1_get_worklogs_batch_parallel.md
+++ b/.agentic-planning/plan_batch_operations/3.1_get_worklogs_batch_parallel.md
@@ -8,12 +8,12 @@
 
 ## ✅ Чек-лист
 
-- [ ] Schema: issueId → issueIds
-- [ ] Batch operation: executeMany()
-- [ ] Tool: unified batch result
-- [ ] Facade/service methods
-- [ ] Unit-тесты
-- [ ] Валидация и коммит
+- [x] Schema: issueId → issueIds
+- [x] Batch operation: executeMany()
+- [x] Tool: unified batch result
+- [x] Facade/service methods
+- [x] Unit-тесты
+- [x] Валидация и коммит
 
 ---
 

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.metadata.ts
@@ -17,11 +17,11 @@ import { MCP_TOOL_PREFIX } from '#constants';
  */
 export const GET_WORKLOGS_TOOL_METADATA: StaticToolMetadata = {
   name: buildToolName('get_worklogs', MCP_TOOL_PREFIX),
-  description: '[Worklog/Read] Получить записи времени задачи',
+  description: '[Worklog/Read] Получить записи времени задач (batch)',
   category: ToolCategory.ISSUES,
   subcategory: 'worklog',
   priority: ToolPriority.HIGH,
-  tags: ['worklog', 'get', 'list', 'read', 'time'],
+  tags: ['worklog', 'get', 'list', 'read', 'time', 'batch'],
   isHelper: false,
   requiresExplicitUserConsent: false,
 } as const;

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.schema.ts
@@ -3,16 +3,16 @@
  */
 
 import { z } from 'zod';
-import { IssueKeySchema, FieldsSchema } from '#common/schemas/index.js';
+import { IssueKeysSchema, FieldsSchema } from '#common/schemas/index.js';
 
 /**
- * Схема параметров для получения записей времени
+ * Схема параметров для получения записей времени (batch режим)
  */
 export const GetWorklogsParamsSchema = z.object({
   /**
-   * Идентификатор или ключ задачи (обязательно)
+   * Массив идентификаторов или ключей задач (обязательно)
    */
-  issueId: IssueKeySchema.describe('Issue ID or key (e.g., TEST-123)'),
+  issueIds: IssueKeysSchema.describe("Array of issue IDs or keys (e.g., ['TEST-123', 'TEST-456'])"),
 
   /**
    * Поля, которые нужно вернуть (обязательно)

--- a/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.tool.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/worklog/get/get-worklogs.tool.ts
@@ -1,13 +1,18 @@
 /**
- * MCP Tool для получения записей времени задачи
+ * MCP Tool для получения записей времени задач
  *
  * API Tool (прямой доступ к API):
- * - 1 tool = 1 API вызов (get worklogs)
+ * - 1 tool = batch API вызов (get worklogs for multiple issues)
  * - Минимальная бизнес-логика
  * - Валидация через Zod
  */
 
-import { BaseTool, ResponseFieldFilter } from '@mcp-framework/core';
+import {
+  BaseTool,
+  ResponseFieldFilter,
+  BatchResultProcessor,
+  ResultLogger,
+} from '@mcp-framework/core';
 import type { YandexTrackerFacade } from '#tracker_api/facade/index.js';
 import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
 import type { WorklogWithUnknownFields } from '#tracker_api/entities/index.js';
@@ -16,11 +21,13 @@ import { GetWorklogsParamsSchema } from '#tools/api/worklog/get/get-worklogs.sch
 import { GET_WORKLOGS_TOOL_METADATA } from './get-worklogs.metadata.js';
 
 /**
- * Инструмент для получения записей времени задачи
+ * Инструмент для получения записей времени задач (batch-режим)
  *
  * Ответственность (SRP):
- * - Координация процесса получения записей времени
+ * - Координация процесса получения записей времени для нескольких задач
  * - Делегирование валидации в BaseTool
+ * - Делегирование обработки результатов в BatchResultProcessor
+ * - Делегирование логирования в ResultLogger
  * - Форматирование итогового результата
  */
 export class GetWorklogsTool extends BaseTool<YandexTrackerFacade> {
@@ -43,34 +50,62 @@ export class GetWorklogsTool extends BaseTool<YandexTrackerFacade> {
       return validation.error;
     }
 
-    const { issueId, fields } = validation.data;
+    const { issueIds, fields } = validation.data;
 
     try {
       // 2. Логирование начала операции
-      this.logger.info('Получение записей времени задачи', {
-        issueId,
-      });
-
-      // 3. API v2: получение записей времени
-      const worklogs = await this.facade.getWorklogs(issueId);
-
-      // 4. Фильтрация полей ответа
-      const filteredWorklogs = worklogs.map((worklog) =>
-        ResponseFieldFilter.filter<WorklogWithUnknownFields>(worklog, fields)
+      ResultLogger.logOperationStart(
+        this.logger,
+        'Получение записей времени',
+        issueIds.length,
+        fields
       );
 
-      // 5. Логирование результата
-      this.logger.info('Записи времени успешно получены', {
-        issueId,
-        worklogsCount: worklogs.length,
-      });
+      // 3. API v2: получение записей времени через batch-метод
+      const results = await this.facade.getWorklogsMany(issueIds);
+
+      // 4. Обработка результатов через BatchResultProcessor
+      const processedResults = BatchResultProcessor.process(
+        results,
+        (worklogs: WorklogWithUnknownFields[]): Partial<WorklogWithUnknownFields>[] =>
+          worklogs.map((worklog) =>
+            ResponseFieldFilter.filter<WorklogWithUnknownFields>(worklog, fields)
+          )
+      );
+
+      // 5. Логирование результатов
+      ResultLogger.logBatchResults(
+        this.logger,
+        'Записи времени получены',
+        {
+          totalRequested: issueIds.length,
+          successCount: processedResults.successful.length,
+          failedCount: processedResults.failed.length,
+          fieldsCount: fields.length,
+        },
+        processedResults
+      );
 
       return this.formatSuccess({
-        data: filteredWorklogs,
+        total: issueIds.length,
+        successful: processedResults.successful.length,
+        failed: processedResults.failed.length,
+        worklogs: processedResults.successful.map((item) => ({
+          issueId: item.key,
+          worklogs: item.data,
+          count: item.data.length,
+        })),
+        errors: processedResults.failed.map((item) => ({
+          issueId: item.key,
+          error: item.error,
+        })),
         fieldsReturned: fields,
       });
     } catch (error: unknown) {
-      return this.formatError(`Ошибка при получении записей времени задачи ${issueId}`, error);
+      return this.formatError(
+        `Ошибка при получении записей времени (${issueIds.length} задач)`,
+        error
+      );
     }
   }
 }

--- a/packages/servers/yandex-tracker/src/tools/generated-index.ts
+++ b/packages/servers/yandex-tracker/src/tools/generated-index.ts
@@ -222,8 +222,8 @@ export const TOOL_SEARCH_INDEX: readonly StaticToolIndex[] = [
     tags: ['comment', 'add', 'create', 'write', 'batch'],
     isHelper: false,
     nameTokens: ['fr', 'yandex', 'tracker', 'add', 'comment'],
-    descriptionTokens: ['comments', 'write'],
-    descriptionShort: '[Comments/Write] Добавить комментарии к одной или нескольким задачам',
+    descriptionTokens: ['comments', 'write', 'batch'],
+    descriptionShort: '[Comments/Write] Добавить комментарии к задачам (batch)',
   },
   {
     name: 'fr_yandex_tracker_get_comments',

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/worklog/get-worklogs.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/worklog/get-worklogs.operation.ts
@@ -2,16 +2,35 @@
  * Операция получения списка записей времени задачи
  *
  * Ответственность (SRP):
- * - ТОЛЬКО получение записей времени задачи
+ * - ТОЛЬКО получение записей времени задачи (single и batch режимы)
+ * - Параллельное выполнение через ParallelExecutor (batch режим)
  * - НЕТ добавления/редактирования/удаления записей
  *
  * API: GET /v2/issues/{issueId}/worklog
  */
 
 import { BaseOperation } from '#tracker_api/api_operations/base-operation.js';
+import { ParallelExecutor } from '@mcp-framework/infrastructure';
 import type { WorklogWithUnknownFields } from '#tracker_api/entities/index.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
+import type { ServerConfig } from '#config';
 
 export class GetWorklogsOperation extends BaseOperation {
+  private readonly parallelExecutor: ParallelExecutor;
+
+  constructor(
+    httpClient: ConstructorParameters<typeof BaseOperation>[0],
+    cacheManager: ConstructorParameters<typeof BaseOperation>[1],
+    logger: ConstructorParameters<typeof BaseOperation>[2],
+    config: ServerConfig
+  ) {
+    super(httpClient, cacheManager, logger);
+
+    this.parallelExecutor = new ParallelExecutor(logger, {
+      maxBatchSize: config.maxBatchSize,
+      maxConcurrentRequests: config.maxConcurrentRequests,
+    });
+  }
   /**
    * Получает список записей времени задачи
    *
@@ -36,5 +55,40 @@ export class GetWorklogsOperation extends BaseOperation {
     );
 
     return Array.isArray(worklogs) ? worklogs : [worklogs];
+  }
+
+  /**
+   * Получает записи времени для нескольких задач параллельно
+   *
+   * @param issueIds - массив идентификаторов задач
+   * @returns массив результатов в формате BatchResult
+   * @throws {Error} если количество задач превышает maxBatchSize
+   *
+   * ВАЖНО:
+   * - Использует ParallelExecutor для соблюдения maxConcurrentRequests
+   * - Retry делается автоматически в HttpClient.get
+   */
+  async executeMany(issueIds: string[]): Promise<BatchResult<string, WorklogWithUnknownFields[]>> {
+    // Проверка на пустой массив
+    if (issueIds.length === 0) {
+      this.logger.warn('GetWorklogsOperation: пустой массив идентификаторов');
+      return [];
+    }
+
+    this.logger.info(
+      `Получение записей времени для ${issueIds.length} задач параллельно: ${issueIds.join(', ')}`
+    );
+
+    // Создаём операции для каждой задачи
+    const operations = issueIds.map((issueId) => ({
+      key: issueId,
+      fn: async (): Promise<WorklogWithUnknownFields[]> => {
+        // Вызываем существующий метод execute() для каждой задачи
+        return this.execute(issueId);
+      },
+    }));
+
+    // Выполняем через ParallelExecutor (централизованный throttling)
+    return this.parallelExecutor.executeParallel(operations, 'get worklogs');
   }
 }

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/services/worklog.service.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/services/worklog.service.ts
@@ -24,6 +24,7 @@ import { UpdateWorklogOperation } from '#tracker_api/api_operations/worklog/upda
 import { DeleteWorklogOperation } from '#tracker_api/api_operations/worklog/delete-worklog.operation.js';
 import type { AddWorklogInput, UpdateWorklogInput } from '#tracker_api/dto/index.js';
 import type { WorklogWithUnknownFields } from '#tracker_api/entities/index.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
 
 @injectable()
 export class WorklogService {
@@ -45,6 +46,17 @@ export class WorklogService {
    */
   async getWorklogs(issueId: string): Promise<WorklogWithUnknownFields[]> {
     return this.getWorklogsOp.execute(issueId);
+  }
+
+  /**
+   * Получает записи времени для нескольких задач параллельно
+   * @param issueIds - массив идентификаторов задач
+   * @returns результаты в формате BatchResult
+   */
+  async getWorklogsMany(
+    issueIds: string[]
+  ): Promise<BatchResult<string, WorklogWithUnknownFields[]>> {
+    return this.getWorklogsOp.executeMany(issueIds);
   }
 
   /**

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -557,6 +557,17 @@ export class YandexTrackerFacade {
   }
 
   /**
+   * Получает записи времени для нескольких задач параллельно
+   * @param issueIds - массив идентификаторов задач
+   * @returns результаты в формате BatchResult
+   */
+  async getWorklogsMany(
+    issueIds: string[]
+  ): Promise<BatchResult<string, WorklogWithUnknownFields[]>> {
+    return this.worklogService.getWorklogsMany(issueIds);
+  }
+
+  /**
    * Добавляет запись времени к задаче
    * @param issueId - идентификатор или ключ задачи
    * @param input - данные записи времени

--- a/packages/servers/yandex-tracker/tests/tracker_api/api_operations/worklog/get-worklogs.operation.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/api_operations/worklog/get-worklogs.operation.test.ts
@@ -3,6 +3,7 @@ import type { IHttpClient } from '@mcp-framework/infrastructure/http/client/i-ht
 import type { CacheManager } from '@mcp-framework/infrastructure/cache/cache-manager.interface.js';
 import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
 import type { WorklogWithUnknownFields } from '#tracker_api/entities/index.js';
+import type { ServerConfig } from '#config';
 import { GetWorklogsOperation } from '#tracker_api/api_operations/worklog/get-worklogs.operation.js';
 
 describe('GetWorklogsOperation', () => {
@@ -10,6 +11,7 @@ describe('GetWorklogsOperation', () => {
   let mockHttpClient: IHttpClient;
   let mockCacheManager: CacheManager;
   let mockLogger: Logger;
+  let mockConfig: ServerConfig;
 
   beforeEach(() => {
     mockHttpClient = {
@@ -36,7 +38,12 @@ describe('GetWorklogsOperation', () => {
       debug: vi.fn(),
     } as unknown as Logger;
 
-    operation = new GetWorklogsOperation(mockHttpClient, mockCacheManager, mockLogger);
+    mockConfig = {
+      maxBatchSize: 100,
+      maxConcurrentRequests: 5,
+    } as ServerConfig;
+
+    operation = new GetWorklogsOperation(mockHttpClient, mockCacheManager, mockLogger, mockConfig);
   });
 
   describe('execute', () => {
@@ -211,6 +218,151 @@ describe('GetWorklogsOperation', () => {
       expect(result).toHaveLength(0);
       expect(mockLogger.info).toHaveBeenCalledWith('Получение записей времени задачи TEST-1');
       expect(mockLogger.info).toHaveBeenCalledWith('Получено 0 записей времени для задачи TEST-1');
+    });
+  });
+
+  describe('executeMany', () => {
+    it('should get worklogs for multiple issues in parallel', async () => {
+      const mockWorklogs1: WorklogWithUnknownFields[] = [
+        {
+          id: '1',
+          self: 'https://api.tracker.yandex.net/v2/issues/TEST-1/worklog/1',
+          issue: {
+            id: 'abc123',
+            key: 'TEST-1',
+            display: 'Test issue',
+          },
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v2/users/1',
+            id: '1',
+            display: 'User 1',
+          },
+          createdAt: '2025-01-18T10:00:00.000+0000',
+          start: '2025-01-18T09:00:00.000+0000',
+          duration: 'PT1H30M',
+        },
+      ];
+
+      const mockWorklogs2: WorklogWithUnknownFields[] = [
+        {
+          id: '2',
+          self: 'https://api.tracker.yandex.net/v2/issues/TEST-2/worklog/2',
+          issue: {
+            id: 'xyz456',
+            key: 'TEST-2',
+            display: 'Another test issue',
+          },
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v2/users/2',
+            id: '2',
+            display: 'User 2',
+          },
+          createdAt: '2025-01-18T11:00:00.000+0000',
+          start: '2025-01-18T10:00:00.000+0000',
+          duration: 'PT2H',
+        },
+      ];
+
+      vi.mocked(mockHttpClient.get)
+        .mockResolvedValueOnce(mockWorklogs1)
+        .mockResolvedValueOnce(mockWorklogs2);
+
+      const results = await operation.executeMany(['TEST-1', 'TEST-2']);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({
+        status: 'fulfilled',
+        key: 'TEST-1',
+        index: 0,
+        value: mockWorklogs1,
+      });
+      expect(results[1]).toEqual({
+        status: 'fulfilled',
+        key: 'TEST-2',
+        index: 1,
+        value: mockWorklogs2,
+      });
+    });
+
+    it('should handle partial failures', async () => {
+      const mockWorklogs1: WorklogWithUnknownFields[] = [
+        {
+          id: '1',
+          self: 'https://api.tracker.yandex.net/v2/issues/TEST-1/worklog/1',
+          issue: {
+            id: 'abc123',
+            key: 'TEST-1',
+            display: 'Test issue',
+          },
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v2/users/1',
+            id: '1',
+            display: 'User 1',
+          },
+          createdAt: '2025-01-18T10:00:00.000+0000',
+          start: '2025-01-18T09:00:00.000+0000',
+          duration: 'PT1H',
+        },
+      ];
+
+      const error = new Error('API Error for TEST-2');
+
+      vi.mocked(mockHttpClient.get)
+        .mockResolvedValueOnce(mockWorklogs1)
+        .mockRejectedValueOnce(error);
+
+      const results = await operation.executeMany(['TEST-1', 'TEST-2']);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].status).toBe('fulfilled');
+      expect(results[0].key).toBe('TEST-1');
+      if (results[0].status === 'fulfilled') {
+        expect(results[0].value).toEqual(mockWorklogs1);
+      }
+      expect(results[1].status).toBe('rejected');
+      expect(results[1].key).toBe('TEST-2');
+      if (results[1].status === 'rejected') {
+        expect(results[1].reason.message).toBe('API Error for TEST-2');
+      }
+    });
+
+    it('should return empty array for empty input', async () => {
+      const results = await operation.executeMany([]);
+
+      expect(results).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'GetWorklogsOperation: пустой массив идентификаторов'
+      );
+    });
+
+    it('should log batch operation info', async () => {
+      const mockWorklogs: WorklogWithUnknownFields[] = [
+        {
+          id: '1',
+          self: 'https://api.tracker.yandex.net/v2/issues/TEST-1/worklog/1',
+          issue: {
+            id: 'abc123',
+            key: 'TEST-1',
+            display: 'Test issue',
+          },
+          createdBy: {
+            self: 'https://api.tracker.yandex.net/v2/users/1',
+            id: '1',
+            display: 'User 1',
+          },
+          createdAt: '2025-01-18T10:00:00.000+0000',
+          start: '2025-01-18T09:00:00.000+0000',
+          duration: 'PT1H',
+        },
+      ];
+
+      vi.mocked(mockHttpClient.get).mockResolvedValue(mockWorklogs);
+
+      await operation.executeMany(['TEST-1', 'TEST-2']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Получение записей времени для 2 задач параллельно: TEST-1, TEST-2'
+      );
     });
   });
 });


### PR DESCRIPTION
Детали:
- Schema: issueId → issueIds (IssueKeysSchema)
- Operation: добавлен метод executeMany() с ParallelExecutor
- Tool: обновлен для unified batch result format
- Facade/Service: добавлены методы getWorklogsMany()
- Metadata: добавлен тег 'batch'
- Tests: добавлены unit-тесты для executeMany()

Breaking Changes:
- Параметр `issueId` переименован в `issueIds` (массив)
- Формат ответа изменен на unified batch format

Этап 3.1 плана batch_operations (средний приоритет - GET операции)

🤖 Generated with Claude Code