### PR TITLE
Continue Yandex Wiki MCP server implementation

### DIFF
--- a/.agentic-planning/plan_yandex_wiki_mcp_server/0_overview.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/0_overview.md
@@ -84,22 +84,22 @@ Grids   Resources
 
 ## Этапы реализации
 
-### Фаза 1: Pages API (Основная)
+### Фаза 1: Pages API (Основная) - ЗАВЕРШЕНА
 
 | Этап | Файл | Тип | Статус |
 |------|------|-----|--------|
-| 1.1 | `1.1_package_setup_sequential.md` | sequential | [ ] |
-| 1.2 | `1.2_infrastructure_sequential.md` | sequential | [ ] |
-| 2.1 | `2.1_entities_parallel.md` | parallel | [ ] |
-| 2.2 | `2.2_dto_parallel.md` | parallel | [ ] |
-| 3.1 | `3.1_page_operations_parallel.md` | parallel | [ ] |
-| 4.1 | `4.1_facade_services_sequential.md` | sequential | [ ] |
-| 5.1 | `5.1_page_tools_parallel.md` | parallel | [ ] |
-| 6.1 | `6.1_composition_root_sequential.md` | sequential | [ ] |
-| 7.1 | `7.1_tests_parallel.md` | parallel | [ ] |
-| 8.1 | `8.1_documentation_sequential.md` | sequential | [ ] |
+| 1.1 | `1.1_package_setup_sequential.md` | sequential | [x] |
+| 1.2 | `1.2_infrastructure_sequential.md` | sequential | [x] |
+| 2.1 | `2.1_entities_parallel.md` | parallel | [x] |
+| 2.2 | `2.2_dto_parallel.md` | parallel | [x] |
+| 3.1 | `3.1_page_operations_parallel.md` | parallel | [x] |
+| 4.1 | `4.1_facade_services_sequential.md` | sequential | [x] |
+| 5.1 | `5.1_page_tools_parallel.md` | parallel | [x] |
+| 6.1 | `6.1_composition_root_sequential.md` | sequential | [x] |
+| 7.1 | `7.1_tests_parallel.md` | parallel | [x] |
+| 8.1 | `8.1_documentation_sequential.md` | sequential | [x] |
 
-### Фаза 2: Grids & Resources (Дополнительная)
+### Фаза 2: Grids & Resources (Дополнительная) - НЕ НАЧАТА
 
 | Этап | Файл | Тип | Статус |
 |------|------|-----|--------|

--- a/packages/servers/yandex-wiki/CLAUDE.md
+++ b/packages/servers/yandex-wiki/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md — Yandex Wiki MCP Server
+
+## Обязательно прочитай
+
+- [Корневой CLAUDE.md](../../../CLAUDE.md) — правила monorepo
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — архитектура
+
+## Структура пакета
+
+```
+src/
+├── index.ts                 # Entry point
+├── constants.ts             # MCP_TOOL_PREFIX = 'yw'
+├── config/                  # Конфигурация
+│   ├── server-config.interface.ts
+│   ├── constants.ts
+│   └── config-loader.ts
+├── wiki_api/
+│   ├── api_operations/      # HTTP операции
+│   │   ├── base-operation.ts
+│   │   └── page/*.operation.ts
+│   ├── entities/            # Типы данных API
+│   │   ├── page.entity.ts
+│   │   ├── grid.entity.ts
+│   │   └── resource.entity.ts
+│   ├── dto/                 # Request DTOs
+│   │   ├── page/*.dto.ts
+│   │   └── grid/*.dto.ts
+│   └── facade/              # Facade + Services
+│       ├── yandex-wiki.facade.ts
+│       └── services/page.service.ts
+├── tools/
+│   ├── api/pages/           # Page tools (7 штук)
+│   └── helpers/ping/        # Ping tool
+├── common/schemas/          # Общие Zod schemas
+└── composition-root/        # DI контейнер
+    ├── container.ts
+    └── definitions/
+```
+
+## Добавление нового Tool
+
+1. Создать директорию `src/tools/api/{category}/{action}/`
+2. Создать файлы:
+   - `{name}.schema.ts` — Zod schema для валидации
+   - `{name}.metadata.ts` — метаданные (name, description, tags)
+   - `{name}.tool.ts` — класс tool, extends BaseTool
+   - `index.ts` — реэкспорт
+3. Добавить в `composition-root/definitions/tool-definitions.ts`
+4. Запустить `npm run validate`
+
+## Naming Conventions
+
+| Элемент | Формат | Пример |
+|---------|--------|--------|
+| Tool prefix | `yw_` | `yw_get_page` |
+| Tool name | snake_case | `yw_create_page` |
+| Operation class | PascalCase | `GetPageOperation` |
+| Service class | PascalCase | `PageService` |
+| DTO | PascalCase + Dto | `CreatePageDto` |
+
+## API особенности Yandex Wiki
+
+- **Base URL:** `https://api.wiki.yandex.net/v1/`
+- **Update через POST** (не PATCH) — Wiki API специфика
+- **Асинхронные операции:** clone возвращает `status_url`
+- **ID страницы:** integer (`idx`)
+- **Slug страницы:** string path (например `users/docs/readme`)
+- **Требуется:** `X-Org-ID` или `X-Cloud-Org-ID` в заголовках
+
+## Зависимости от framework
+
+```typescript
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import { IHttpClient, Logger, CacheManager } from '@mcp-framework/infrastructure';
+```
+
+## Валидация
+
+```bash
+# Полная валидация (lint + typecheck + test)
+npm run validate
+
+# Для AI агентов (минимальный вывод)
+npm run validate:quiet
+
+# Только тесты
+npm run test
+
+# С coverage
+npm run test:coverage
+```
+
+## Текущий статус реализации
+
+### Фаза 1: Pages API (завершена)
+
+- [x] Package setup
+- [x] Infrastructure (config, constants)
+- [x] Entities (Page, Grid, Resource, Operation)
+- [x] DTOs (CreatePage, UpdatePage, ClonePage, AppendContent)
+- [x] Page Operations (7 штук)
+- [x] Facade + PageService
+- [x] Page Tools (7 штук + ping)
+- [x] Composition Root
+- [x] Unit Tests для operations
+- [x] Documentation
+
+### Фаза 2: Grids & Resources (не начата)
+
+- [ ] Grid Operations (12 штук)
+- [ ] Grid Tools
+- [ ] Resources Tool

--- a/packages/servers/yandex-wiki/README.md
+++ b/packages/servers/yandex-wiki/README.md
@@ -1,0 +1,138 @@
+# MCP Server for Yandex Wiki
+
+MCP сервер для работы с API Yandex Wiki.
+
+## Установка
+
+```bash
+npm install mcp-server-yandex-wiki
+```
+
+## Конфигурация
+
+### Обязательные переменные окружения
+
+| Переменная | Описание |
+|------------|----------|
+| `YANDEX_WIKI_TOKEN` | OAuth токен для Wiki API |
+| `YANDEX_ORG_ID` | ID организации (Яндекс 360) |
+
+Или для Yandex Cloud:
+
+| Переменная | Описание |
+|------------|----------|
+| `YANDEX_WIKI_TOKEN` | OAuth токен |
+| `YANDEX_CLOUD_ORG_ID` | ID организации (Cloud) |
+
+### Опциональные переменные
+
+| Переменная | Default | Описание |
+|------------|---------|----------|
+| `LOG_LEVEL` | `info` | Уровень логирования |
+| `REQUEST_TIMEOUT` | `30000` | Таймаут запросов (мс) |
+| `YANDEX_WIKI_RETRY_ATTEMPTS` | `3` | Количество retry попыток |
+
+## Использование
+
+### С Claude Desktop
+
+Добавьте в `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "yandex-wiki": {
+      "command": "npx",
+      "args": ["mcp-server-yandex-wiki"],
+      "env": {
+        "YANDEX_WIKI_TOKEN": "your-token",
+        "YANDEX_ORG_ID": "your-org-id"
+      }
+    }
+  }
+}
+```
+
+## Доступные инструменты
+
+### Pages API
+
+| Tool | Описание |
+|------|----------|
+| `yw_get_page` | Получить страницу по slug |
+| `yw_get_page_by_id` | Получить страницу по ID |
+| `yw_create_page` | Создать страницу |
+| `yw_update_page` | Обновить страницу |
+| `yw_delete_page` | Удалить страницу |
+| `yw_clone_page` | Клонировать страницу |
+| `yw_append_content` | Добавить контент к странице |
+
+### Helpers
+
+| Tool | Описание |
+|------|----------|
+| `yw_ping` | Проверка подключения |
+
+## Примеры использования
+
+### Получить страницу
+
+```
+yw_get_page(slug: "users/docs/readme", fields: "attributes,content")
+```
+
+### Создать страницу
+
+```
+yw_create_page(
+  page_type: "page",
+  slug: "users/docs/new-page",
+  title: "New Page",
+  content: "# Hello World\n\nThis is a new page."
+)
+```
+
+### Обновить страницу
+
+```
+yw_update_page(
+  idx: 12345,
+  content: "# Updated Content"
+)
+```
+
+### Клонировать страницу
+
+```
+yw_clone_page(
+  idx: 12345,
+  target: "users/docs/cloned-page",
+  title: "Cloned Page",
+  recursive: true
+)
+```
+
+## API Reference
+
+- Base URL: `https://api.wiki.yandex.net/v1/`
+- Документация API: https://yandex.ru/support/wiki/ru/api-ref/
+
+## Структура проекта
+
+```
+src/
+├── config/         # Конфигурация и загрузка env
+├── wiki_api/       # Интеграция с Wiki API
+│   ├── api_operations/  # HTTP операции
+│   ├── entities/        # Типы данных
+│   ├── dto/             # Request DTOs
+│   └── facade/          # Facade + Services
+├── tools/          # MCP Tools
+│   ├── api/pages/  # Page tools
+│   └── helpers/    # Utility tools
+└── composition-root/    # DI контейнер
+```
+
+## License
+
+MIT

--- a/packages/servers/yandex-wiki/tests/helpers/index.ts
+++ b/packages/servers/yandex-wiki/tests/helpers/index.ts
@@ -1,0 +1,14 @@
+// tests/helpers/index.ts
+export {
+  createMockLogger,
+  createMockHttpClient,
+  createMockCacheManager,
+  createMockFacade,
+  createPartialMock,
+} from './mock-factories.js';
+
+export {
+  createPageFixture,
+  createAsyncOperationFixture,
+  createDeleteResultFixture,
+} from './page.fixture.js';

--- a/packages/servers/yandex-wiki/tests/helpers/mock-factories.ts
+++ b/packages/servers/yandex-wiki/tests/helpers/mock-factories.ts
@@ -1,0 +1,75 @@
+// tests/helpers/mock-factories.ts
+import { vi } from 'vitest';
+import type { Logger } from '@mcp-framework/infrastructure/logging/logger.js';
+import type { IHttpClient } from '@mcp-framework/infrastructure/http/client/i-http-client.interface.js';
+import type { CacheManager } from '@mcp-framework/infrastructure';
+import type { YandexWikiFacade } from '../../src/wiki_api/facade/yandex-wiki.facade.js';
+
+/**
+ * Создать полностью типизированный mock для Logger
+ */
+export function createMockLogger(): Logger {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+    setAlertingTransport: vi.fn(),
+    setLevel: vi.fn(),
+  } as unknown as Logger;
+
+  // Настроить child чтобы возвращал сам себя
+  (childLogger.child as ReturnType<typeof vi.fn>).mockReturnValue(childLogger);
+
+  return childLogger;
+}
+
+/**
+ * Создать mock для IHttpClient
+ */
+export function createMockHttpClient(): IHttpClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    put: vi.fn(),
+  } as unknown as IHttpClient;
+}
+
+/**
+ * Создать mock для CacheManager
+ */
+export function createMockCacheManager(): CacheManager {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockResolvedValue(false),
+  } as unknown as CacheManager;
+}
+
+/**
+ * Создать partial mock для YandexWikiFacade
+ * Используй это для unit тестов tools
+ */
+export function createMockFacade(): Partial<YandexWikiFacade> {
+  return {
+    getPage: vi.fn(),
+    getPageById: vi.fn(),
+    createPage: vi.fn(),
+    updatePage: vi.fn(),
+    deletePage: vi.fn(),
+    clonePage: vi.fn(),
+    appendContent: vi.fn(),
+  };
+}
+
+/**
+ * Helper для создания partial mock с явным типом
+ */
+export function createPartialMock<T>(partial: Partial<T>): T {
+  return partial as T;
+}

--- a/packages/servers/yandex-wiki/tests/helpers/page.fixture.ts
+++ b/packages/servers/yandex-wiki/tests/helpers/page.fixture.ts
@@ -1,0 +1,54 @@
+// tests/helpers/page.fixture.ts
+import type {
+  Page,
+  PageWithUnknownFields,
+  AsyncOperation,
+} from '../../src/wiki_api/entities/index.js';
+
+/**
+ * Создать фикстуру для Page
+ */
+export function createPageFixture(overrides?: Partial<Page>): PageWithUnknownFields {
+  return {
+    id: 12345,
+    slug: 'users/testuser/test-page',
+    title: 'Test Page Title',
+    page_type: 'page',
+    attributes: {
+      created_at: '2024-01-15T10:30:00.000Z',
+      modified_at: '2024-01-20T14:45:00.000Z',
+      is_readonly: false,
+      comments_count: 5,
+      comments_enabled: true,
+    },
+    breadcrumbs: [
+      { page_exists: true, slug: 'users', title: 'Users', id: 1 },
+      { page_exists: true, slug: 'users/testuser', title: 'TestUser', id: 2 },
+    ],
+    ...overrides,
+  };
+}
+
+/**
+ * Создать фикстуру для AsyncOperation (clone result)
+ */
+export function createAsyncOperationFixture(overrides?: Partial<AsyncOperation>): AsyncOperation {
+  return {
+    operation: {
+      type: 'clone',
+      id: 'op-123456',
+    },
+    dry_run: false,
+    status_url: 'https://api.wiki.yandex.net/v1/operations/op-123456',
+    ...overrides,
+  };
+}
+
+/**
+ * Создать фикстуру для DeletePageResult
+ */
+export function createDeleteResultFixture(): { recovery_token: string } {
+  return {
+    recovery_token: 'recovery-token-abc123',
+  };
+}

--- a/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/clone-page.operation.test.ts
+++ b/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/clone-page.operation.test.ts
@@ -1,0 +1,64 @@
+// tests/unit/wiki_api/api_operations/page/clone-page.operation.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClonePageOperation } from '#wiki_api/api_operations/page/clone-page.operation.js';
+import {
+  createMockHttpClient,
+  createMockCacheManager,
+  createMockLogger,
+  createAsyncOperationFixture,
+} from '#helpers/index.js';
+import type { IHttpClient } from '@mcp-framework/infrastructure';
+
+describe('ClonePageOperation', () => {
+  let operation: ClonePageOperation;
+  let mockHttpClient: IHttpClient;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    mockLogger = createMockLogger();
+    const mockCache = createMockCacheManager();
+    operation = new ClonePageOperation(mockHttpClient, mockCache, mockLogger);
+  });
+
+  it('должен клонировать страницу', async () => {
+    const expectedResult = createAsyncOperationFixture();
+    vi.mocked(mockHttpClient.post).mockResolvedValue(expectedResult);
+
+    const result = await operation.execute(12345, {
+      target: 'users/new/cloned-page',
+    });
+
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/pages/12345/clone', {
+      target: 'users/new/cloned-page',
+    });
+    expect(result.operation.type).toBe('clone');
+    expect(result.status_url).toBeDefined();
+  });
+
+  it('должен передавать опциональные параметры клонирования', async () => {
+    vi.mocked(mockHttpClient.post).mockResolvedValue(createAsyncOperationFixture());
+
+    await operation.execute(12345, {
+      target: 'users/new/cloned-page',
+      title: 'New Title',
+      recursive: true,
+      dry_run: true,
+    });
+
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/pages/12345/clone', {
+      target: 'users/new/cloned-page',
+      title: 'New Title',
+      recursive: true,
+      dry_run: true,
+    });
+  });
+
+  it('должен логировать операцию', async () => {
+    vi.mocked(mockHttpClient.post).mockResolvedValue(createAsyncOperationFixture());
+
+    await operation.execute(99, { target: 'new/path' });
+
+    expect(mockLogger.info).toHaveBeenCalledWith('Cloning page 99 to new/path');
+  });
+});

--- a/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/create-page.operation.test.ts
+++ b/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/create-page.operation.test.ts
@@ -1,0 +1,77 @@
+// tests/unit/wiki_api/api_operations/page/create-page.operation.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CreatePageOperation } from '#wiki_api/api_operations/page/create-page.operation.js';
+import {
+  createMockHttpClient,
+  createMockCacheManager,
+  createMockLogger,
+  createPageFixture,
+} from '#helpers/index.js';
+import type { IHttpClient } from '@mcp-framework/infrastructure';
+
+describe('CreatePageOperation', () => {
+  let operation: CreatePageOperation;
+  let mockHttpClient: IHttpClient;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    mockLogger = createMockLogger();
+    const mockCache = createMockCacheManager();
+    operation = new CreatePageOperation(mockHttpClient, mockCache, mockLogger);
+  });
+
+  it('должен создать страницу', async () => {
+    const expectedPage = createPageFixture({ slug: 'users/new-page' });
+    vi.mocked(mockHttpClient.post).mockResolvedValue(expectedPage);
+
+    const result = await operation.execute({
+      data: {
+        page_type: 'page',
+        slug: 'users/new-page',
+        title: 'New Page',
+      },
+    });
+
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/pages', {
+      page_type: 'page',
+      slug: 'users/new-page',
+      title: 'New Page',
+    });
+    expect(result).toEqual(expectedPage);
+  });
+
+  it('должен создать страницу с контентом', async () => {
+    vi.mocked(mockHttpClient.post).mockResolvedValue(createPageFixture());
+
+    await operation.execute({
+      data: {
+        page_type: 'page',
+        slug: 'users/test',
+        title: 'Test',
+        content: '# Hello World',
+      },
+    });
+
+    expect(mockHttpClient.post).toHaveBeenCalledWith('/v1/pages', {
+      page_type: 'page',
+      slug: 'users/test',
+      title: 'Test',
+      content: '# Hello World',
+    });
+  });
+
+  it('должен логировать операцию', async () => {
+    vi.mocked(mockHttpClient.post).mockResolvedValue(createPageFixture());
+
+    await operation.execute({
+      data: {
+        page_type: 'page',
+        slug: 'users/new',
+        title: 'New',
+      },
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith('Creating page: users/new');
+  });
+});

--- a/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/delete-page.operation.test.ts
+++ b/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/delete-page.operation.test.ts
@@ -1,0 +1,41 @@
+// tests/unit/wiki_api/api_operations/page/delete-page.operation.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DeletePageOperation } from '#wiki_api/api_operations/page/delete-page.operation.js';
+import {
+  createMockHttpClient,
+  createMockCacheManager,
+  createMockLogger,
+  createDeleteResultFixture,
+} from '#helpers/index.js';
+import type { IHttpClient } from '@mcp-framework/infrastructure';
+
+describe('DeletePageOperation', () => {
+  let operation: DeletePageOperation;
+  let mockHttpClient: IHttpClient;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    mockLogger = createMockLogger();
+    const mockCache = createMockCacheManager();
+    operation = new DeletePageOperation(mockHttpClient, mockCache, mockLogger);
+  });
+
+  it('должен удалить страницу и вернуть recovery token', async () => {
+    const expectedResult = createDeleteResultFixture();
+    vi.mocked(mockHttpClient.delete).mockResolvedValue(expectedResult);
+
+    const result = await operation.execute(12345);
+
+    expect(mockHttpClient.delete).toHaveBeenCalledWith('/v1/pages/12345');
+    expect(result.recovery_token).toBe('recovery-token-abc123');
+  });
+
+  it('должен логировать операцию', async () => {
+    vi.mocked(mockHttpClient.delete).mockResolvedValue(createDeleteResultFixture());
+
+    await operation.execute(99);
+
+    expect(mockLogger.info).toHaveBeenCalledWith('Deleting page: 99');
+  });
+});

--- a/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/get-page-by-id.operation.test.ts
+++ b/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/get-page-by-id.operation.test.ts
@@ -1,0 +1,58 @@
+// tests/unit/wiki_api/api_operations/page/get-page-by-id.operation.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetPageByIdOperation } from '#wiki_api/api_operations/page/get-page-by-id.operation.js';
+import {
+  createMockHttpClient,
+  createMockCacheManager,
+  createMockLogger,
+  createPageFixture,
+} from '#helpers/index.js';
+import type { IHttpClient } from '@mcp-framework/infrastructure';
+
+describe('GetPageByIdOperation', () => {
+  let operation: GetPageByIdOperation;
+  let mockHttpClient: IHttpClient;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    mockLogger = createMockLogger();
+    const mockCache = createMockCacheManager();
+    operation = new GetPageByIdOperation(mockHttpClient, mockCache, mockLogger);
+  });
+
+  it('должен получить страницу по ID', async () => {
+    const expectedPage = createPageFixture({ id: 12345 });
+    vi.mocked(mockHttpClient.get).mockResolvedValue(expectedPage);
+
+    const result = await operation.execute({ idx: 12345 });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/pages/12345', undefined);
+    expect(result).toEqual(expectedPage);
+  });
+
+  it('должен передавать опциональные параметры', async () => {
+    vi.mocked(mockHttpClient.get).mockResolvedValue(createPageFixture());
+
+    await operation.execute({
+      idx: 12345,
+      fields: 'attributes,content',
+      raise_on_redirect: true,
+      revision_id: 10,
+    });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/pages/12345', {
+      fields: 'attributes,content',
+      raise_on_redirect: true,
+      revision_id: 10,
+    });
+  });
+
+  it('должен логировать операцию', async () => {
+    vi.mocked(mockHttpClient.get).mockResolvedValue(createPageFixture());
+
+    await operation.execute({ idx: 99 });
+
+    expect(mockLogger.info).toHaveBeenCalledWith('Getting page by id: 99');
+  });
+});

--- a/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/get-page.operation.test.ts
+++ b/packages/servers/yandex-wiki/tests/unit/wiki_api/api_operations/page/get-page.operation.test.ts
@@ -1,0 +1,69 @@
+// tests/unit/wiki_api/api_operations/page/get-page.operation.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetPageOperation } from '#wiki_api/api_operations/page/get-page.operation.js';
+import {
+  createMockHttpClient,
+  createMockCacheManager,
+  createMockLogger,
+  createPageFixture,
+} from '#helpers/index.js';
+import type { IHttpClient } from '@mcp-framework/infrastructure';
+
+describe('GetPageOperation', () => {
+  let operation: GetPageOperation;
+  let mockHttpClient: IHttpClient;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    mockLogger = createMockLogger();
+    const mockCache = createMockCacheManager();
+    operation = new GetPageOperation(mockHttpClient, mockCache, mockLogger);
+  });
+
+  it('должен получить страницу по slug', async () => {
+    const expectedPage = createPageFixture({ slug: 'users/docs/test' });
+    vi.mocked(mockHttpClient.get).mockResolvedValue(expectedPage);
+
+    const result = await operation.execute({ slug: 'users/docs/test' });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/pages', {
+      slug: 'users/docs/test',
+    });
+    expect(result).toEqual(expectedPage);
+  });
+
+  it('должен передавать опциональные параметры', async () => {
+    const expectedPage = createPageFixture();
+    vi.mocked(mockHttpClient.get).mockResolvedValue(expectedPage);
+
+    await operation.execute({
+      slug: 'test',
+      fields: 'attributes,content',
+      raise_on_redirect: true,
+      revision_id: 5,
+    });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/v1/pages', {
+      slug: 'test',
+      fields: 'attributes,content',
+      raise_on_redirect: true,
+      revision_id: 5,
+    });
+  });
+
+  it('должен логировать операцию', async () => {
+    vi.mocked(mockHttpClient.get).mockResolvedValue(createPageFixture());
+
+    await operation.execute({ slug: 'users/test' });
+
+    expect(mockLogger.info).toHaveBeenCalledWith('Getting page by slug: users/test');
+  });
+
+  it('должен пробрасывать ошибки HTTP клиента', async () => {
+    const error = new Error('Network error');
+    vi.mocked(mockHttpClient.get).mockRejectedValue(error);
+
+    await expect(operation.execute({ slug: 'test' })).rejects.toThrow('Network error');
+  });
+});


### PR DESCRIPTION
Завершена Фаза 1 реализации Yandex Wiki MCP сервера:
- Добавлены unit тесты для page operations (5 файлов, 15 тестов)
- Созданы test helpers (mock factories, fixtures)
- Добавлен README.md для пользователей
- Добавлен CLAUDE.md для разработчиков
- Обновлен план: Фаза 1 (Pages API) полностью завершена

Следующий шаг: Фаза 2 (Grids & Resources) - опционально

🤖 Generated with Claude Code