### PR TITLE
Add batch support for delete checklist item

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.metadata.ts
@@ -17,11 +17,11 @@ import { MCP_TOOL_PREFIX } from '#constants';
  */
 export const DELETE_CHECKLIST_ITEM_TOOL_METADATA: StaticToolMetadata = {
   name: buildToolName('delete_checklist_item', MCP_TOOL_PREFIX),
-  description: '[Checklist/Write] Удалить элемент из чеклиста',
+  description: '[Checklist/Write] Удалить элементы из чеклистов (batch)',
   category: ToolCategory.CHECKLISTS,
   subcategory: 'write',
   priority: ToolPriority.HIGH,
-  tags: ['checklist', 'delete', 'remove', 'write'],
+  tags: ['checklist', 'delete', 'remove', 'write', 'batch'],
   isHelper: false,
   requiresExplicitUserConsent: true,
 } as const;

--- a/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.schema.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/delete/delete-checklist-item.schema.ts
@@ -1,14 +1,14 @@
 /**
- * Zod схема для валидации параметров DeleteChecklistItemTool
+ * Zod схема для валидации параметров DeleteChecklistItemTool (batch-режим)
  */
 
 import { z } from 'zod';
 import { IssueKeySchema } from '#common/schemas/index.js';
 
 /**
- * Схема параметров для удаления элемента чеклиста
+ * Схема элемента чеклиста для удаления
  */
-export const DeleteChecklistItemParamsSchema = z.object({
+const DeleteChecklistItemSchema = z.object({
   /**
    * Идентификатор или ключ задачи (обязательно)
    */
@@ -17,7 +17,23 @@ export const DeleteChecklistItemParamsSchema = z.object({
   /**
    * Идентификатор элемента чеклиста (обязательно)
    */
-  checklistItemId: z.string().min(1, 'ID элемента не может быть пустым'),
+  itemId: z.string().min(1, 'ID элемента не может быть пустым'),
+});
+
+/**
+ * Схема параметров для удаления элементов из чеклистов (batch-режим)
+ *
+ * Паттерн DELETE операций: Input Pattern - индивидуальные параметры
+ * Каждый элемент имеет свои параметры (issueId, itemId)
+ */
+export const DeleteChecklistItemParamsSchema = z.object({
+  /**
+   * Массив элементов чеклиста для удаления
+   */
+  items: z
+    .array(DeleteChecklistItemSchema)
+    .min(1, 'Массив items должен содержать минимум 1 элемент')
+    .describe('Array of checklist items to delete'),
 });
 
 /**

--- a/packages/servers/yandex-tracker/src/tools/generated-index.ts
+++ b/packages/servers/yandex-tracker/src/tools/generated-index.ts
@@ -316,11 +316,11 @@ export const TOOL_SEARCH_INDEX: readonly StaticToolIndex[] = [
   {
     name: 'fr_yandex_tracker_delete_checklist_item',
     category: ToolCategory.CHECKLISTS,
-    tags: ['checklist', 'delete', 'remove', 'write'],
+    tags: ['checklist', 'delete', 'remove', 'write', 'batch'],
     isHelper: false,
     nameTokens: ['fr', 'yandex', 'tracker', 'delete', 'checklist', 'item'],
-    descriptionTokens: ['checklist', 'write'],
-    descriptionShort: '[Checklist/Write] Удалить элемент из чеклиста',
+    descriptionTokens: ['checklist', 'write', 'batch'],
+    descriptionShort: '[Checklist/Write] Удалить элементы из чеклистов (batch)',
   },
   {
     name: 'fr_yandex_tracker_get_projects',

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/checklist/delete-checklist-item.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/checklist/delete-checklist-item.operation.ts
@@ -2,15 +2,35 @@
  * Операция удаления элемента чеклиста
  *
  * Ответственность (SRP):
- * - ТОЛЬКО удаление элемента из чеклиста
+ * - ТОЛЬКО удаление элемента из чеклиста (single и batch режимы)
+ * - Параллельное выполнение через ParallelExecutor (batch режим)
  * - НЕТ добавления/получения/редактирования элементов
  *
  * API: DELETE /v2/issues/{issueId}/checklistItems/{checklistItemId}
  */
 
 import { BaseOperation } from '#tracker_api/api_operations/base-operation.js';
+import { ParallelExecutor } from '@mcp-framework/infrastructure';
+import type { BatchResult } from '@mcp-framework/infrastructure';
+import type { ServerConfig } from '#config';
 
 export class DeleteChecklistItemOperation extends BaseOperation {
+  private readonly parallelExecutor: ParallelExecutor;
+
+  constructor(
+    httpClient: ConstructorParameters<typeof BaseOperation>[0],
+    cacheManager: ConstructorParameters<typeof BaseOperation>[1],
+    logger: ConstructorParameters<typeof BaseOperation>[2],
+    config: ServerConfig
+  ) {
+    super(httpClient, cacheManager, logger);
+
+    this.parallelExecutor = new ParallelExecutor(logger, {
+      maxBatchSize: config.maxBatchSize,
+      maxConcurrentRequests: config.maxConcurrentRequests,
+    });
+  }
+
   /**
    * Удаляет элемент из чеклиста
    *
@@ -29,5 +49,44 @@ export class DeleteChecklistItemOperation extends BaseOperation {
     await this.deleteRequest<void>(`/v2/issues/${issueId}/checklistItems/${checklistItemId}`);
 
     this.logger.info(`Элемент ${checklistItemId} чеклиста задачи ${issueId} успешно удалён`);
+  }
+
+  /**
+   * Удаляет элементы из чеклистов нескольких задач параллельно
+   *
+   * @param items - массив элементов для удаления с issueId и itemId
+   * @returns массив результатов в формате BatchResult
+   * @throws {Error} если количество элементов превышает maxBatchSize
+   *
+   * ВАЖНО:
+   * - Каждый элемент имеет свои параметры (issueId, itemId)
+   * - Использует ParallelExecutor для соблюдения maxConcurrentRequests
+   * - Retry делается автоматически в HttpClient.delete
+   */
+  async executeMany(
+    items: Array<{ issueId: string; itemId: string }>
+  ): Promise<BatchResult<string, void>> {
+    // Проверка на пустой массив
+    if (items.length === 0) {
+      this.logger.warn('DeleteChecklistItemOperation: пустой массив элементов');
+      return [];
+    }
+
+    this.logger.info(
+      `Удаление элементов из чеклистов ${items.length} задач параллельно: ${items.map((i) => `${i.issueId}/${i.itemId}`).join(', ')}`
+    );
+
+    // Создаём операции для каждой задачи
+    // Используем комбинацию issueId/itemId как ключ для идентификации результатов
+    const operations = items.map(({ issueId, itemId }) => ({
+      key: `${issueId}/${itemId}`,
+      fn: async (): Promise<void> => {
+        // Вызываем существующий метод execute() для каждого элемента
+        return this.execute(issueId, itemId);
+      },
+    }));
+
+    // Выполняем через ParallelExecutor (централизованный throttling)
+    return this.parallelExecutor.executeParallel(operations, 'delete checklist items');
   }
 }

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/services/checklist.service.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/services/checklist.service.ts
@@ -113,4 +113,15 @@ export class ChecklistService {
   async deleteChecklistItem(issueId: string, checklistItemId: string): Promise<void> {
     return this.deleteChecklistItemOp.execute(issueId, checklistItemId);
   }
+
+  /**
+   * Удаляет элементы из чеклистов нескольких задач параллельно
+   * @param items - массив элементов для удаления с индивидуальными параметрами
+   * @returns результаты batch-операции
+   */
+  async deleteChecklistItemMany(
+    items: Array<{ issueId: string; itemId: string }>
+  ): Promise<BatchResult<string, void>> {
+    return this.deleteChecklistItemOp.executeMany(items);
+  }
 }

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -595,6 +595,17 @@ export class YandexTrackerFacade {
     return this.checklistService.deleteChecklistItem(issueId, checklistItemId);
   }
 
+  /**
+   * Удаляет элементы из чеклистов нескольких задач параллельно
+   * @param items - массив элементов для удаления с индивидуальными параметрами
+   * @returns результаты batch-операции
+   */
+  async deleteChecklistItemMany(
+    items: Array<{ issueId: string; itemId: string }>
+  ): Promise<BatchResult<string, void>> {
+    return this.checklistService.deleteChecklistItemMany(items);
+  }
+
   // === Worklog Methods ===
 
   /**

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/checklists/delete/delete-checklist-item.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/checklists/delete/delete-checklist-item.tool.integration.test.ts
@@ -5,7 +5,7 @@ import { createMockServer } from '#integration/helpers/mock-server.js';
 import type { TestMCPClient } from '#integration/helpers/mcp-client.js';
 import type { MockServer } from '#integration/helpers/mock-server.js';
 
-describe('delete-checklist-item integration tests', () => {
+describe('delete-checklist-item integration tests (batch)', () => {
   let client: TestMCPClient;
   let mockServer: MockServer;
 
@@ -18,62 +18,98 @@ describe('delete-checklist-item integration tests', () => {
     mockServer.cleanup();
   });
 
-  it('должен удалить элемент из чеклиста', async () => {
+  it('должен удалить элемент из чеклиста (batch)', async () => {
     // Arrange
     const issueKey = 'TEST-100';
-    const checklistItemId = 'item-123';
-    mockServer.mockDeleteChecklistItemSuccess(issueKey, checklistItemId);
+    const itemId = 'item-123';
+    mockServer.mockDeleteChecklistItemSuccess(issueKey, itemId);
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_delete_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
+      items: [{ issueId: issueKey, itemId }],
     });
 
     // Assert
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.message).toBeDefined();
-    expect(response.data.itemId).toBe(checklistItemId);
-    expect(response.data.issueId).toBe(issueKey);
+    expect(response.data.successful).toBe(1);
+    expect(response.data.items).toHaveLength(1);
+    expect(response.data.items[0].success).toBe(true);
     mockServer.assertAllRequestsDone();
   });
 
   it('должен обработать ошибку 404 (элемент не найден)', async () => {
     // Arrange
     const issueKey = 'TEST-101';
-    const checklistItemId = 'nonexistent-item';
-    mockServer.mockDeleteChecklistItem404(issueKey, checklistItemId);
+    const itemId = 'nonexistent-item';
+    mockServer.mockDeleteChecklistItem404(issueKey, itemId);
 
     // Act
     const result = await client.callTool('fr_yandex_tracker_delete_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-    });
-
-    // Assert
-    expect(result.isError).toBe(true);
-    mockServer.assertAllRequestsDone();
-  });
-
-  it('должен удалить элемент с валидным ID', async () => {
-    // Arrange
-    const issueKey = 'TEST-102';
-    const checklistItemId = 'valid-item-id-456';
-    mockServer.mockDeleteChecklistItemSuccess(issueKey, checklistItemId);
-
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_delete_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
+      items: [{ issueId: issueKey, itemId }],
     });
 
     // Assert
     expect(result.isError).toBeUndefined();
     const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.message).toBeDefined();
-    expect(response.data.itemId).toBe(checklistItemId);
-    expect(response.data.issueId).toBe(issueKey);
+    expect(response.data.failed).toBe(1);
+    expect(response.data.errors).toHaveLength(1);
+    mockServer.assertAllRequestsDone();
+  });
+
+  it('должен удалить несколько элементов', async () => {
+    // Arrange
+    const issueKey1 = 'TEST-102';
+    const itemId1 = 'item-456';
+    const issueKey2 = 'TEST-103';
+    const itemId2 = 'item-789';
+    mockServer.mockDeleteChecklistItemSuccess(issueKey1, itemId1);
+    mockServer.mockDeleteChecklistItemSuccess(issueKey2, itemId2);
+
+    // Act
+    const result = await client.callTool('fr_yandex_tracker_delete_checklist_item', {
+      items: [
+        { issueId: issueKey1, itemId: itemId1 },
+        { issueId: issueKey2, itemId: itemId2 },
+      ],
+    });
+
+    // Assert
+    expect(result.isError).toBeUndefined();
+    const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(2);
+    expect(response.data.successful).toBe(2);
+    expect(response.data.failed).toBe(0);
+    expect(response.data.items).toHaveLength(2);
+    expect(response.data.errors).toHaveLength(0);
+    mockServer.assertAllRequestsDone();
+  });
+
+  it('должен обработать частичную ошибку в batch', async () => {
+    // Arrange
+    const issueKey1 = 'TEST-104';
+    const itemId1 = 'item-good';
+    const issueKey2 = 'TEST-105';
+    const itemId2 = 'item-bad';
+    mockServer.mockDeleteChecklistItemSuccess(issueKey1, itemId1);
+    mockServer.mockDeleteChecklistItem404(issueKey2, itemId2);
+
+    // Act
+    const result = await client.callTool('fr_yandex_tracker_delete_checklist_item', {
+      items: [
+        { issueId: issueKey1, itemId: itemId1 },
+        { issueId: issueKey2, itemId: itemId2 },
+      ],
+    });
+
+    // Assert
+    expect(result.isError).toBeUndefined();
+    const response = JSON.parse(result.content[0]!.text);
+    expect(response.data.total).toBe(2);
+    expect(response.data.successful).toBe(1);
+    expect(response.data.failed).toBe(1);
+    expect(response.data.items).toHaveLength(1);
+    expect(response.data.errors).toHaveLength(1);
     mockServer.assertAllRequestsDone();
   });
 });

--- a/packages/servers/yandex-tracker/tests/tools/api/checklists/delete/delete-checklist-item.tool.test.ts
+++ b/packages/servers/yandex-tracker/tests/tools/api/checklists/delete/delete-checklist-item.tool.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit тесты для DeleteChecklistItemTool
+ * Unit тесты для DeleteChecklistItemTool (batch-режим)
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -16,7 +16,7 @@ describe('DeleteChecklistItemTool', () => {
 
   beforeEach(() => {
     mockTrackerFacade = {
-      deleteChecklistItem: vi.fn(),
+      deleteChecklistItemMany: vi.fn(),
     } as unknown as YandexTrackerFacade;
 
     mockLogger = {
@@ -44,22 +44,22 @@ describe('DeleteChecklistItemTool', () => {
     it('должен иметь корректное описание', () => {
       const definition = tool.getDefinition();
 
-      expect(definition.description).toContain('Удалить элемент');
+      expect(definition.description).toContain('Удалить элементы');
+      expect(definition.description).toContain('batch');
     });
 
-    it('должен иметь корректную схему с обязательными полями', () => {
+    it('должен иметь корректную схему с массивом items', () => {
       const definition = tool.getDefinition();
 
       expect(definition.inputSchema.type).toBe('object');
-      expect(definition.inputSchema.required).toEqual(['issueId', 'checklistItemId']);
-      expect(definition.inputSchema.properties?.['issueId']).toBeDefined();
-      expect(definition.inputSchema.properties?.['checklistItemId']).toBeDefined();
+      expect(definition.inputSchema.required).toEqual(['items']);
+      expect(definition.inputSchema.properties?.['items']).toBeDefined();
     });
   });
 
   describe('Validation', () => {
-    it('должен требовать параметр issueId', async () => {
-      const result = await tool.execute({ checklistItemId: 'item-123' });
+    it('должен требовать массив items', async () => {
+      const result = await tool.execute({});
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -70,8 +70,8 @@ describe('DeleteChecklistItemTool', () => {
       expect(parsed.message).toContain('валидации');
     });
 
-    it('должен требовать параметр checklistItemId', async () => {
-      const result = await tool.execute({ issueId: 'TEST-123' });
+    it('должен отклонить пустой массив items', async () => {
+      const result = await tool.execute({ items: [] });
 
       expect(result.isError).toBe(true);
       const parsed = JSON.parse(result.content[0]?.text || '{}') as {
@@ -79,29 +79,24 @@ describe('DeleteChecklistItemTool', () => {
         message: string;
       };
       expect(parsed.success).toBe(false);
-      expect(parsed.message).toContain('валидации');
     });
 
-    it('должен отклонить пустой issueId', async () => {
-      const result = await tool.execute({ issueId: '', checklistItemId: 'item-123' });
+    it('должен отклонить пустой itemId', async () => {
+      const result = await tool.execute({
+        items: [{ issueId: 'TEST-123', itemId: '' }],
+      });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('валидации');
-    });
-
-    it('должен отклонить пустой checklistItemId', async () => {
-      const result = await tool.execute({ issueId: 'TEST-123', checklistItemId: '' });
-
-      expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('валидации');
+      expect(result.content[0]?.text).toContain('ID элемента');
     });
 
     it('должен принять корректные параметры', async () => {
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockResolvedValue();
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'fulfilled', key: 'TEST-123/item-123', value: undefined },
+      ]);
 
       const result = await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'item-123',
+        items: [{ issueId: 'TEST-123', itemId: 'item-123' }],
       });
 
       expect(result.isError).toBeUndefined();
@@ -109,134 +104,201 @@ describe('DeleteChecklistItemTool', () => {
   });
 
   describe('Operation calls', () => {
-    it('должен вызвать deleteChecklistItem с параметрами', async () => {
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockResolvedValue();
+    it('должен вызвать deleteChecklistItemMany с корректными параметрами', async () => {
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'fulfilled', key: 'TEST-123/item-123', value: undefined },
+      ]);
 
       await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'item-123',
+        items: [{ issueId: 'TEST-123', itemId: 'item-123' }],
       });
 
-      expect(mockTrackerFacade.deleteChecklistItem).toHaveBeenCalledWith('TEST-123', 'item-123');
+      expect(mockTrackerFacade.deleteChecklistItemMany).toHaveBeenCalledWith([
+        { issueId: 'TEST-123', itemId: 'item-123' },
+      ]);
     });
 
-    it('должен вернуть успешный результат', async () => {
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockResolvedValue();
+    it('должен вернуть успешный результат для batch операции', async () => {
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'fulfilled', key: 'TEST-123/item-123', value: undefined },
+        { status: 'fulfilled', key: 'TEST-456/item-456', value: undefined },
+      ]);
 
       const result = await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'item-123',
+        items: [
+          { issueId: 'TEST-123', itemId: 'item-123' },
+          { issueId: 'TEST-456', itemId: 'item-456' },
+        ],
       });
 
       expect(result.isError).toBeUndefined();
       const parsed = JSON.parse(result.content[0]?.text || '{}') as {
         success: boolean;
         data: {
-          message: string;
-          itemId: string;
-          issueId: string;
+          total: number;
+          successful: number;
+          failed: number;
+          items: Array<{ issueId: string; itemId: string; success: boolean }>;
+          errors: Array<{ issueId: string; itemId: string; error: string }>;
         };
       };
       expect(parsed.success).toBe(true);
-      expect(parsed.data.itemId).toBe('item-123');
-      expect(parsed.data.issueId).toBe('TEST-123');
-      expect(parsed.data.message).toContain('item-123');
-      expect(parsed.data.message).toContain('TEST-123');
-      expect(parsed.data.message).toContain('успешно удалён');
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.successful).toBe(2);
+      expect(parsed.data.failed).toBe(0);
+      expect(parsed.data.items).toHaveLength(2);
+      expect(parsed.data.errors).toHaveLength(0);
     });
   });
 
   describe('Logging', () => {
-    it('должен логировать начало удаления элемента', async () => {
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockResolvedValue();
+    it('должен логировать начало удаления', async () => {
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'fulfilled', key: 'TEST-123/item-123', value: undefined },
+      ]);
 
       await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'item-123',
+        items: [{ issueId: 'TEST-123', itemId: 'item-123' }],
       });
 
       expect(mockLogger.info).toHaveBeenCalledWith(
-        'Удаление элемента из чеклиста задачи',
-        expect.objectContaining({
-          issueId: 'TEST-123',
-          itemId: 'item-123',
-        })
+        expect.stringContaining('Удаление элементов из чеклистов'),
+        expect.any(Object)
       );
     });
 
-    it('должен логировать успешное удаление', async () => {
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockResolvedValue();
+    it('должен логировать результаты', async () => {
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'fulfilled', key: 'TEST-123/item-123', value: undefined },
+      ]);
 
       await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'item-123',
+        items: [{ issueId: 'TEST-123', itemId: 'item-123' }],
       });
 
+      // ResultLogger.logBatchResults вызывает info с сообщением о результатах
+      expect(mockLogger.info).toHaveBeenCalled();
+      // Первый вызов - logOperationStart с "Удаление элементов из чеклистов: N"
       expect(mockLogger.info).toHaveBeenCalledWith(
-        'Элемент успешно удалён из чеклиста',
-        expect.objectContaining({
-          issueId: 'TEST-123',
-          itemId: 'item-123',
-        })
+        expect.stringContaining('Удаление элементов из чеклистов'),
+        expect.any(Object)
       );
     });
   });
 
   describe('Error handling', () => {
-    it('должен обработать ошибки от operation', async () => {
-      const error = new Error('API Error');
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockRejectedValue(error);
+    it('должен обработать частичные ошибки в batch', async () => {
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'fulfilled', key: 'TEST-123/item-123', value: undefined },
+        { status: 'rejected', key: 'TEST-456/item-456', reason: new Error('Item not found') },
+      ]);
 
       const result = await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'item-123',
+        items: [
+          { issueId: 'TEST-123', itemId: 'item-123' },
+          { issueId: 'TEST-456', itemId: 'item-456' },
+        ],
       });
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('Ошибка при удалении элемента');
-      expect(result.content[0]?.text).toContain('item-123');
-      expect(result.content[0]?.text).toContain('TEST-123');
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          total: number;
+          successful: number;
+          failed: number;
+          items: Array<{ issueId: string; itemId: string; success: boolean }>;
+          errors: Array<{ issueId: string; itemId: string; error: string }>;
+        };
+      };
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.successful).toBe(1);
+      expect(parsed.data.failed).toBe(1);
+      expect(parsed.data.items).toHaveLength(1);
+      expect(parsed.data.errors).toHaveLength(1);
+      expect(parsed.data.errors[0].issueId).toBe('TEST-456');
+      expect(parsed.data.errors[0].itemId).toBe('item-456');
+      expect(parsed.data.errors[0].error).toContain('Item not found');
     });
 
-    it('должен обработать ошибку несуществующей задачи (404)', async () => {
-      const notFoundError = new Error('Issue not found');
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockRejectedValue(notFoundError);
+    it('должен обработать полную ошибку batch', async () => {
+      const error = new Error('API Error');
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockRejectedValue(error);
 
       const result = await tool.execute({
-        issueId: 'NONEXISTENT-999',
-        checklistItemId: 'item-123',
+        items: [{ issueId: 'TEST-123', itemId: 'item-123' }],
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('Ошибка при удалении элемента');
-      expect(result.content[0]?.text).toContain('NONEXISTENT-999');
+      expect(result.content[0]?.text).toContain('Ошибка при удалении элементов');
     });
 
     it('должен обработать ошибку несуществующего элемента (404)', async () => {
-      const notFoundError = new Error('Checklist item not found');
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockRejectedValue(notFoundError);
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        {
+          status: 'rejected',
+          key: 'TEST-123/NONEXISTENT',
+          reason: new Error('Checklist item not found'),
+        },
+      ]);
 
       const result = await tool.execute({
-        issueId: 'TEST-123',
-        checklistItemId: 'nonexistent-item',
+        items: [{ issueId: 'TEST-123', itemId: 'NONEXISTENT' }],
       });
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('Ошибка при удалении элемента');
-      expect(result.content[0]?.text).toContain('nonexistent-item');
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          errors: Array<{ issueId: string; itemId: string; error: string }>;
+        };
+      };
+      expect(parsed.data.errors).toHaveLength(1);
+      expect(parsed.data.errors[0].error).toContain('Checklist item not found');
     });
 
     it('должен обработать ошибку доступа (403)', async () => {
-      const forbiddenError = new Error('Access denied');
-      vi.mocked(mockTrackerFacade.deleteChecklistItem).mockRejectedValue(forbiddenError);
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        { status: 'rejected', key: 'PRIVATE-123/item-123', reason: new Error('Access denied') },
+      ]);
 
       const result = await tool.execute({
-        issueId: 'PRIVATE-123',
-        checklistItemId: 'item-123',
+        items: [{ issueId: 'PRIVATE-123', itemId: 'item-123' }],
       });
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('Ошибка при удалении элемента');
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          errors: Array<{ issueId: string; itemId: string; error: string }>;
+        };
+      };
+      expect(parsed.data.errors).toHaveLength(1);
+      expect(parsed.data.errors[0].error).toContain('Access denied');
+    });
+
+    it('должен обработать ошибку несуществующей задачи (404)', async () => {
+      vi.mocked(mockTrackerFacade.deleteChecklistItemMany).mockResolvedValue([
+        {
+          status: 'rejected',
+          key: 'NONEXISTENT-999/item-123',
+          reason: new Error('Issue not found'),
+        },
+      ]);
+
+      const result = await tool.execute({
+        items: [{ issueId: 'NONEXISTENT-999', itemId: 'item-123' }],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text || '{}') as {
+        success: boolean;
+        data: {
+          errors: Array<{ issueId: string; itemId: string; error: string }>;
+        };
+      };
+      expect(parsed.data.errors).toHaveLength(1);
+      expect(parsed.data.errors[0].error).toContain('Issue not found');
     });
   });
 });

--- a/packages/servers/yandex-tracker/tests/tracker_api/facade/yandex-tracker.facade.test.ts
+++ b/packages/servers/yandex-tracker/tests/tracker_api/facade/yandex-tracker.facade.test.ts
@@ -130,9 +130,12 @@ describe('YandexTrackerFacade', () => {
 
     mockChecklistService = {
       getChecklist: vi.fn(),
+      getChecklistMany: vi.fn(),
       addChecklistItem: vi.fn(),
+      addChecklistItemMany: vi.fn(),
       updateChecklistItem: vi.fn(),
       deleteChecklistItem: vi.fn(),
+      deleteChecklistItemMany: vi.fn(),
     } as unknown as ChecklistService;
 
     mockWorklogService = {


### PR DESCRIPTION
Детали:
- Добавлен метод executeMany в DeleteChecklistItemOperation с ParallelExecutor
- Добавлен deleteChecklistItemMany в ChecklistService и YandexTrackerFacade
- Изменена схема на items[] array pattern для batch API
- Обновлён tool для использования ручной обработки void результатов
- Добавлен тег batch в метаданные
- Обновлены unit, operation и integration тесты

🤖 Generated with Claude Code