### PR TITLE
Add batch support to checklist item updates

### DIFF
--- a/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.metadata.ts
+++ b/packages/servers/yandex-tracker/src/tools/api/checklists/update/update-checklist-item.metadata.ts
@@ -17,11 +17,11 @@ import { MCP_TOOL_PREFIX } from '#constants';
  */
 export const UPDATE_CHECKLIST_ITEM_TOOL_METADATA: StaticToolMetadata = {
   name: buildToolName('update_checklist_item', MCP_TOOL_PREFIX),
-  description: '[Checklist/Write] Обновить элемент чеклиста',
+  description: '[Checklist/Write] Обновить элементы чеклистов (batch)',
   category: ToolCategory.CHECKLISTS,
   subcategory: 'write',
   priority: ToolPriority.HIGH,
-  tags: ['checklist', 'update', 'edit', 'write'],
+  tags: ['checklist', 'update', 'edit', 'write', 'batch'],
   isHelper: false,
   requiresExplicitUserConsent: true,
 } as const;

--- a/packages/servers/yandex-tracker/src/tools/generated-index.ts
+++ b/packages/servers/yandex-tracker/src/tools/generated-index.ts
@@ -307,11 +307,11 @@ export const TOOL_SEARCH_INDEX: readonly StaticToolIndex[] = [
   {
     name: 'fr_yandex_tracker_update_checklist_item',
     category: ToolCategory.CHECKLISTS,
-    tags: ['checklist', 'update', 'edit', 'write'],
+    tags: ['checklist', 'update', 'edit', 'write', 'batch'],
     isHelper: false,
     nameTokens: ['fr', 'yandex', 'tracker', 'update', 'checklist', 'item'],
-    descriptionTokens: ['checklist', 'write'],
-    descriptionShort: '[Checklist/Write] Обновить элемент чеклиста',
+    descriptionTokens: ['checklist', 'write', 'batch'],
+    descriptionShort: '[Checklist/Write] Обновить элементы чеклистов (batch)',
   },
   {
     name: 'fr_yandex_tracker_delete_checklist_item',

--- a/packages/servers/yandex-tracker/src/tracker_api/api_operations/checklist/update-checklist-item.operation.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/api_operations/checklist/update-checklist-item.operation.ts
@@ -2,17 +2,36 @@
  * Операция обновления элемента чеклиста
  *
  * Ответственность (SRP):
- * - ТОЛЬКО обновление существующего элемента чеклиста
+ * - ТОЛЬКО обновление существующего элемента чеклиста (single и batch режимы)
+ * - Параллельное выполнение через ParallelExecutor (batch режим)
  * - НЕТ добавления/получения/удаления элементов
  *
  * API: PATCH /v2/issues/{issueId}/checklistItems/{checklistItemId}
  */
 
 import { BaseOperation } from '#tracker_api/api_operations/base-operation.js';
+import { ParallelExecutor } from '@mcp-framework/infrastructure';
 import type { UpdateChecklistItemInput } from '#tracker_api/dto/index.js';
 import type { ChecklistItemWithUnknownFields } from '#tracker_api/entities/index.js';
+import type { BatchResult } from '@mcp-framework/infrastructure';
+import type { ServerConfig } from '#config';
 
 export class UpdateChecklistItemOperation extends BaseOperation {
+  private readonly parallelExecutor: ParallelExecutor;
+
+  constructor(
+    httpClient: ConstructorParameters<typeof BaseOperation>[0],
+    cacheManager: ConstructorParameters<typeof BaseOperation>[1],
+    logger: ConstructorParameters<typeof BaseOperation>[2],
+    config: ServerConfig
+  ) {
+    super(httpClient, cacheManager, logger);
+
+    this.parallelExecutor = new ParallelExecutor(logger, {
+      maxBatchSize: config.maxBatchSize,
+      maxConcurrentRequests: config.maxConcurrentRequests,
+    });
+  }
   /**
    * Обновляет элемент чеклиста
    *
@@ -42,5 +61,52 @@ export class UpdateChecklistItemOperation extends BaseOperation {
     this.logger.info(`Элемент ${checklistItemId} чеклиста задачи ${issueId} успешно обновлён`);
 
     return item;
+  }
+
+  /**
+   * Обновляет элементы чеклистов нескольких задач параллельно
+   *
+   * @param items - массив элементов с индивидуальными параметрами
+   * @returns массив результатов в формате BatchResult
+   * @throws {Error} если количество элементов превышает maxBatchSize
+   *
+   * ВАЖНО:
+   * - Каждый элемент имеет свои параметры (issueId, checklistItemId, text?, checked?, assignee?, deadline?)
+   * - Использует ParallelExecutor для соблюдения maxConcurrentRequests
+   * - Retry делается автоматически в HttpClient.patch
+   */
+  async executeMany(
+    items: Array<{
+      issueId: string;
+      checklistItemId: string;
+      text?: string | undefined;
+      checked?: boolean | undefined;
+      assignee?: string | undefined;
+      deadline?: string | undefined;
+    }>
+  ): Promise<BatchResult<string, ChecklistItemWithUnknownFields>> {
+    // Проверка на пустой массив
+    if (items.length === 0) {
+      this.logger.warn('UpdateChecklistItemOperation: пустой массив элементов');
+      return [];
+    }
+
+    this.logger.info(
+      `Обновление элементов чеклистов ${items.length} задач параллельно: ${items.map((i) => `${i.issueId}/${i.checklistItemId}`).join(', ')}`
+    );
+
+    // Создаём операции для каждого элемента
+    const operations = items.map(
+      ({ issueId, checklistItemId, text, checked, assignee, deadline }) => ({
+        key: `${issueId}/${checklistItemId}`,
+        fn: async (): Promise<ChecklistItemWithUnknownFields> => {
+          // Вызываем существующий метод execute() для каждого элемента с индивидуальными параметрами
+          return this.execute(issueId, checklistItemId, { text, checked, assignee, deadline });
+        },
+      })
+    );
+
+    // Выполняем через ParallelExecutor (централизованный throttling)
+    return this.parallelExecutor.executeParallel(operations, 'update checklist items');
   }
 }

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/services/checklist.service.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/services/checklist.service.ts
@@ -105,6 +105,24 @@ export class ChecklistService {
   }
 
   /**
+   * Обновляет элементы чеклистов нескольких задач параллельно
+   * @param items - массив элементов с индивидуальными параметрами
+   * @returns результаты batch-операции
+   */
+  async updateChecklistItemMany(
+    items: Array<{
+      issueId: string;
+      checklistItemId: string;
+      text?: string | undefined;
+      checked?: boolean | undefined;
+      assignee?: string | undefined;
+      deadline?: string | undefined;
+    }>
+  ): Promise<BatchResult<string, ChecklistItemWithUnknownFields>> {
+    return this.updateChecklistItemOp.executeMany(items);
+  }
+
+  /**
    * Удаляет элемент из чеклиста
    * @param issueId - идентификатор или ключ задачи
    * @param checklistItemId - идентификатор элемента чеклиста

--- a/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
+++ b/packages/servers/yandex-tracker/src/tracker_api/facade/yandex-tracker.facade.ts
@@ -586,6 +586,24 @@ export class YandexTrackerFacade {
   }
 
   /**
+   * Обновляет элементы чеклистов нескольких задач параллельно
+   * @param items - массив элементов с индивидуальными параметрами
+   * @returns результаты batch-операции
+   */
+  async updateChecklistItemMany(
+    items: Array<{
+      issueId: string;
+      checklistItemId: string;
+      text?: string | undefined;
+      checked?: boolean | undefined;
+      assignee?: string | undefined;
+      deadline?: string | undefined;
+    }>
+  ): Promise<BatchResult<string, ChecklistItemWithUnknownFields>> {
+    return this.checklistService.updateChecklistItemMany(items);
+  }
+
+  /**
    * Удаляет элемент из чеклиста
    * @param issueId - идентификатор или ключ задачи
    * @param checklistItemId - идентификатор элемента чеклиста

--- a/packages/servers/yandex-tracker/tests/integration/tools/api/checklists/update/update-checklist-item.tool.integration.test.ts
+++ b/packages/servers/yandex-tracker/tests/integration/tools/api/checklists/update/update-checklist-item.tool.integration.test.ts
@@ -1,4 +1,10 @@
-// tests/integration/tools/api/checklists/update/update-checklist-item.tool.integration.test.ts
+/**
+ * Интеграционные тесты для update-checklist-item tool (batch-режим)
+ *
+ * Тестирование end-to-end flow:
+ * MCP Client → ToolRegistry → UpdateChecklistItemTool → UpdateChecklistItemOperation → HttpClient → API (mock)
+ */
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestClient } from '#integration/helpers/mcp-client.js';
 import { createMockServer } from '#integration/helpers/mock-server.js';
@@ -6,7 +12,7 @@ import type { TestMCPClient } from '#integration/helpers/mcp-client.js';
 import type { MockServer } from '#integration/helpers/mock-server.js';
 import { STANDARD_CHECKLIST_FIELDS } from '#helpers/test-fields.js';
 
-describe('update-checklist-item integration tests', () => {
+describe('update-checklist-item integration tests (batch)', () => {
   let client: TestMCPClient;
   let mockServer: MockServer;
 
@@ -19,165 +25,291 @@ describe('update-checklist-item integration tests', () => {
     mockServer.cleanup();
   });
 
-  it('должен обновить текст элемента', async () => {
-    // Arrange
-    const issueKey = 'TEST-100';
-    const checklistItemId = 'item-123';
-    const updatedText = 'Updated text';
-    const item = { id: checklistItemId, text: updatedText, checked: false };
-    mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+  describe('Happy Path', () => {
+    it('должен обновить элемент в чеклисте одной задачи', async () => {
+      // Arrange
+      const issueKey = 'TEST-100';
+      const checklistItemId = 'item-123';
+      const updatedText = 'Updated text';
+      const item = { id: checklistItemId, text: updatedText, checked: false };
+      mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
 
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-      text: updatedText,
-      fields: STANDARD_CHECKLIST_FIELDS,
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: issueKey, checklistItemId, text: updatedText }],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.total).toBe(1);
+      expect(response.successful).toBe(1);
+      expect(response.failed).toBe(0);
+      expect(response.items).toHaveLength(1);
+      expect(response.items[0].issueId).toBe(issueKey);
+      expect(response.items[0].checklistItemId).toBe(checklistItemId);
+      expect(response.items[0].item.text).toBe(updatedText);
+
+      mockServer.assertAllRequestsDone();
     });
 
-    // Assert
-    expect(result.isError).toBeUndefined();
-    const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.item).toBeDefined();
-    expect(response.data.item.id).toBe(checklistItemId);
-    expect(response.data.item.text).toBe(updatedText);
-    mockServer.assertAllRequestsDone();
+    it('должен обновить элементы в чеклистах нескольких задач (batch)', async () => {
+      // Arrange
+      const item1 = { id: 'item-1', text: 'Updated 1', checked: false };
+      const item2 = { id: 'item-2', text: 'Item 2', checked: true };
+      mockServer.mockUpdateChecklistItemSuccess('TEST-100', 'item-1', item1);
+      mockServer.mockUpdateChecklistItemSuccess('TEST-101', 'item-2', item2);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [
+          { issueId: 'TEST-100', checklistItemId: 'item-1', text: 'Updated 1' },
+          { issueId: 'TEST-101', checklistItemId: 'item-2', checked: true },
+        ],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.total).toBe(2);
+      expect(response.successful).toBe(2);
+      expect(response.failed).toBe(0);
+      expect(response.items).toHaveLength(2);
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен отметить элемент как выполненный', async () => {
+      // Arrange
+      const issueKey = 'TEST-101';
+      const checklistItemId = 'item-456';
+      const item = { id: checklistItemId, text: 'Item text', checked: true };
+      mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: issueKey, checklistItemId, checked: true }],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.items[0].item.checked).toBe(true);
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обновить assignee элемента', async () => {
+      // Arrange
+      const issueKey = 'TEST-102';
+      const checklistItemId = 'item-789';
+      const assignee = 'user456';
+      const item = {
+        id: checklistItemId,
+        text: 'Item text',
+        checked: false,
+        assignee: { id: assignee, display: 'New User' },
+      };
+      mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: issueKey, checklistItemId, assignee }],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.items[0].item.assignee).toBeDefined();
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обновить deadline элемента', async () => {
+      // Arrange
+      const issueKey = 'TEST-103';
+      const checklistItemId = 'item-abc';
+      const deadline = '2025-12-31T23:59:59.000Z';
+      const item = { id: checklistItemId, text: 'Item text', checked: false, deadline };
+      mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: issueKey, checklistItemId, deadline }],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.items[0].item.deadline).toBe(deadline);
+
+      mockServer.assertAllRequestsDone();
+    });
+
+    it('должен обновить несколько полей одновременно', async () => {
+      // Arrange
+      const issueKey = 'TEST-105';
+      const checklistItemId = 'item-multi';
+      const updatedText = 'Updated multi-field';
+      const assignee = 'user789';
+      const deadline = '2025-06-30T23:59:59.000Z';
+      const item = {
+        id: checklistItemId,
+        text: updatedText,
+        checked: true,
+        assignee: { id: assignee, display: 'Multi User' },
+        deadline,
+      };
+      mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [
+          {
+            issueId: issueKey,
+            checklistItemId,
+            text: updatedText,
+            checked: true,
+            assignee,
+            deadline,
+          },
+        ],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.items[0].item.text).toBe(updatedText);
+      expect(response.items[0].item.checked).toBe(true);
+      expect(response.items[0].item.assignee).toBeDefined();
+      expect(response.items[0].item.deadline).toBe(deadline);
+
+      mockServer.assertAllRequestsDone();
+    });
   });
 
-  it('должен отметить элемент как выполненный', async () => {
-    // Arrange
-    const issueKey = 'TEST-101';
-    const checklistItemId = 'item-456';
-    const item = { id: checklistItemId, text: 'Item text', checked: true };
-    mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+  describe('Error Handling', () => {
+    it('должен обработать частичные ошибки (один элемент не найден)', async () => {
+      // Arrange
+      const item1 = { id: 'item-1', text: 'Updated 1', checked: false };
+      mockServer.mockUpdateChecklistItemSuccess('TEST-100', 'item-1', item1);
+      mockServer.mockUpdateChecklistItem404('NONEXISTENT-1', 'item-2');
 
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-      checked: true,
-      fields: STANDARD_CHECKLIST_FIELDS,
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [
+          { issueId: 'TEST-100', checklistItemId: 'item-1', text: 'Updated 1' },
+          { issueId: 'NONEXISTENT-1', checklistItemId: 'item-2', text: 'Item 2' },
+        ],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.total).toBe(2);
+      expect(response.successful).toBe(1);
+      expect(response.failed).toBe(1);
+      expect(response.items).toHaveLength(1);
+      expect(response.items[0].issueId).toBe('TEST-100');
+      expect(response.errors).toHaveLength(1);
+      expect(response.errors[0].issueId).toBe('NONEXISTENT-1');
+
+      mockServer.assertAllRequestsDone();
     });
 
-    // Assert
-    expect(result.isError).toBeUndefined();
-    const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.item).toBeDefined();
-    expect(response.data.item.id).toBe(checklistItemId);
-    expect(response.data.item.checked).toBe(true);
-    mockServer.assertAllRequestsDone();
+    it('должен обработать ошибку 404 для единственной задачи', async () => {
+      // Arrange
+      const issueKey = 'NONEXISTENT-1';
+      const checklistItemId = 'item-1';
+      mockServer.mockUpdateChecklistItem404(issueKey, checklistItemId);
+
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: issueKey, checklistItemId, text: 'Test item' }],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
+
+      // Assert - partial failure is not an error at tool level
+      expect(result.isError).toBeUndefined();
+      const responseWrapper = JSON.parse(result.content[0]!.text);
+      const response = responseWrapper.data;
+
+      expect(response.total).toBe(1);
+      expect(response.successful).toBe(0);
+      expect(response.failed).toBe(1);
+      expect(response.errors).toHaveLength(1);
+      expect(response.errors[0].issueId).toBe(issueKey);
+
+      mockServer.assertAllRequestsDone();
+    });
   });
 
-  it('должен обновить assignee элемента', async () => {
-    // Arrange
-    const issueKey = 'TEST-102';
-    const checklistItemId = 'item-789';
-    const assignee = 'user456';
-    const item = {
-      id: checklistItemId,
-      text: 'Item text',
-      checked: false,
-      assignee: { id: assignee, display: 'New User' },
-    };
-    mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
+  describe('Validation', () => {
+    it('должен вернуть ошибку при пустом массиве items', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
 
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-      assignee,
-      fields: STANDARD_CHECKLIST_FIELDS,
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('валидации');
     });
 
-    // Assert
-    expect(result.isError).toBeUndefined();
-    const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.item).toBeDefined();
-    expect(response.data.item.id).toBe(checklistItemId);
-    expect(response.data.item.assignee).toBeDefined();
-    mockServer.assertAllRequestsDone();
-  });
+    it('должен вернуть ошибку при отсутствии items', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
 
-  it('должен обновить deadline элемента', async () => {
-    // Arrange
-    const issueKey = 'TEST-103';
-    const checklistItemId = 'item-abc';
-    const deadline = '2025-12-31T23:59:59.000Z';
-    const item = { id: checklistItemId, text: 'Item text', checked: false, deadline };
-    mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
-
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-      deadline,
-      fields: STANDARD_CHECKLIST_FIELDS,
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('валидации');
     });
 
-    // Assert
-    expect(result.isError).toBeUndefined();
-    const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.item).toBeDefined();
-    expect(response.data.item.id).toBe(checklistItemId);
-    expect(response.data.item.deadline).toBe(deadline);
-    mockServer.assertAllRequestsDone();
-  });
+    it('должен вернуть ошибку при отсутствии fields', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: 'TEST-100', checklistItemId: 'item-1', text: 'Test' }],
+      });
 
-  it('должен обработать ошибку 404 (элемент не найден)', async () => {
-    // Arrange
-    const issueKey = 'TEST-104';
-    const checklistItemId = 'nonexistent-item';
-    mockServer.mockUpdateChecklistItem404(issueKey, checklistItemId);
-
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-      text: 'Some text',
-      fields: STANDARD_CHECKLIST_FIELDS,
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('валидации');
     });
 
-    // Assert
-    expect(result.isError).toBe(true);
-    mockServer.assertAllRequestsDone();
-  });
+    it('должен вернуть ошибку при пустом checklistItemId в элементе', async () => {
+      // Act
+      const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
+        items: [{ issueId: 'TEST-100', checklistItemId: '', text: 'Test' }],
+        fields: STANDARD_CHECKLIST_FIELDS,
+      });
 
-  it('должен обновить несколько полей одновременно', async () => {
-    // Arrange
-    const issueKey = 'TEST-105';
-    const checklistItemId = 'item-multi';
-    const updatedText = 'Updated multi-field';
-    const assignee = 'user789';
-    const deadline = '2025-06-30T23:59:59.000Z';
-    const item = {
-      id: checklistItemId,
-      text: updatedText,
-      checked: true,
-      assignee: { id: assignee, display: 'Multi User' },
-      deadline,
-    };
-    mockServer.mockUpdateChecklistItemSuccess(issueKey, checklistItemId, item);
-
-    // Act
-    const result = await client.callTool('fr_yandex_tracker_update_checklist_item', {
-      issueId: issueKey,
-      checklistItemId,
-      text: updatedText,
-      checked: true,
-      assignee,
-      deadline,
-      fields: STANDARD_CHECKLIST_FIELDS,
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('валидации');
     });
-
-    // Assert
-    expect(result.isError).toBeUndefined();
-    const response = JSON.parse(result.content[0]!.text);
-    expect(response.data.item).toBeDefined();
-    expect(response.data.item.id).toBe(checklistItemId);
-    expect(response.data.item.text).toBe(updatedText);
-    expect(response.data.item.checked).toBe(true);
-    expect(response.data.item.assignee).toBeDefined();
-    expect(response.data.item.deadline).toBe(deadline);
-    mockServer.assertAllRequestsDone();
   });
 });


### PR DESCRIPTION
Изменения:
- Operation: добавлен executeMany с ParallelExecutor
- Service/Facade: добавлены updateChecklistItemMany proxy методы
- Schema: изменена на items[] array pattern
- Tool: использует BatchResultProcessor и ResultLogger
- Metadata: добавлен batch тег, обновлено описание
- Тесты: обновлены unit и integration тесты

🤖 Generated with Claude Code