### PR TITLE
Implement Yandex Wiki MCP server

### DIFF
--- a/.agentic-planning/plan_yandex_wiki_mcp_server/0_overview.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/0_overview.md
@@ -1,0 +1,134 @@
+# План: MCP Server для Yandex Wiki
+
+## Цель
+Создать MCP сервер `mcp-server-yandex-wiki` для работы с API Yandex Wiki.
+
+## Ключевые решения
+
+| Решение | Значение |
+|---------|----------|
+| Пакет | `packages/servers/yandex-wiki/` |
+| NPM name | `mcp-server-yandex-wiki` |
+| Токен | `YANDEX_WIKI_TOKEN` (отдельный) |
+| Префикс | `yw_` |
+| Base URL | `https://api.wiki.yandex.net` (hardcoded) |
+| Batch | Не требуется |
+
+## API Yandex Wiki
+
+### Pages API (7 методов) — Приоритет 1
+| Tool | HTTP | Endpoint |
+|------|------|----------|
+| `yw_get_page` | GET | `/v1/pages?slug={slug}` |
+| `yw_get_page_by_id` | GET | `/v1/pages/{idx}` |
+| `yw_create_page` | POST | `/v1/pages` |
+| `yw_update_page` | POST | `/v1/pages/{idx}` |
+| `yw_delete_page` | DELETE | `/v1/pages/{idx}` |
+| `yw_clone_page` | POST | `/v1/pages/{idx}/clone` |
+| `yw_append_content` | POST | `/v1/pages/{idx}/append-content` |
+
+### Grids API (12 методов) — Приоритет 2
+| Tool | HTTP | Endpoint |
+|------|------|----------|
+| `yw_create_grid` | POST | `/v1/grids` |
+| `yw_get_grid` | GET | `/v1/grids/{idx}` |
+| `yw_update_grid` | POST | `/v1/grids/{idx}` |
+| `yw_delete_grid` | DELETE | `/v1/grids/{idx}` |
+| `yw_add_rows` | POST | `/v1/grids/{idx}/rows` |
+| `yw_remove_rows` | DELETE | `/v1/grids/{idx}/rows` |
+| `yw_add_columns` | POST | `/v1/grids/{idx}/columns` |
+| `yw_remove_columns` | DELETE | `/v1/grids/{idx}/columns` |
+| `yw_update_cells` | POST | `/v1/grids/{idx}/cells` |
+| `yw_move_rows` | POST | `/v1/grids/{idx}/rows/move` |
+| `yw_move_columns` | POST | `/v1/grids/{idx}/columns/move` |
+| `yw_clone_grid` | POST | `/v1/grids/{idx}/clone` |
+
+### Resources API (1 метод) — Приоритет 3
+| Tool | HTTP | Endpoint |
+|------|------|----------|
+| `yw_get_resources` | GET | `/v1/pages/{idx}/resources` |
+
+## Граф зависимостей
+
+```
+1.1 Package Setup
+    ↓
+1.2 Infrastructure
+    ↓
+┌───┴───┐
+2.1     2.2      ← Можно параллельно
+Entities DTOs
+└───┬───┘
+    ↓
+3.1 Page Operations
+    ↓
+4.1 Facade & Services
+    ↓
+5.1 Page Tools
+    ↓
+6.1 Composition Root
+    ↓
+┌───┴───┐
+7.1     8.1      ← Можно параллельно
+Tests   Docs
+└───┬───┘
+    ↓
+Pages API Ready ✓
+    ↓
+┌───┴───┐
+9.1     10.1     ← Можно параллельно
+Grids   Resources
+    ↓
+9.2 Grid Tools
+```
+
+## Этапы реализации
+
+### Фаза 1: Pages API (Основная)
+
+| Этап | Файл | Тип | Статус |
+|------|------|-----|--------|
+| 1.1 | `1.1_package_setup_sequential.md` | sequential | [ ] |
+| 1.2 | `1.2_infrastructure_sequential.md` | sequential | [ ] |
+| 2.1 | `2.1_entities_parallel.md` | parallel | [ ] |
+| 2.2 | `2.2_dto_parallel.md` | parallel | [ ] |
+| 3.1 | `3.1_page_operations_parallel.md` | parallel | [ ] |
+| 4.1 | `4.1_facade_services_sequential.md` | sequential | [ ] |
+| 5.1 | `5.1_page_tools_parallel.md` | parallel | [ ] |
+| 6.1 | `6.1_composition_root_sequential.md` | sequential | [ ] |
+| 7.1 | `7.1_tests_parallel.md` | parallel | [ ] |
+| 8.1 | `8.1_documentation_sequential.md` | sequential | [ ] |
+
+### Фаза 2: Grids & Resources (Дополнительная)
+
+| Этап | Файл | Тип | Статус |
+|------|------|-----|--------|
+| 9.1 | `9.1_grid_operations_parallel.md` | parallel | [ ] |
+| 9.2 | `9.2_grid_tools_parallel.md` | parallel | [ ] |
+| 10.1 | `10.1_resources_parallel.md` | parallel | [ ] |
+
+## Зависимости от framework
+
+- `@mcp-framework/infrastructure` — HttpClient, Logger, Cache
+- `@mcp-framework/core` — BaseTool, ToolRegistry, ResponseFieldFilter
+- `@mcp-framework/search` — ToolSearchEngine (опционально)
+- `@mcp-framework/cli` — CLI для подключений
+
+## Команды валидации
+
+```bash
+# После каждого этапа
+cd packages/servers/yandex-wiki
+npm run validate:quiet
+
+# Полная валидация monorepo
+npm run validate
+```
+
+## Промпт для продолжения
+
+```
+Продолжить реализацию Yandex Wiki MCP сервера.
+План: .agentic-planning/plan_yandex_wiki_mcp_server/
+Текущий этап: [указать номер]
+```

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/1.1_package_setup_sequential.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/1.1_package_setup_sequential.md
@@ -1,0 +1,192 @@
+# Этап 1.1: Package Setup (Sequential)
+
+## Цель
+Создать базовую структуру пакета `mcp-server-yandex-wiki`.
+
+## Чек-лист
+
+### 1. Создать директорию пакета
+- [ ] `packages/servers/yandex-wiki/`
+
+### 2. package.json
+- [ ] Создать `packages/servers/yandex-wiki/package.json`
+
+```json
+{
+  "name": "mcp-server-yandex-wiki",
+  "version": "0.1.0",
+  "description": "MCP Server for Yandex Wiki API",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "mcp-wiki-connect": "./dist/cli/bin/mcp-connect.js"
+  },
+  "scripts": {
+    "build": "tsc -b && tsc-alias",
+    "clean": "rimraf dist",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "lint:quiet": "eslint src --ext .ts --quiet",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:quiet": "vitest run --reporter=dot --silent",
+    "test:verbose": "vitest run --reporter=verbose",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit",
+    "validate": "npm run lint && npm run typecheck && npm run test",
+    "validate:quiet": "npm run lint:quiet && npm run typecheck && npm run test:quiet"
+  },
+  "imports": {
+    "#wiki_api/*": "./src/wiki_api/*",
+    "#tools/*": "./src/tools/*",
+    "#composition-root/*": "./src/composition-root/*",
+    "#cli/*": "./src/cli/*",
+    "#constants": "./src/constants.ts",
+    "#common/*": "./src/common/*",
+    "#config": "./src/config/index.js",
+    "#helpers/*": "./tests/helpers/*"
+  },
+  "dependencies": {
+    "@mcp-framework/infrastructure": "workspace:*",
+    "@mcp-framework/core": "workspace:*",
+    "@mcp-framework/search": "workspace:*",
+    "@mcp-framework/cli": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "inversify": "^7.0.0",
+    "reflect-metadata": "^0.2.2",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "rimraf": "^6.0.0",
+    "tsc-alias": "^1.8.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}
+```
+
+### 3. tsconfig.json
+- [ ] Создать `packages/servers/yandex-wiki/tsconfig.json`
+
+```json
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "baseUrl": ".",
+    "paths": {
+      "#wiki_api/*": ["./src/wiki_api/*"],
+      "#tools/*": ["./src/tools/*"],
+      "#composition-root/*": ["./src/composition-root/*"],
+      "#cli/*": ["./src/cli/*"],
+      "#constants": ["./src/constants.ts"],
+      "#common/*": ["./src/common/*"],
+      "#config": ["./src/config/index.ts"],
+      "#helpers/*": ["./tests/helpers/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [
+    { "path": "../../framework/infrastructure" },
+    { "path": "../../framework/core" },
+    { "path": "../../framework/search" },
+    { "path": "../../framework/cli" }
+  ]
+}
+```
+
+### 4. vitest.config.ts
+- [ ] Создать `packages/servers/yandex-wiki/vitest.config.ts`
+
+```typescript
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules', 'dist', 'tests'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 75,
+        statements: 80,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '#wiki_api': resolve(__dirname, './src/wiki_api'),
+      '#tools': resolve(__dirname, './src/tools'),
+      '#composition-root': resolve(__dirname, './src/composition-root'),
+      '#cli': resolve(__dirname, './src/cli'),
+      '#constants': resolve(__dirname, './src/constants.ts'),
+      '#common': resolve(__dirname, './src/common'),
+      '#config': resolve(__dirname, './src/config'),
+      '#helpers': resolve(__dirname, './tests/helpers'),
+    },
+  },
+});
+```
+
+### 5. Структура директорий
+- [ ] Создать базовые директории:
+
+```
+packages/servers/yandex-wiki/
+├── src/
+│   ├── index.ts
+│   ├── constants.ts
+│   ├── config/
+│   ├── wiki_api/
+│   │   ├── api_operations/
+│   │   ├── entities/
+│   │   ├── dto/
+│   │   └── facade/
+│   ├── tools/
+│   │   ├── api/
+│   │   └── helpers/
+│   ├── composition-root/
+│   ├── common/
+│   └── cli/
+└── tests/
+    ├── unit/
+    ├── integration/
+    └── helpers/
+```
+
+### 6. Обновить корневые файлы monorepo
+- [ ] Добавить workspace в корневой `package.json`
+- [ ] Добавить reference в корневой `tsconfig.json`
+- [ ] Обновить `turbo.json` если нужно
+
+## Валидация
+```bash
+cd packages/servers/yandex-wiki
+npm install
+npm run build  # должен пройти без ошибок (пустой index.ts)
+```
+
+## Результат
+- Пакет создан и интегрирован в monorepo
+- Базовая структура директорий готова
+- Build проходит успешно

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/1.2_infrastructure_sequential.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/1.2_infrastructure_sequential.md
@@ -1,0 +1,153 @@
+# Этап 1.2: Infrastructure (Sequential)
+
+## Цель
+Создать конфигурацию и константы для Wiki MCP сервера.
+
+## Зависимости
+- Этап 1.1 завершён
+
+## Чек-лист
+
+### 1. Constants
+- [ ] Создать `src/constants.ts`
+
+```typescript
+/**
+ * Префикс для всех MCP tools Yandex Wiki
+ */
+export const MCP_TOOL_PREFIX = 'yw';
+
+/**
+ * Base URL API Yandex Wiki (hardcoded)
+ */
+export const YANDEX_WIKI_API_BASE = 'https://api.wiki.yandex.net';
+```
+
+### 2. Config Interface
+- [ ] Создать `src/config/server-config.interface.ts`
+
+```typescript
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface ServerConfig {
+  /** OAuth токен для Wiki API */
+  readonly token: string;
+
+  /** ID организации (Яндекс 360) */
+  readonly orgId?: string;
+
+  /** ID организации (Yandex Cloud) */
+  readonly cloudOrgId?: string;
+
+  /** Base URL API (hardcoded) */
+  readonly apiBase: string;
+
+  /** Уровень логирования */
+  readonly logLevel: LogLevel;
+
+  /** Таймаут запросов в мс */
+  readonly requestTimeout: number;
+
+  /** Директория для логов */
+  readonly logsDir: string;
+
+  /** Pretty-print логов */
+  readonly prettyLogs: boolean;
+
+  /** Макс размер лог-файла */
+  readonly logMaxSize: number;
+
+  /** Макс количество лог-файлов */
+  readonly logMaxFiles: number;
+
+  /** Retry attempts */
+  readonly retryAttempts: number;
+
+  /** Min retry delay */
+  readonly retryMinDelay: number;
+
+  /** Max retry delay */
+  readonly retryMaxDelay: number;
+
+  /** Tool discovery mode */
+  readonly toolDiscoveryMode: 'lazy' | 'eager';
+}
+```
+
+### 3. Config Constants
+- [ ] Создать `src/config/constants.ts`
+
+```typescript
+export const DEFAULT_API_BASE = 'https://api.wiki.yandex.net';
+export const DEFAULT_LOG_LEVEL = 'info';
+export const DEFAULT_REQUEST_TIMEOUT = 30000;
+export const DEFAULT_LOGS_DIR = './logs';
+export const DEFAULT_LOG_MAX_SIZE = 51200; // 50KB
+export const DEFAULT_LOG_MAX_FILES = 20;
+export const DEFAULT_RETRY_ATTEMPTS = 3;
+export const DEFAULT_RETRY_MIN_DELAY = 1000;
+export const DEFAULT_RETRY_MAX_DELAY = 10000;
+export const DEFAULT_TOOL_DISCOVERY_MODE = 'eager';
+
+export const ENV_VAR_NAMES = {
+  YANDEX_WIKI_TOKEN: 'YANDEX_WIKI_TOKEN',
+  YANDEX_ORG_ID: 'YANDEX_ORG_ID',
+  YANDEX_CLOUD_ORG_ID: 'YANDEX_CLOUD_ORG_ID',
+  LOG_LEVEL: 'LOG_LEVEL',
+  REQUEST_TIMEOUT: 'REQUEST_TIMEOUT',
+  LOGS_DIR: 'LOGS_DIR',
+  PRETTY_LOGS: 'PRETTY_LOGS',
+  LOG_MAX_SIZE: 'LOG_MAX_SIZE',
+  LOG_MAX_FILES: 'LOG_MAX_FILES',
+  RETRY_ATTEMPTS: 'YANDEX_WIKI_RETRY_ATTEMPTS',
+  RETRY_MIN_DELAY: 'YANDEX_WIKI_RETRY_MIN_DELAY',
+  RETRY_MAX_DELAY: 'YANDEX_WIKI_RETRY_MAX_DELAY',
+  TOOL_DISCOVERY_MODE: 'TOOL_DISCOVERY_MODE',
+} as const;
+```
+
+### 4. Config Loader
+- [ ] Создать `src/config/config-loader.ts`
+- [ ] Скопировать логику из yandex-tracker и адаптировать:
+  - Заменить `YANDEX_TRACKER_TOKEN` на `YANDEX_WIKI_TOKEN`
+  - Убрать batch-related конфигурацию
+  - Hardcode `apiBase = YANDEX_WIKI_API_BASE`
+
+### 5. Config Index
+- [ ] Создать `src/config/index.ts`
+
+```typescript
+export type { ServerConfig, LogLevel } from './server-config.interface.js';
+export { loadConfig } from './config-loader.js';
+export * from './constants.js';
+```
+
+### 6. Entry Point (заглушка)
+- [ ] Создать `src/index.ts`
+
+```typescript
+/**
+ * MCP Server для Yandex Wiki
+ *
+ * Entry point для запуска сервера
+ */
+
+import 'reflect-metadata';
+
+export { loadConfig } from '#config';
+export type { ServerConfig } from '#config';
+
+// TODO: Добавить createContainer и startServer после реализации DI
+```
+
+## Валидация
+```bash
+cd packages/servers/yandex-wiki
+npm run build
+npm run typecheck
+```
+
+## Результат
+- Конфигурация загружается из переменных окружения
+- Constants определены (MCP_TOOL_PREFIX = 'yw')
+- Entry point готов к расширению

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/10.1_resources_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/10.1_resources_parallel.md
@@ -1,0 +1,56 @@
+# Этап 10.1: Resources API (Parallel) — ПРИОРИТЕТ 3
+
+## Цель
+Добавить поддержку Resources API.
+
+## Зависимости
+- Этапы 1-8 завершены (Pages API работает)
+
+## API Reference
+
+| Operation | HTTP | Endpoint |
+|-----------|------|----------|
+| GetResources | GET | `/v1/pages/{idx}/resources` |
+
+## Query Parameters
+
+- `cursor` — курсор пагинации
+- `order_by` — поле сортировки: `name_title`, `created_at`
+- `order_direction` — направление: `asc`, `desc`
+- `page_id` — номер страницы (default: 1)
+- `page_size` — размер страницы (default: 25, max: 50)
+- `q` — поиск по заголовку
+- `types` — типы ресурсов: `attachment`, `sharepoint_resource`, `grid`
+
+## Response
+
+```json
+{
+  "results": [
+    { "item": {...}, "type": "attachment|grid|sharepoint_resource" }
+  ],
+  "next_cursor": "...",
+  "prev_cursor": "..."
+}
+```
+
+## Чек-лист
+
+### 1. Operation
+- [ ] `src/wiki_api/api_operations/resource/get-resources.operation.ts`
+
+### 2. Service
+- [ ] `src/wiki_api/facade/services/resource.service.ts`
+- [ ] Обновить Facade
+
+### 3. Tool
+- [ ] `src/tools/api/resources/get/`
+  - `get-resources.schema.ts`
+  - `get-resources.metadata.ts`
+  - `get-resources.tool.ts`
+
+### 4. Tests
+- [ ] Unit тесты
+
+## Статус
+- [ ] Не начат

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/2.1_entities_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/2.1_entities_parallel.md
@@ -1,0 +1,300 @@
+# Этап 2.1: Entities (Parallel)
+
+## Цель
+Создать типы данных (entities) для ответов Wiki API.
+
+## Зависимости
+- Этап 1.2 завершён
+
+## Может выполняться параллельно с
+- Этап 2.2 (DTOs)
+
+## Чек-лист
+
+### 1. Базовые типы
+- [ ] Создать `src/wiki_api/entities/types.ts`
+
+```typescript
+/**
+ * Helper тип для поддержки неизвестных полей API
+ */
+export type WithUnknownFields<T> = T & { readonly [key: string]: unknown };
+```
+
+### 2. Page Entity
+- [ ] Создать `src/wiki_api/entities/page.entity.ts`
+
+```typescript
+import type { WithUnknownFields } from './types.js';
+
+/**
+ * Тип страницы Wiki
+ */
+export type PageType = 'page' | 'grid' | 'cloud_page' | 'wysiwyg' | 'template';
+
+/**
+ * Атрибуты страницы
+ */
+export interface PageAttributes {
+  readonly created_at: string;
+  readonly modified_at: string;
+  readonly lang?: string;
+  readonly is_readonly: boolean;
+  readonly comments_count: number;
+  readonly comments_enabled: boolean;
+  readonly keywords?: string[];
+  readonly is_collaborative?: boolean;
+  readonly is_draft?: boolean;
+}
+
+/**
+ * Breadcrumb (навигационная цепочка)
+ */
+export interface Breadcrumb {
+  readonly page_exists: boolean;
+  readonly slug: string;
+  readonly title: string;
+  readonly id?: number;
+}
+
+/**
+ * Redirect информация
+ */
+export interface PageRedirect {
+  readonly page_id: number;
+  readonly redirect_target: Page;
+}
+
+/**
+ * Страница Wiki
+ */
+export interface Page {
+  readonly id: number;
+  readonly slug: string;
+  readonly title: string;
+  readonly page_type: PageType;
+  readonly attributes?: PageAttributes;
+  readonly breadcrumbs?: Breadcrumb[];
+  readonly content?: unknown;
+  readonly redirect?: PageRedirect;
+}
+
+export type PageWithUnknownFields = WithUnknownFields<Page>;
+```
+
+### 3. Grid Entity
+- [ ] Создать `src/wiki_api/entities/grid.entity.ts`
+
+```typescript
+import type { WithUnknownFields } from './types.js';
+
+/**
+ * Тип колонки
+ */
+export type ColumnType =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'select'
+  | 'staff'
+  | 'checkbox'
+  | 'ticket'
+  | 'ticket_field';
+
+/**
+ * Формат текста
+ */
+export type TextFormat = 'yfm' | 'wom' | 'plain';
+
+/**
+ * Цвет фона
+ */
+export type BGColor =
+  | 'blue' | 'yellow' | 'pink' | 'red' | 'green'
+  | 'mint' | 'grey' | 'orange' | 'magenta'
+  | 'purple' | 'copper' | 'ocean';
+
+/**
+ * Колонка таблицы
+ */
+export interface GridColumn {
+  readonly id?: string;
+  readonly title: string;
+  readonly slug: string;
+  readonly type: ColumnType;
+  readonly required: boolean;
+  readonly color?: BGColor;
+  readonly width?: number;
+  readonly width_units?: '%' | 'px';
+  readonly pinned?: 'left' | 'right';
+  readonly format?: TextFormat;
+  readonly multiple?: boolean;
+  readonly select_options?: string[];
+  readonly description?: string;
+}
+
+/**
+ * Строка таблицы
+ */
+export interface GridRow {
+  readonly id: string;
+  readonly row: unknown[];
+  readonly pinned?: boolean;
+  readonly color?: BGColor;
+}
+
+/**
+ * Сортировка
+ */
+export interface SortConfig {
+  readonly column_slug: string;
+  readonly direction: 'asc' | 'desc';
+}
+
+/**
+ * Структура таблицы
+ */
+export interface GridStructure {
+  readonly columns: GridColumn[];
+  readonly default_sort?: SortConfig[];
+}
+
+/**
+ * Атрибуты таблицы
+ */
+export interface GridAttributes {
+  readonly created_at: string;
+  readonly modified_at: string;
+}
+
+/**
+ * Динамическая таблица
+ */
+export interface Grid {
+  readonly created_at: string;
+  readonly title: string;
+  readonly page: {
+    readonly id: number;
+    readonly slug: string;
+  };
+  readonly revision: string;
+  readonly rich_text_format: TextFormat;
+  readonly structure: GridStructure;
+  readonly rows: GridRow[];
+  readonly attributes?: GridAttributes;
+  readonly user_permissions?: unknown;
+  readonly template_id?: string;
+}
+
+export type GridWithUnknownFields = WithUnknownFields<Grid>;
+```
+
+### 4. Resource Entity
+- [ ] Создать `src/wiki_api/entities/resource.entity.ts`
+
+```typescript
+import type { WithUnknownFields } from './types.js';
+
+/**
+ * Тип ресурса
+ */
+export type ResourceType = 'attachment' | 'grid' | 'sharepoint_resource';
+
+/**
+ * Ресурс страницы
+ */
+export interface Resource {
+  readonly item: unknown;
+  readonly type: ResourceType;
+}
+
+/**
+ * Ответ со списком ресурсов
+ */
+export interface ResourcesResponse {
+  readonly results: Resource[];
+  readonly next_cursor?: string;
+  readonly prev_cursor?: string;
+}
+
+export type ResourceWithUnknownFields = WithUnknownFields<Resource>;
+```
+
+### 5. Operation Entity
+- [ ] Создать `src/wiki_api/entities/operation.entity.ts`
+
+```typescript
+/**
+ * Тип асинхронной операции
+ */
+export type OperationType =
+  | 'clone'
+  | 'clone_grid'
+  | 'test'
+  | 'export'
+  | 'move';
+
+/**
+ * Асинхронная операция (clone, etc.)
+ */
+export interface AsyncOperation {
+  readonly operation: {
+    readonly type: OperationType;
+    readonly id: string;
+  };
+  readonly dry_run: boolean;
+  readonly status_url: string;
+}
+```
+
+### 6. Index файл
+- [ ] Создать `src/wiki_api/entities/index.ts`
+
+```typescript
+export type { WithUnknownFields } from './types.js';
+
+export type {
+  PageType,
+  PageAttributes,
+  Breadcrumb,
+  PageRedirect,
+  Page,
+  PageWithUnknownFields,
+} from './page.entity.js';
+
+export type {
+  ColumnType,
+  TextFormat,
+  BGColor,
+  GridColumn,
+  GridRow,
+  SortConfig,
+  GridStructure,
+  GridAttributes,
+  Grid,
+  GridWithUnknownFields,
+} from './grid.entity.js';
+
+export type {
+  ResourceType,
+  Resource,
+  ResourcesResponse,
+  ResourceWithUnknownFields,
+} from './resource.entity.js';
+
+export type {
+  OperationType,
+  AsyncOperation,
+} from './operation.entity.js';
+```
+
+## Валидация
+```bash
+npm run typecheck
+npm run lint
+```
+
+## Результат
+- Все entity типы определены
+- Поддержка `WithUnknownFields<T>` для forward compatibility
+- Типы экспортируются через index.ts

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/2.2_dto_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/2.2_dto_parallel.md
@@ -1,0 +1,344 @@
+# Этап 2.2: DTOs (Parallel)
+
+## Цель
+Создать Data Transfer Objects для запросов к Wiki API.
+
+## Зависимости
+- Этап 1.2 завершён
+
+## Может выполняться параллельно с
+- Этап 2.1 (Entities)
+
+## Чек-лист
+
+### 1. Page DTOs
+- [ ] Создать `src/wiki_api/dto/page/create-page.dto.ts`
+
+```typescript
+import type { PageType, TextFormat } from '#wiki_api/entities/index.js';
+
+/**
+ * Cloud page configuration (MS365)
+ */
+export type CloudPageConfig =
+  | { method: 'empty_doc'; doctype: 'docx' | 'pptx' | 'xlsx' }
+  | { method: 'from_url'; url: string }
+  | { method: 'upload_doc'; mimetype: string }
+  | { method: 'finalize_upload'; upload_session: string }
+  | { method: 'upload_onprem'; upload_session: string };
+
+/**
+ * DTO для создания страницы
+ */
+export interface CreatePageDto {
+  /** Тип страницы (обязательно) */
+  page_type: PageType;
+
+  /** Slug страницы (обязательно) */
+  slug: string;
+
+  /** Название страницы (1-255 символов, обязательно) */
+  title: string;
+
+  /** Содержимое страницы */
+  content?: string;
+
+  /** Формат текста для grid */
+  grid_format?: TextFormat;
+
+  /** Конфигурация облачного документа */
+  cloud_page?: CloudPageConfig;
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/page/update-page.dto.ts`
+
+```typescript
+/**
+ * DTO для обновления страницы
+ */
+export interface UpdatePageDto {
+  /** Новое название (1-255 символов) */
+  title?: string;
+
+  /** Новое содержимое */
+  content?: string;
+
+  /** Redirect на другую страницу */
+  redirect?: {
+    page: {
+      id?: number;
+      slug?: string;
+    };
+  };
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/page/clone-page.dto.ts`
+
+```typescript
+/**
+ * DTO для клонирования страницы
+ */
+export interface ClonePageDto {
+  /** Целевой slug (обязательно) */
+  target: string;
+
+  /** Название копии (1-255 символов) */
+  title?: string;
+
+  /** Подписаться на изменения */
+  subscribe_me?: boolean;
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/page/append-content.dto.ts`
+
+```typescript
+/**
+ * Позиция вставки
+ */
+export type InsertLocation = 'top' | 'bottom';
+
+/**
+ * DTO для добавления контента
+ */
+export interface AppendContentDto {
+  /** Контент для добавления (обязательно) */
+  content: string;
+
+  /** Вставка в тело страницы */
+  body?: {
+    location: InsertLocation;
+  };
+
+  /** Вставка в секцию */
+  section?: {
+    id: number;
+    location: InsertLocation;
+  };
+
+  /** Вставка по якорю */
+  anchor?: {
+    name: string;
+    fallback?: boolean;
+    regex?: boolean;
+  };
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/page/index.ts`
+
+### 2. Grid DTOs
+- [ ] Создать `src/wiki_api/dto/grid/create-grid.dto.ts`
+
+```typescript
+/**
+ * DTO для создания таблицы
+ */
+export interface CreateGridDto {
+  /** Название таблицы (1-255 символов, обязательно) */
+  title: string;
+
+  /** Страница для таблицы (обязательно) */
+  page: {
+    id?: number;
+    slug?: string;
+  };
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/grid/update-grid.dto.ts`
+
+```typescript
+import type { SortConfig } from '#wiki_api/entities/index.js';
+
+/**
+ * DTO для обновления таблицы
+ */
+export interface UpdateGridDto {
+  /** Текущая ревизия (обязательно) */
+  revision: string;
+
+  /** Новое название (1-255 символов) */
+  title?: string;
+
+  /** Сортировка по умолчанию */
+  default_sort?: SortConfig[];
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/grid/rows.dto.ts`
+
+```typescript
+import type { BGColor } from '#wiki_api/entities/index.js';
+
+/**
+ * DTO для добавления строк
+ */
+export interface AddRowsDto {
+  /** Ревизия таблицы */
+  revision?: string;
+
+  /** Позиция вставки */
+  position?: number;
+
+  /** Вставить после строки */
+  after_row_id?: string;
+
+  /** Данные строк (обязательно) */
+  rows: Array<{
+    row: unknown[];
+    pinned?: boolean;
+    color?: BGColor;
+  }>;
+}
+
+/**
+ * DTO для удаления строк
+ */
+export interface RemoveRowsDto {
+  /** Ревизия таблицы */
+  revision?: string;
+
+  /** ID строк для удаления (обязательно) */
+  row_ids: string[];
+}
+
+/**
+ * DTO для перемещения строки
+ */
+export interface MoveRowDto {
+  /** ID строки (обязательно) */
+  row_id: string;
+
+  /** Переместить после строки */
+  after_row_id?: string;
+
+  /** Позиция */
+  position?: number;
+
+  /** Ревизия */
+  revision?: string;
+
+  /** Количество строк */
+  rows_count?: number;
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/grid/columns.dto.ts`
+
+```typescript
+import type { GridColumn } from '#wiki_api/entities/index.js';
+
+/**
+ * DTO для добавления колонок
+ */
+export interface AddColumnsDto {
+  /** Ревизия */
+  revision?: string;
+
+  /** Позиция вставки */
+  position?: number;
+
+  /** Колонки (обязательно) */
+  columns: Omit<GridColumn, 'id'>[];
+}
+
+/**
+ * DTO для удаления колонок
+ */
+export interface RemoveColumnsDto {
+  /** Ревизия */
+  revision?: string;
+
+  /** Slugs колонок для удаления (обязательно) */
+  column_slugs: string[];
+}
+
+/**
+ * DTO для перемещения колонки
+ */
+export interface MoveColumnDto {
+  /** Slug колонки (обязательно) */
+  column_slug: string;
+
+  /** Целевая позиция (обязательно) */
+  position: number;
+
+  /** Ревизия */
+  revision?: string;
+
+  /** Количество колонок */
+  columns_count?: number;
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/grid/cells.dto.ts`
+
+```typescript
+/**
+ * DTO для обновления ячеек
+ */
+export interface UpdateCellsDto {
+  /** Ревизия */
+  revision?: string;
+
+  /** Ячейки для обновления (обязательно) */
+  cells: Array<{
+    row_id: number;
+    column_slug: string;
+    value: unknown;
+  }>;
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/grid/clone-grid.dto.ts`
+
+```typescript
+/**
+ * DTO для клонирования таблицы
+ */
+export interface CloneGridDto {
+  /** Целевой slug страницы (обязательно) */
+  target: string;
+
+  /** Название копии (1-255 символов) */
+  title?: string;
+
+  /** Копировать с данными */
+  with_data?: boolean;
+}
+```
+
+- [ ] Создать `src/wiki_api/dto/grid/index.ts`
+
+### 3. Главный Index
+- [ ] Создать `src/wiki_api/dto/index.ts`
+
+```typescript
+// Page DTOs
+export type { CreatePageDto, CloudPageConfig } from './page/create-page.dto.js';
+export type { UpdatePageDto } from './page/update-page.dto.js';
+export type { ClonePageDto } from './page/clone-page.dto.js';
+export type { AppendContentDto, InsertLocation } from './page/append-content.dto.js';
+
+// Grid DTOs
+export type { CreateGridDto } from './grid/create-grid.dto.js';
+export type { UpdateGridDto } from './grid/update-grid.dto.js';
+export type { AddRowsDto, RemoveRowsDto, MoveRowDto } from './grid/rows.dto.js';
+export type { AddColumnsDto, RemoveColumnsDto, MoveColumnDto } from './grid/columns.dto.js';
+export type { UpdateCellsDto } from './grid/cells.dto.js';
+export type { CloneGridDto } from './grid/clone-grid.dto.js';
+```
+
+## Валидация
+```bash
+npm run typecheck
+npm run lint
+```
+
+## Результат
+- Все DTO типы определены для Pages и Grids
+- Типы экспортируются через index.ts
+- Готовы для использования в Operations

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/3.1_page_operations_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/3.1_page_operations_parallel.md
@@ -1,0 +1,291 @@
+# Этап 3.1: Page Operations (Parallel)
+
+## Цель
+Создать API Operations для работы со страницами Wiki.
+
+## Зависимости
+- Этап 2.1 (Entities) завершён
+- Этап 2.2 (DTOs) завершён
+
+## Чек-лист
+
+### 1. Base Operation
+- [ ] Создать `src/wiki_api/api_operations/base-operation.ts`
+
+```typescript
+import type { IHttpClient, CacheManager } from '@mcp-framework/infrastructure';
+import type { Logger } from '@mcp-framework/infrastructure';
+
+/**
+ * Базовый класс для API операций Wiki
+ */
+export abstract class BaseOperation {
+  constructor(
+    protected readonly httpClient: IHttpClient,
+    protected readonly cacheManager: CacheManager,
+    protected readonly logger: Logger
+  ) {}
+
+  /**
+   * Выполнение с кешированием
+   */
+  protected async withCache<T>(
+    cacheKey: string,
+    fn: () => Promise<T>,
+    ttl?: number
+  ): Promise<T> {
+    const cached = await this.cacheManager.get<T>(cacheKey);
+    if (cached !== undefined) {
+      this.logger.debug(`Cache hit: ${cacheKey}`);
+      return cached;
+    }
+
+    const result = await fn();
+    await this.cacheManager.set(cacheKey, result, ttl);
+    return result;
+  }
+}
+```
+
+### 2. Get Page Operation
+- [ ] Создать `src/wiki_api/api_operations/page/get-page.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+import type { PageWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export interface GetPageParams {
+  slug: string;
+  fields?: string;
+  raise_on_redirect?: boolean;
+  revision_id?: number;
+}
+
+export class GetPageOperation extends BaseOperation {
+  async execute(params: GetPageParams): Promise<PageWithUnknownFields> {
+    const queryParams: Record<string, string | number | boolean> = {
+      slug: params.slug,
+    };
+
+    if (params.fields) queryParams.fields = params.fields;
+    if (params.raise_on_redirect) queryParams.raise_on_redirect = true;
+    if (params.revision_id) queryParams.revision_id = params.revision_id;
+
+    this.logger.info(`Getting page by slug: ${params.slug}`);
+
+    return this.httpClient.get<PageWithUnknownFields>('/v1/pages', queryParams);
+  }
+}
+```
+
+### 3. Get Page By ID Operation
+- [ ] Создать `src/wiki_api/api_operations/page/get-page-by-id.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+import type { PageWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export interface GetPageByIdParams {
+  idx: number;
+  fields?: string;
+  raise_on_redirect?: boolean;
+  revision_id?: number;
+}
+
+export class GetPageByIdOperation extends BaseOperation {
+  async execute(params: GetPageByIdParams): Promise<PageWithUnknownFields> {
+    const queryParams: Record<string, string | number | boolean> = {};
+
+    if (params.fields) queryParams.fields = params.fields;
+    if (params.raise_on_redirect) queryParams.raise_on_redirect = true;
+    if (params.revision_id) queryParams.revision_id = params.revision_id;
+
+    this.logger.info(`Getting page by id: ${params.idx}`);
+
+    return this.httpClient.get<PageWithUnknownFields>(
+      `/v1/pages/${params.idx}`,
+      queryParams
+    );
+  }
+}
+```
+
+### 4. Create Page Operation
+- [ ] Создать `src/wiki_api/api_operations/page/create-page.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+import type { CreatePageDto } from '#wiki_api/dto/index.js';
+
+export interface CreatePageParams {
+  data: CreatePageDto;
+  fields?: string;
+  is_silent?: boolean;
+}
+
+export class CreatePageOperation extends BaseOperation {
+  async execute(params: CreatePageParams): Promise<Record<string, never>> {
+    const queryParams: Record<string, string | boolean> = {};
+
+    if (params.fields) queryParams.fields = params.fields;
+    if (params.is_silent) queryParams.is_silent = true;
+
+    this.logger.info(`Creating page: ${params.data.slug}`);
+
+    return this.httpClient.post<Record<string, never>>(
+      '/v1/pages',
+      params.data
+    );
+  }
+}
+```
+
+### 5. Update Page Operation
+- [ ] Создать `src/wiki_api/api_operations/page/update-page.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+import type { UpdatePageDto } from '#wiki_api/dto/index.js';
+import type { PageWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export interface UpdatePageParams {
+  idx: number;
+  data: UpdatePageDto;
+  allow_merge?: boolean;
+  fields?: string;
+  is_silent?: boolean;
+}
+
+export class UpdatePageOperation extends BaseOperation {
+  async execute(params: UpdatePageParams): Promise<PageWithUnknownFields> {
+    const queryParams: Record<string, string | boolean> = {};
+
+    if (params.allow_merge) queryParams.allow_merge = true;
+    if (params.fields) queryParams.fields = params.fields;
+    if (params.is_silent) queryParams.is_silent = true;
+
+    this.logger.info(`Updating page: ${params.idx}`);
+
+    // Wiki API использует POST для update
+    return this.httpClient.post<PageWithUnknownFields>(
+      `/v1/pages/${params.idx}`,
+      params.data
+    );
+  }
+}
+```
+
+### 6. Delete Page Operation
+- [ ] Создать `src/wiki_api/api_operations/page/delete-page.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+
+export interface DeletePageResult {
+  recovery_token: string;
+}
+
+export class DeletePageOperation extends BaseOperation {
+  async execute(idx: number): Promise<DeletePageResult> {
+    this.logger.info(`Deleting page: ${idx}`);
+
+    return this.httpClient.delete<DeletePageResult>(`/v1/pages/${idx}`);
+  }
+}
+```
+
+### 7. Clone Page Operation
+- [ ] Создать `src/wiki_api/api_operations/page/clone-page.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+import type { ClonePageDto } from '#wiki_api/dto/index.js';
+import type { AsyncOperation } from '#wiki_api/entities/index.js';
+
+export class ClonePageOperation extends BaseOperation {
+  async execute(idx: number, data: ClonePageDto): Promise<AsyncOperation> {
+    this.logger.info(`Cloning page ${idx} to ${data.target}`);
+
+    return this.httpClient.post<AsyncOperation>(
+      `/v1/pages/${idx}/clone`,
+      data
+    );
+  }
+}
+```
+
+### 8. Append Content Operation
+- [ ] Создать `src/wiki_api/api_operations/page/append-content.operation.ts`
+
+```typescript
+import { BaseOperation } from '../base-operation.js';
+import type { AppendContentDto } from '#wiki_api/dto/index.js';
+import type { PageWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export interface AppendContentParams {
+  idx: number;
+  data: AppendContentDto;
+  fields?: string;
+  is_silent?: boolean;
+}
+
+export class AppendContentOperation extends BaseOperation {
+  async execute(params: AppendContentParams): Promise<PageWithUnknownFields> {
+    const queryParams: Record<string, string | boolean> = {};
+
+    if (params.fields) queryParams.fields = params.fields;
+    if (params.is_silent) queryParams.is_silent = true;
+
+    this.logger.info(`Appending content to page: ${params.idx}`);
+
+    return this.httpClient.post<PageWithUnknownFields>(
+      `/v1/pages/${params.idx}/append-content`,
+      params.data
+    );
+  }
+}
+```
+
+### 9. Index файлы
+- [ ] Создать `src/wiki_api/api_operations/page/index.ts`
+
+```typescript
+export { GetPageOperation } from './get-page.operation.js';
+export type { GetPageParams } from './get-page.operation.js';
+
+export { GetPageByIdOperation } from './get-page-by-id.operation.js';
+export type { GetPageByIdParams } from './get-page-by-id.operation.js';
+
+export { CreatePageOperation } from './create-page.operation.js';
+export type { CreatePageParams } from './create-page.operation.js';
+
+export { UpdatePageOperation } from './update-page.operation.js';
+export type { UpdatePageParams } from './update-page.operation.js';
+
+export { DeletePageOperation } from './delete-page.operation.js';
+export type { DeletePageResult } from './delete-page.operation.js';
+
+export { ClonePageOperation } from './clone-page.operation.js';
+
+export { AppendContentOperation } from './append-content.operation.js';
+export type { AppendContentParams } from './append-content.operation.js';
+```
+
+- [ ] Создать `src/wiki_api/api_operations/index.ts`
+
+```typescript
+export { BaseOperation } from './base-operation.js';
+export * from './page/index.js';
+// export * from './grid/index.js';  // TODO: добавить позже
+```
+
+## Валидация
+```bash
+npm run typecheck
+npm run lint
+```
+
+## Результат
+- 7 операций для Pages API готовы
+- Все операции наследуют BaseOperation
+- Готовы для использования в Facade

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/4.1_facade_services_sequential.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/4.1_facade_services_sequential.md
@@ -1,0 +1,201 @@
+# Этап 4.1: Facade & Services (Sequential)
+
+## Цель
+Создать Facade и доменные сервисы для Wiki API.
+
+## Зависимости
+- Этап 3.1 (Page Operations) завершён
+
+## Чек-лист
+
+### 1. Page Service
+- [ ] Создать `src/wiki_api/facade/services/page.service.ts`
+
+```typescript
+import { injectable, inject } from 'inversify';
+import {
+  GetPageOperation,
+  GetPageByIdOperation,
+  CreatePageOperation,
+  UpdatePageOperation,
+  DeletePageOperation,
+  ClonePageOperation,
+  AppendContentOperation,
+} from '#wiki_api/api_operations/index.js';
+import type {
+  GetPageParams,
+  GetPageByIdParams,
+  CreatePageParams,
+  UpdatePageParams,
+  AppendContentParams,
+  DeletePageResult,
+} from '#wiki_api/api_operations/index.js';
+import type { PageWithUnknownFields, AsyncOperation } from '#wiki_api/entities/index.js';
+import type { ClonePageDto } from '#wiki_api/dto/index.js';
+
+@injectable()
+export class PageService {
+  constructor(
+    @inject(GetPageOperation) private readonly getPageOp: GetPageOperation,
+    @inject(GetPageByIdOperation) private readonly getPageByIdOp: GetPageByIdOperation,
+    @inject(CreatePageOperation) private readonly createPageOp: CreatePageOperation,
+    @inject(UpdatePageOperation) private readonly updatePageOp: UpdatePageOperation,
+    @inject(DeletePageOperation) private readonly deletePageOp: DeletePageOperation,
+    @inject(ClonePageOperation) private readonly clonePageOp: ClonePageOperation,
+    @inject(AppendContentOperation) private readonly appendContentOp: AppendContentOperation
+  ) {}
+
+  async getPage(params: GetPageParams): Promise<PageWithUnknownFields> {
+    return this.getPageOp.execute(params);
+  }
+
+  async getPageById(params: GetPageByIdParams): Promise<PageWithUnknownFields> {
+    return this.getPageByIdOp.execute(params);
+  }
+
+  async createPage(params: CreatePageParams): Promise<Record<string, never>> {
+    return this.createPageOp.execute(params);
+  }
+
+  async updatePage(params: UpdatePageParams): Promise<PageWithUnknownFields> {
+    return this.updatePageOp.execute(params);
+  }
+
+  async deletePage(idx: number): Promise<DeletePageResult> {
+    return this.deletePageOp.execute(idx);
+  }
+
+  async clonePage(idx: number, data: ClonePageDto): Promise<AsyncOperation> {
+    return this.clonePageOp.execute(idx, data);
+  }
+
+  async appendContent(params: AppendContentParams): Promise<PageWithUnknownFields> {
+    return this.appendContentOp.execute(params);
+  }
+}
+```
+
+### 2. Services Index
+- [ ] Создать `src/wiki_api/facade/services/index.ts`
+
+```typescript
+export { PageService } from './page.service.js';
+// export { GridService } from './grid.service.js';  // TODO: добавить позже
+```
+
+### 3. YandexWikiFacade
+- [ ] Создать `src/wiki_api/facade/yandex-wiki.facade.ts`
+
+```typescript
+import { injectable, inject } from 'inversify';
+import { PageService } from './services/index.js';
+import type {
+  GetPageParams,
+  GetPageByIdParams,
+  CreatePageParams,
+  UpdatePageParams,
+  AppendContentParams,
+  DeletePageResult,
+} from '#wiki_api/api_operations/index.js';
+import type { PageWithUnknownFields, AsyncOperation } from '#wiki_api/entities/index.js';
+import type { ClonePageDto } from '#wiki_api/dto/index.js';
+
+/**
+ * Фасад для работы с API Yandex Wiki
+ *
+ * Ответственность:
+ * - ТОЛЬКО делегирование вызовов доменным сервисам
+ * - НЕТ бизнес-логики
+ */
+@injectable()
+export class YandexWikiFacade {
+  constructor(
+    @inject(PageService) private readonly pageService: PageService
+    // @inject(GridService) private readonly gridService: GridService  // TODO
+  ) {}
+
+  // === Page Methods ===
+
+  /**
+   * Получает страницу по slug
+   */
+  async getPage(params: GetPageParams): Promise<PageWithUnknownFields> {
+    return this.pageService.getPage(params);
+  }
+
+  /**
+   * Получает страницу по ID
+   */
+  async getPageById(params: GetPageByIdParams): Promise<PageWithUnknownFields> {
+    return this.pageService.getPageById(params);
+  }
+
+  /**
+   * Создает новую страницу
+   */
+  async createPage(params: CreatePageParams): Promise<Record<string, never>> {
+    return this.pageService.createPage(params);
+  }
+
+  /**
+   * Обновляет страницу
+   */
+  async updatePage(params: UpdatePageParams): Promise<PageWithUnknownFields> {
+    return this.pageService.updatePage(params);
+  }
+
+  /**
+   * Удаляет страницу
+   * @returns recovery_token для восстановления
+   */
+  async deletePage(idx: number): Promise<DeletePageResult> {
+    return this.pageService.deletePage(idx);
+  }
+
+  /**
+   * Клонирует страницу
+   * @returns AsyncOperation с status_url для отслеживания
+   */
+  async clonePage(idx: number, data: ClonePageDto): Promise<AsyncOperation> {
+    return this.pageService.clonePage(idx, data);
+  }
+
+  /**
+   * Добавляет контент к странице
+   */
+  async appendContent(params: AppendContentParams): Promise<PageWithUnknownFields> {
+    return this.pageService.appendContent(params);
+  }
+
+  // === Grid Methods (TODO) ===
+}
+```
+
+### 4. Facade Index
+- [ ] Создать `src/wiki_api/facade/index.ts`
+
+```typescript
+export { YandexWikiFacade } from './yandex-wiki.facade.js';
+export * from './services/index.js';
+```
+
+### 5. Wiki API Index
+- [ ] Создать `src/wiki_api/index.ts`
+
+```typescript
+export * from './entities/index.js';
+export * from './dto/index.js';
+export * from './api_operations/index.js';
+export * from './facade/index.js';
+```
+
+## Валидация
+```bash
+npm run typecheck
+npm run lint
+```
+
+## Результат
+- PageService инкапсулирует логику работы со страницами
+- YandexWikiFacade предоставляет единый интерфейс для Tools
+- Готово для DI регистрации

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/5.1_page_tools_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/5.1_page_tools_parallel.md
@@ -1,0 +1,213 @@
+# Этап 5.1: Page Tools (Parallel)
+
+## Цель
+Создать MCP Tools для работы со страницами Wiki.
+
+## Зависимости
+- Этап 4.1 (Facade & Services) завершён
+
+## Чек-лист
+
+### 1. Common Schemas
+- [ ] Создать `src/common/schemas/page-id.schema.ts`
+
+```typescript
+import { z } from 'zod';
+
+/**
+ * Schema для ID страницы (integer)
+ */
+export const PageIdSchema = z
+  .number()
+  .int()
+  .positive()
+  .describe('ID страницы Wiki (целое число)');
+
+/**
+ * Schema для slug страницы (path)
+ */
+export const PageSlugSchema = z
+  .string()
+  .min(1)
+  .describe('Slug страницы Wiki (например, users/docs/readme)');
+```
+
+- [ ] Создать `src/common/schemas/fields.schema.ts`
+
+```typescript
+import { z } from 'zod';
+
+/**
+ * Schema для дополнительных полей ответа
+ */
+export const WikiFieldsSchema = z
+  .string()
+  .optional()
+  .describe('Дополнительные поля через запятую: attributes, breadcrumbs, content, redirect');
+```
+
+- [ ] Создать `src/common/schemas/index.ts`
+
+### 2. Get Page Tool
+- [ ] Создать `src/tools/api/pages/get/get-page.schema.ts`
+
+```typescript
+import { z } from 'zod';
+import { PageSlugSchema, WikiFieldsSchema } from '#common/schemas/index.js';
+
+export const GetPageParamsSchema = z.object({
+  slug: PageSlugSchema,
+  fields: WikiFieldsSchema,
+  raise_on_redirect: z
+    .boolean()
+    .optional()
+    .describe('Вернуть ошибку при редиректе (default: false)'),
+  revision_id: z
+    .number()
+    .int()
+    .optional()
+    .describe('ID конкретной ревизии страницы'),
+});
+
+export type GetPageParams = z.infer<typeof GetPageParamsSchema>;
+```
+
+- [ ] Создать `src/tools/api/pages/get/get-page.metadata.ts`
+
+```typescript
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const GET_PAGE_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_page', MCP_TOOL_PREFIX),
+  description: '[Pages/Read] Получить страницу Wiki по slug',
+  category: ToolCategory.PAGES,  // Нужно добавить в core
+  subcategory: 'read',
+  priority: ToolPriority.CRITICAL,
+  tags: ['read', 'get', 'page', 'wiki'],
+  isHelper: false,
+} as const;
+```
+
+- [ ] Создать `src/tools/api/pages/get/get-page.tool.ts`
+
+```typescript
+import { BaseTool } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { ResponseFieldFilter, ResultLogger } from '@mcp-framework/core';
+import { GetPageParamsSchema } from './get-page.schema.js';
+import { GET_PAGE_TOOL_METADATA } from './get-page.metadata.js';
+
+export class GetPageTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = GET_PAGE_TOOL_METADATA;
+
+  protected override getParamsSchema() {
+    return GetPageParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, GetPageParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { slug, fields, raise_on_redirect, revision_id } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Получение страницы', 1);
+
+      const page = await this.facade.getPage({
+        slug,
+        fields,
+        raise_on_redirect,
+        revision_id,
+      });
+
+      return this.formatSuccess({
+        page,
+        fieldsReturned: fields?.split(',') ?? ['id', 'slug', 'title', 'page_type'],
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при получении страницы: ${slug}`, error);
+    }
+  }
+}
+```
+
+- [ ] Создать `src/tools/api/pages/get/index.ts`
+
+### 3. Get Page By ID Tool
+- [ ] Создать структуру `src/tools/api/pages/get-by-id/`
+  - `get-page-by-id.schema.ts`
+  - `get-page-by-id.metadata.ts`
+  - `get-page-by-id.tool.ts`
+  - `index.ts`
+
+### 4. Create Page Tool
+- [ ] Создать структуру `src/tools/api/pages/create/`
+  - `create-page.schema.ts` — page_type, slug, title, content (опционально)
+  - `create-page.metadata.ts`
+  - `create-page.tool.ts`
+  - `index.ts`
+
+### 5. Update Page Tool
+- [ ] Создать структуру `src/tools/api/pages/update/`
+  - `update-page.schema.ts` — idx, title, content, allow_merge
+  - `update-page.metadata.ts`
+  - `update-page.tool.ts`
+  - `index.ts`
+
+### 6. Delete Page Tool
+- [ ] Создать структуру `src/tools/api/pages/delete/`
+  - `delete-page.schema.ts` — idx
+  - `delete-page.metadata.ts`
+  - `delete-page.tool.ts` — возвращает recovery_token
+  - `index.ts`
+
+### 7. Clone Page Tool
+- [ ] Создать структуру `src/tools/api/pages/clone/`
+  - `clone-page.schema.ts` — idx, target, title, subscribe_me
+  - `clone-page.metadata.ts`
+  - `clone-page.tool.ts` — возвращает AsyncOperation с status_url
+  - `index.ts`
+
+### 8. Append Content Tool
+- [ ] Создать структуру `src/tools/api/pages/append/`
+  - `append-content.schema.ts` — idx, content, body/section/anchor
+  - `append-content.metadata.ts`
+  - `append-content.tool.ts`
+  - `index.ts`
+
+### 9. Ping Tool
+- [ ] Создать `src/tools/helpers/ping/`
+  - Простой tool для проверки подключения
+  - Использовать GET `/v1/pages?slug=homepage` или аналог
+
+### 10. Tools Index
+- [ ] Создать `src/tools/api/pages/index.ts`
+- [ ] Создать `src/tools/api/index.ts`
+- [ ] Создать `src/tools/index.ts`
+
+## Пример структуры tool директории
+
+```
+src/tools/api/pages/get/
+├── get-page.schema.ts      # Zod schema (source of truth)
+├── get-page.metadata.ts    # Static metadata
+├── get-page.tool.ts        # Tool class
+└── index.ts                # Re-exports
+```
+
+## Валидация
+```bash
+npm run typecheck
+npm run lint
+npm run test  # unit tests для tools
+```
+
+## Результат
+- 7 Page tools + 1 Ping tool готовы
+- Все tools используют Zod schemas
+- Готовы для регистрации в DI

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/6.1_composition_root_sequential.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/6.1_composition_root_sequential.md
@@ -1,0 +1,231 @@
+# Этап 6.1: Composition Root (Sequential)
+
+## Цель
+Настроить Dependency Injection с InversifyJS.
+
+## Зависимости
+- Этап 5.1 (Page Tools) завершён
+
+## Чек-лист
+
+### 1. DI Types
+- [ ] Создать `src/composition-root/types.ts`
+
+```typescript
+/**
+ * Symbol-based DI токены
+ */
+export const TYPES = {
+  // Infrastructure
+  ServerConfig: Symbol.for('ServerConfig'),
+  Logger: Symbol.for('Logger'),
+  HttpClient: Symbol.for('HttpClient'),
+  CacheManager: Symbol.for('CacheManager'),
+  RetryStrategy: Symbol.for('RetryStrategy'),
+
+  // Facade
+  YandexWikiFacade: Symbol.for('YandexWikiFacade'),
+
+  // Services
+  PageService: Symbol.for('PageService'),
+  // GridService: Symbol.for('GridService'),  // TODO
+
+  // Registry
+  ToolRegistry: Symbol.for('ToolRegistry'),
+  ToolSearchEngine: Symbol.for('ToolSearchEngine'),
+} as const;
+
+/**
+ * Автоматически генерируемые символы для Tools
+ */
+export const TOOL_SYMBOLS: Record<string, symbol> = {};
+
+/**
+ * Автоматически генерируемые символы для Operations
+ */
+export const OPERATION_SYMBOLS: Record<string, symbol> = {};
+```
+
+### 2. Tool Definitions
+- [ ] Создать `src/composition-root/definitions/tool-definitions.ts`
+
+```typescript
+import { PingTool } from '#tools/helpers/ping/index.js';
+import { GetPageTool } from '#tools/api/pages/get/index.js';
+import { GetPageByIdTool } from '#tools/api/pages/get-by-id/index.js';
+import { CreatePageTool } from '#tools/api/pages/create/index.js';
+import { UpdatePageTool } from '#tools/api/pages/update/index.js';
+import { DeletePageTool } from '#tools/api/pages/delete/index.js';
+import { ClonePageTool } from '#tools/api/pages/clone/index.js';
+import { AppendContentTool } from '#tools/api/pages/append/index.js';
+
+/**
+ * Все Tool классы для автоматической регистрации
+ *
+ * Для добавления нового tool - просто добавь класс в массив
+ */
+export const TOOL_CLASSES = [
+  // Helpers
+  PingTool,
+
+  // Pages
+  GetPageTool,
+  GetPageByIdTool,
+  CreatePageTool,
+  UpdatePageTool,
+  DeletePageTool,
+  ClonePageTool,
+  AppendContentTool,
+] as const;
+```
+
+### 3. Operation Definitions
+- [ ] Создать `src/composition-root/definitions/operation-definitions.ts`
+
+```typescript
+import {
+  GetPageOperation,
+  GetPageByIdOperation,
+  CreatePageOperation,
+  UpdatePageOperation,
+  DeletePageOperation,
+  ClonePageOperation,
+  AppendContentOperation,
+} from '#wiki_api/api_operations/index.js';
+
+/**
+ * Все Operation классы для автоматической регистрации
+ */
+export const OPERATION_CLASSES = [
+  GetPageOperation,
+  GetPageByIdOperation,
+  CreatePageOperation,
+  UpdatePageOperation,
+  DeletePageOperation,
+  ClonePageOperation,
+  AppendContentOperation,
+] as const;
+```
+
+### 4. Facade Services Binding
+- [ ] Создать `src/composition-root/definitions/facade-services.ts`
+
+```typescript
+import type { Container } from 'inversify';
+import { PageService } from '#wiki_api/facade/services/index.js';
+
+/**
+ * Регистрация доменных сервисов
+ */
+export function bindFacadeServices(container: Container): void {
+  container.bind(PageService).toSelf().inSingletonScope();
+  // container.bind(GridService).toSelf().inSingletonScope();  // TODO
+}
+```
+
+### 5. Definitions Index
+- [ ] Создать `src/composition-root/definitions/index.ts`
+
+```typescript
+export { TOOL_CLASSES } from './tool-definitions.js';
+export { OPERATION_CLASSES } from './operation-definitions.js';
+export { bindFacadeServices } from './facade-services.js';
+```
+
+### 6. Container
+- [ ] Создать `src/composition-root/container.ts`
+- [ ] Скопировать логику из yandex-tracker/composition-root/container.ts
+- [ ] Адаптировать:
+  - Заменить YandexTrackerFacade на YandexWikiFacade
+  - Использовать YANDEX_WIKI_API_BASE
+  - Убрать batch-related конфигурацию
+  - Обновить imports
+
+### 7. Validation
+- [ ] Создать `src/composition-root/validation.ts`
+
+```typescript
+import { TOOL_CLASSES } from './definitions/tool-definitions.js';
+import { OPERATION_CLASSES } from './definitions/operation-definitions.js';
+
+/**
+ * Валидация уникальности имён классов в DI
+ */
+export function validateDIRegistrations(): void {
+  const names = new Set<string>();
+
+  for (const ToolClass of TOOL_CLASSES) {
+    if (names.has(ToolClass.name)) {
+      throw new Error(`Duplicate tool class name: ${ToolClass.name}`);
+    }
+    names.add(ToolClass.name);
+  }
+
+  for (const OpClass of OPERATION_CLASSES) {
+    if (names.has(OpClass.name)) {
+      throw new Error(`Duplicate operation class name: ${OpClass.name}`);
+    }
+    names.add(OpClass.name);
+  }
+}
+```
+
+### 8. Composition Root Index
+- [ ] Создать `src/composition-root/index.ts`
+
+```typescript
+export { createContainer } from './container.js';
+export { TYPES, TOOL_SYMBOLS, OPERATION_SYMBOLS } from './types.js';
+export { validateDIRegistrations } from './validation.js';
+```
+
+### 9. Entry Point (финализация)
+- [ ] Обновить `src/index.ts`
+
+```typescript
+import 'reflect-metadata';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { loadConfig } from '#config';
+import { createContainer } from '#composition-root/index.js';
+import { TYPES } from '#composition-root/types.js';
+import { ToolRegistry } from '@mcp-framework/core';
+import type { Logger } from '@mcp-framework/infrastructure';
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const container = await createContainer(config);
+
+  const logger = container.get<Logger>(TYPES.Logger);
+  const toolRegistry = container.get<ToolRegistry>(TYPES.ToolRegistry);
+
+  logger.info('Starting Yandex Wiki MCP Server...');
+
+  const server = new Server(
+    { name: 'mcp-server-yandex-wiki', version: '0.1.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  // Регистрация tools
+  server.setRequestHandler(/* ... */);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  logger.info('Yandex Wiki MCP Server started');
+}
+
+main().catch(console.error);
+```
+
+## Валидация
+```bash
+npm run build
+npm run typecheck
+npm run validate
+```
+
+## Результат
+- DI контейнер полностью настроен
+- Все компоненты автоматически регистрируются
+- Entry point готов к запуску

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/7.1_tests_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/7.1_tests_parallel.md
@@ -1,0 +1,188 @@
+# Этап 7.1: Unit Tests (Parallel)
+
+## Цель
+Создать unit тесты для всех компонентов.
+
+## Зависимости
+- Этап 6.1 (Composition Root) завершён
+
+## Чек-лист
+
+### 1. Test Helpers
+- [ ] Создать `tests/helpers/mock-http-client.ts`
+
+```typescript
+import type { IHttpClient } from '@mcp-framework/infrastructure';
+
+export function createMockHttpClient(): jest.Mocked<IHttpClient> {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+```
+
+- [ ] Создать `tests/helpers/mock-logger.ts`
+- [ ] Создать `tests/helpers/mock-cache.ts`
+- [ ] Создать `tests/helpers/fixtures/page.fixture.ts`
+
+```typescript
+import type { Page, PageWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export function createPageFixture(overrides?: Partial<Page>): PageWithUnknownFields {
+  return {
+    id: 123,
+    slug: 'users/docs/test-page',
+    title: 'Test Page',
+    page_type: 'page',
+    ...overrides,
+  };
+}
+```
+
+- [ ] Создать `tests/helpers/index.ts`
+
+### 2. Entity Tests
+- [ ] Создать `tests/unit/wiki_api/entities/page.entity.test.ts`
+  - Проверка типов
+  - Проверка WithUnknownFields
+
+### 3. Operation Tests
+- [ ] Создать `tests/unit/wiki_api/api_operations/page/get-page.operation.test.ts`
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetPageOperation } from '#wiki_api/api_operations/page/get-page.operation.js';
+import { createMockHttpClient, createMockLogger, createMockCache } from '#helpers/index.js';
+import { createPageFixture } from '#helpers/fixtures/page.fixture.js';
+
+describe('GetPageOperation', () => {
+  let operation: GetPageOperation;
+  let mockHttpClient: ReturnType<typeof createMockHttpClient>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    const mockLogger = createMockLogger();
+    const mockCache = createMockCache();
+    operation = new GetPageOperation(mockHttpClient, mockCache, mockLogger);
+  });
+
+  it('should fetch page by slug', async () => {
+    const expectedPage = createPageFixture();
+    mockHttpClient.get.mockResolvedValue(expectedPage);
+
+    const result = await operation.execute({ slug: 'users/docs/test' });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/pages', { slug: 'users/docs/test' });
+    expect(result).toEqual(expectedPage);
+  });
+
+  it('should pass optional parameters', async () => {
+    mockHttpClient.get.mockResolvedValue(createPageFixture());
+
+    await operation.execute({
+      slug: 'test',
+      fields: 'attributes,content',
+      raise_on_redirect: true,
+      revision_id: 5,
+    });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/pages', {
+      slug: 'test',
+      fields: 'attributes,content',
+      raise_on_redirect: true,
+      revision_id: 5,
+    });
+  });
+});
+```
+
+- [ ] Создать тесты для остальных operations:
+  - `get-page-by-id.operation.test.ts`
+  - `create-page.operation.test.ts`
+  - `update-page.operation.test.ts`
+  - `delete-page.operation.test.ts`
+  - `clone-page.operation.test.ts`
+  - `append-content.operation.test.ts`
+
+### 4. Service Tests
+- [ ] Создать `tests/unit/wiki_api/facade/services/page.service.test.ts`
+  - Проверка делегирования вызовов в operations
+
+### 5. Facade Tests
+- [ ] Создать `tests/unit/wiki_api/facade/yandex-wiki.facade.test.ts`
+  - Проверка делегирования в services
+
+### 6. Tool Tests
+- [ ] Создать `tests/unit/tools/api/pages/get/get-page.tool.test.ts`
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetPageTool } from '#tools/api/pages/get/index.js';
+import { createMockLogger } from '#helpers/index.js';
+import { createPageFixture } from '#helpers/fixtures/page.fixture.js';
+
+describe('GetPageTool', () => {
+  let tool: GetPageTool;
+  let mockFacade: { getPage: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockFacade = { getPage: vi.fn() };
+    const mockLogger = createMockLogger();
+    tool = new GetPageTool(mockFacade as any, mockLogger);
+  });
+
+  it('should return page on success', async () => {
+    const expectedPage = createPageFixture();
+    mockFacade.getPage.mockResolvedValue(expectedPage);
+
+    const result = await tool.execute({ slug: 'test-page' });
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('test-page');
+  });
+
+  it('should validate required parameters', async () => {
+    const result = await tool.execute({});
+
+    expect(result.isError).toBe(true);
+  });
+});
+```
+
+- [ ] Создать тесты для остальных tools
+
+### 7. Schema Tests
+- [ ] Создать `tests/unit/tools/api/pages/get/get-page.schema.test.ts`
+  - Проверка валидации Zod schemas
+
+### 8. Config Tests
+- [ ] Создать `tests/unit/config/config-loader.test.ts`
+  - Проверка загрузки из env
+  - Проверка валидации
+  - Проверка default values
+
+### 9. Integration Tests (опционально)
+- [ ] Создать `tests/integration/wiki-api.test.ts`
+  - Требует реальный токен
+  - Пометить как skip по умолчанию
+
+### 10. Tests README
+- [ ] Создать `tests/README.md`
+  - Структура тестов
+  - Как запускать
+  - Fixtures и helpers
+
+## Валидация
+```bash
+npm run test
+npm run test:coverage
+# Проверить coverage >= 80%
+```
+
+## Результат
+- Unit тесты для всех компонентов
+- Coverage >= 80%
+- Fixtures и helpers для удобства тестирования

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/8.1_documentation_sequential.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/8.1_documentation_sequential.md
@@ -1,0 +1,202 @@
+# Этап 8.1: Documentation (Sequential)
+
+## Цель
+Создать документацию для пакета.
+
+## Зависимости
+- Этап 7.1 (Tests) завершён
+
+## Чек-лист
+
+### 1. README.md
+- [ ] Создать `packages/servers/yandex-wiki/README.md`
+
+```markdown
+# MCP Server for Yandex Wiki
+
+MCP сервер для работы с API Yandex Wiki.
+
+## Установка
+
+```bash
+npm install mcp-server-yandex-wiki
+```
+
+## Конфигурация
+
+### Обязательные переменные окружения
+
+| Переменная | Описание |
+|------------|----------|
+| `YANDEX_WIKI_TOKEN` | OAuth токен для Wiki API |
+| `YANDEX_ORG_ID` | ID организации (Яндекс 360) |
+
+Или для Yandex Cloud:
+
+| Переменная | Описание |
+|------------|----------|
+| `YANDEX_WIKI_TOKEN` | OAuth токен |
+| `YANDEX_CLOUD_ORG_ID` | ID организации (Cloud) |
+
+### Опциональные переменные
+
+| Переменная | Default | Описание |
+|------------|---------|----------|
+| `LOG_LEVEL` | `info` | Уровень логирования |
+| `REQUEST_TIMEOUT` | `30000` | Таймаут запросов (мс) |
+
+## Использование
+
+### С Claude Desktop
+
+Добавьте в `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "yandex-wiki": {
+      "command": "npx",
+      "args": ["mcp-server-yandex-wiki"],
+      "env": {
+        "YANDEX_WIKI_TOKEN": "your-token",
+        "YANDEX_ORG_ID": "your-org-id"
+      }
+    }
+  }
+}
+```
+
+## Доступные инструменты
+
+### Pages
+
+| Tool | Описание |
+|------|----------|
+| `yw_get_page` | Получить страницу по slug |
+| `yw_get_page_by_id` | Получить страницу по ID |
+| `yw_create_page` | Создать страницу |
+| `yw_update_page` | Обновить страницу |
+| `yw_delete_page` | Удалить страницу |
+| `yw_clone_page` | Клонировать страницу |
+| `yw_append_content` | Добавить контент |
+
+### Helpers
+
+| Tool | Описание |
+|------|----------|
+| `yw_ping` | Проверка подключения |
+
+## Примеры
+
+### Получить страницу
+
+```
+yw_get_page(slug: "users/docs/readme", fields: "attributes,content")
+```
+
+### Создать страницу
+
+```
+yw_create_page(
+  page_type: "page",
+  slug: "users/docs/new-page",
+  title: "New Page",
+  content: "# Hello World"
+)
+```
+
+## API Reference
+
+Base URL: `https://api.wiki.yandex.net/v1/`
+
+Документация API: https://yandex.ru/support/wiki/ru/api-ref/
+
+## License
+
+MIT
+```
+
+### 2. CLAUDE.md
+- [ ] Создать `packages/servers/yandex-wiki/CLAUDE.md`
+
+```markdown
+# CLAUDE.md — Yandex Wiki MCP Server
+
+## Обязательно прочитай
+
+- [Корневой CLAUDE.md](../../../CLAUDE.md) — правила monorepo
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — архитектура
+
+## Структура пакета
+
+```
+src/
+├── index.ts                 # Entry point
+├── constants.ts             # MCP_TOOL_PREFIX = 'yw'
+├── config/                  # Конфигурация
+├── wiki_api/
+│   ├── api_operations/      # HTTP операции
+│   ├── entities/            # Типы данных
+│   ├── dto/                 # Request DTOs
+│   └── facade/              # Facade + Services
+├── tools/
+│   ├── api/pages/           # Page tools
+│   └── helpers/             # Ping tool
+└── composition-root/        # DI контейнер
+```
+
+## Добавление нового Tool
+
+1. Создать директорию `src/tools/api/{category}/{action}/`
+2. Создать файлы:
+   - `{name}.schema.ts` — Zod schema
+   - `{name}.metadata.ts` — метаданные
+   - `{name}.tool.ts` — класс tool
+   - `index.ts` — реэкспорт
+3. Добавить в `composition-root/definitions/tool-definitions.ts`
+4. Запустить `npm run validate`
+
+## Naming Conventions
+
+- Tool prefix: `yw_`
+- Tool names: `yw_get_page`, `yw_create_page`
+- Operations: `GetPageOperation`, `CreatePageOperation`
+- Services: `PageService`, `GridService`
+
+## API особенности
+
+- Base URL: `https://api.wiki.yandex.net/v1/`
+- Update через POST (не PATCH)
+- Асинхронные операции (clone) возвращают status_url
+- ID страницы: integer (`idx`)
+- Slug страницы: string path
+
+## Валидация
+
+```bash
+npm run validate        # lint + typecheck + test
+npm run validate:quiet  # для AI агентов
+```
+```
+
+### 3. Module READMEs
+- [ ] Создать `src/wiki_api/entities/README.md`
+- [ ] Создать `src/wiki_api/dto/README.md`
+- [ ] Создать `src/wiki_api/api_operations/README.md`
+- [ ] Создать `src/wiki_api/facade/README.md`
+- [ ] Создать `src/tools/README.md`
+- [ ] Создать `src/composition-root/README.md`
+
+### 4. Обновить корневую документацию
+- [ ] Добавить yandex-wiki в `DOCS.md`
+- [ ] Добавить в `README.md` список серверов
+
+## Валидация
+```bash
+npm run validate:docs  # Проверка лимитов документации
+```
+
+## Результат
+- README.md для пользователей
+- CLAUDE.md для разработчиков
+- Module READMEs для внутренней навигации

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/9.1_grid_operations_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/9.1_grid_operations_parallel.md
@@ -1,0 +1,61 @@
+# Этап 9.1: Grid Operations (Parallel) — ПРИОРИТЕТ 2
+
+## Цель
+Создать API Operations для работы с динамическими таблицами.
+
+## Зависимости
+- Этапы 1-8 завершены (Pages API работает)
+
+## API Reference
+
+| Operation | HTTP | Endpoint |
+|-----------|------|----------|
+| CreateGrid | POST | `/v1/grids` |
+| GetGrid | GET | `/v1/grids/{idx}` |
+| UpdateGrid | POST | `/v1/grids/{idx}` |
+| DeleteGrid | DELETE | `/v1/grids/{idx}` |
+| AddRows | POST | `/v1/grids/{idx}/rows` |
+| RemoveRows | DELETE | `/v1/grids/{idx}/rows` |
+| AddColumns | POST | `/v1/grids/{idx}/columns` |
+| RemoveColumns | DELETE | `/v1/grids/{idx}/columns` |
+| UpdateCells | POST | `/v1/grids/{idx}/cells` |
+| MoveRows | POST | `/v1/grids/{idx}/rows/move` |
+| MoveColumns | POST | `/v1/grids/{idx}/columns/move` |
+| CloneGrid | POST | `/v1/grids/{idx}/clone` |
+
+## Особенности
+
+- Grid ID: UUID4 (не integer как у Pages)
+- Ревизии: каждая операция возвращает новую revision
+- Clone: асинхронная операция (status_url)
+- Фильтрация: GetGrid поддерживает filter, only_cols, only_rows, sort
+
+## Чек-лист
+
+### 1. Grid Operations
+- [ ] `src/wiki_api/api_operations/grid/create-grid.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/get-grid.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/update-grid.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/delete-grid.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/add-rows.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/remove-rows.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/add-columns.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/remove-columns.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/update-cells.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/move-rows.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/move-columns.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/clone-grid.operation.ts`
+- [ ] `src/wiki_api/api_operations/grid/index.ts`
+
+### 2. Grid Service
+- [ ] `src/wiki_api/facade/services/grid.service.ts`
+- [ ] Обновить `services/index.ts`
+
+### 3. Facade Update
+- [ ] Добавить Grid методы в `YandexWikiFacade`
+
+### 4. Operation Definitions
+- [ ] Добавить Grid operations в `operation-definitions.ts`
+
+## Статус
+- [ ] Не начат

--- a/.agentic-planning/plan_yandex_wiki_mcp_server/9.2_grid_tools_parallel.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/9.2_grid_tools_parallel.md
@@ -1,0 +1,57 @@
+# Этап 9.2: Grid Tools (Parallel) — ПРИОРИТЕТ 2
+
+## Цель
+Создать MCP Tools для работы с динамическими таблицами.
+
+## Зависимости
+- Этап 9.1 (Grid Operations) завершён
+
+## Tools
+
+| Tool | Описание |
+|------|----------|
+| `yw_create_grid` | Создать таблицу |
+| `yw_get_grid` | Получить таблицу |
+| `yw_update_grid` | Обновить таблицу |
+| `yw_delete_grid` | Удалить таблицу |
+| `yw_add_rows` | Добавить строки |
+| `yw_remove_rows` | Удалить строки |
+| `yw_add_columns` | Добавить колонки |
+| `yw_remove_columns` | Удалить колонки |
+| `yw_update_cells` | Обновить ячейки |
+| `yw_move_rows` | Переместить строки |
+| `yw_move_columns` | Переместить колонки |
+| `yw_clone_grid` | Клонировать таблицу |
+
+## Чек-лист
+
+### 1. Grid Tools Structure
+```
+src/tools/api/grids/
+├── create/
+├── get/
+├── update/
+├── delete/
+├── rows/
+│   ├── add/
+│   ├── remove/
+│   └── move/
+├── columns/
+│   ├── add/
+│   ├── remove/
+│   └── move/
+├── cells/
+│   └── update/
+├── clone/
+└── index.ts
+```
+
+### 2. Create Tools
+- [ ] Каждый tool: schema.ts, metadata.ts, tool.ts, index.ts
+- [ ] Добавить в `tool-definitions.ts`
+
+### 3. Tests
+- [ ] Unit тесты для каждого tool
+
+## Статус
+- [ ] Не начат


### PR DESCRIPTION
План включает 13 этапов:
- Фаза 1 (Pages API): setup, config, entities, DTOs, operations, facade, tools, DI, tests, docs
- Фаза 2 (Grids/Resources): 12 grid operations, 12 grid tools, resources API

Ключевые решения:
- Отдельный пакет: packages/servers/yandex-wiki/
- Токен: YANDEX_WIKI_TOKEN
- Префикс: yw_
- Base URL: https://api.wiki.yandex.net (hardcoded)
- Без batch операций

🤖 Generated with Claude Code