### PR TITLE
Continue Yandex Wiki MCP server implementation

### DIFF
--- a/.agentic-planning/plan_yandex_wiki_mcp_server/0_overview.md
+++ b/.agentic-planning/plan_yandex_wiki_mcp_server/0_overview.md
@@ -99,13 +99,13 @@ Grids   Resources
 | 7.1 | `7.1_tests_parallel.md` | parallel | [x] |
 | 8.1 | `8.1_documentation_sequential.md` | sequential | [x] |
 
-### Фаза 2: Grids & Resources (Дополнительная) - НЕ НАЧАТА
+### Фаза 2: Grids & Resources (Дополнительная) - ЗАВЕРШЕНА
 
 | Этап | Файл | Тип | Статус |
 |------|------|-----|--------|
-| 9.1 | `9.1_grid_operations_parallel.md` | parallel | [ ] |
-| 9.2 | `9.2_grid_tools_parallel.md` | parallel | [ ] |
-| 10.1 | `10.1_resources_parallel.md` | parallel | [ ] |
+| 9.1 | `9.1_grid_operations_parallel.md` | parallel | [x] |
+| 9.2 | `9.2_grid_tools_parallel.md` | parallel | [x] |
+| 10.1 | `10.1_resources_parallel.md` | parallel | [x] |
 
 ## Зависимости от framework
 

--- a/packages/framework/core/src/tools/base/tool-metadata.ts
+++ b/packages/framework/core/src/tools/base/tool-metadata.ts
@@ -29,6 +29,7 @@ export enum ToolCategory {
   // Wiki API операции
   PAGES = 'pages',
   GRIDS = 'grids',
+  RESOURCES = 'resources',
 
   // Системные инструменты
   SYSTEM = 'system',

--- a/packages/framework/infrastructure/src/http/client/axios-http-client.ts
+++ b/packages/framework/infrastructure/src/http/client/axios-http-client.ts
@@ -129,11 +129,12 @@ export class AxiosHttpClient implements IHttpClient {
   /**
    * Выполняет DELETE запрос с retry логикой
    * @param path - путь к ресурсу
+   * @param data - опциональные данные для body
    * @returns данные ответа
    */
-  async delete<T = unknown>(path: string): Promise<T> {
+  async delete<T = unknown>(path: string, data?: unknown): Promise<T> {
     return this.retryHandler.executeWithRetry(async () => {
-      const response = await this.client.delete<T>(path);
+      const response = await this.client.delete<T>(path, { data });
       return response.data;
     });
   }

--- a/packages/framework/infrastructure/src/http/client/i-http-client.interface.ts
+++ b/packages/framework/infrastructure/src/http/client/i-http-client.interface.ts
@@ -35,9 +35,10 @@ export interface IHttpClient {
   /**
    * Выполняет DELETE запрос
    * @param path - путь к ресурсу
+   * @param data - опциональные данные для отправки в body
    * @returns данные ответа
    */
-  delete<T = unknown>(path: string): Promise<T>;
+  delete<T = unknown>(path: string, data?: unknown): Promise<T>;
 
   /**
    * Получить Axios instance (для специальных операций)

--- a/packages/framework/infrastructure/src/http/client/mock-http-client.ts
+++ b/packages/framework/infrastructure/src/http/client/mock-http-client.ts
@@ -10,7 +10,12 @@ import type { QueryParams } from '../../types.js';
 
 export class MockHttpClient implements IHttpClient {
   private responses: Map<string, unknown> = new Map();
-  private requestHistory: Array<{ method: string; path: string; data?: unknown; params?: QueryParams }> = [];
+  private requestHistory: Array<{
+    method: string;
+    path: string;
+    data?: unknown;
+    params?: QueryParams;
+  }> = [];
 
   /**
    * Установить мок-ответ для конкретного пути
@@ -26,7 +31,12 @@ export class MockHttpClient implements IHttpClient {
   /**
    * Получить историю запросов
    */
-  getRequestHistory(): Array<{ method: string; path: string; data?: unknown; params?: QueryParams }> {
+  getRequestHistory(): Array<{
+    method: string;
+    path: string;
+    data?: unknown;
+    params?: QueryParams;
+  }> {
     return [...this.requestHistory];
   }
 
@@ -80,7 +90,7 @@ export class MockHttpClient implements IHttpClient {
     return Promise.resolve(response as T);
   }
 
-  delete<T = unknown>(path: string): Promise<T> {
+  delete<T = unknown>(path: string, _data?: unknown): Promise<T> {
     this.requestHistory.push({ method: 'DELETE', path });
     const key = `DELETE:${path}`;
     const response = this.responses.get(key);

--- a/packages/servers/yandex-wiki/src/composition-root/definitions/facade-services.ts
+++ b/packages/servers/yandex-wiki/src/composition-root/definitions/facade-services.ts
@@ -1,9 +1,11 @@
 import type { Container } from 'inversify';
-import { PageService } from '#wiki_api/facade/services/index.js';
+import { PageService, GridService, ResourceService } from '#wiki_api/facade/services/index.js';
 
 /**
  * Регистрация доменных сервисов для Yandex Wiki
  */
 export function bindFacadeServices(container: Container): void {
   container.bind(PageService).toSelf().inSingletonScope();
+  container.bind(GridService).toSelf().inSingletonScope();
+  container.bind(ResourceService).toSelf().inSingletonScope();
 }

--- a/packages/servers/yandex-wiki/src/composition-root/definitions/operation-definitions.ts
+++ b/packages/servers/yandex-wiki/src/composition-root/definitions/operation-definitions.ts
@@ -1,4 +1,5 @@
 import {
+  // Page Operations
   GetPageOperation,
   GetPageByIdOperation,
   CreatePageOperation,
@@ -6,12 +7,28 @@ import {
   DeletePageOperation,
   ClonePageOperation,
   AppendContentOperation,
+  // Grid Operations
+  CreateGridOperation,
+  GetGridOperation,
+  UpdateGridOperation,
+  DeleteGridOperation,
+  AddRowsOperation,
+  RemoveRowsOperation,
+  AddColumnsOperation,
+  RemoveColumnsOperation,
+  UpdateCellsOperation,
+  MoveRowsOperation,
+  MoveColumnsOperation,
+  CloneGridOperation,
+  // Resource Operations
+  GetResourcesOperation,
 } from '#wiki_api/api_operations/index.js';
 
 /**
  * Все Operation классы для автоматической регистрации в DI
  */
 export const OPERATION_CLASSES = [
+  // Page Operations
   GetPageOperation,
   GetPageByIdOperation,
   CreatePageOperation,
@@ -19,4 +36,19 @@ export const OPERATION_CLASSES = [
   DeletePageOperation,
   ClonePageOperation,
   AppendContentOperation,
+  // Grid Operations
+  CreateGridOperation,
+  GetGridOperation,
+  UpdateGridOperation,
+  DeleteGridOperation,
+  AddRowsOperation,
+  RemoveRowsOperation,
+  AddColumnsOperation,
+  RemoveColumnsOperation,
+  UpdateCellsOperation,
+  MoveRowsOperation,
+  MoveColumnsOperation,
+  CloneGridOperation,
+  // Resource Operations
+  GetResourcesOperation,
 ] as const;

--- a/packages/servers/yandex-wiki/src/composition-root/definitions/tool-definitions.ts
+++ b/packages/servers/yandex-wiki/src/composition-root/definitions/tool-definitions.ts
@@ -1,4 +1,6 @@
 import { PingTool } from '#tools/helpers/ping/index.js';
+
+// Pages
 import { GetPageTool } from '#tools/api/pages/get/index.js';
 import { GetPageByIdTool } from '#tools/api/pages/get-by-id/index.js';
 import { CreatePageTool } from '#tools/api/pages/create/index.js';
@@ -6,6 +8,23 @@ import { UpdatePageTool } from '#tools/api/pages/update/index.js';
 import { DeletePageTool } from '#tools/api/pages/delete/index.js';
 import { ClonePageTool } from '#tools/api/pages/clone/index.js';
 import { AppendContentTool } from '#tools/api/pages/append/index.js';
+
+// Grids
+import { CreateGridTool } from '#tools/api/grids/create/index.js';
+import { GetGridTool } from '#tools/api/grids/get/index.js';
+import { UpdateGridTool } from '#tools/api/grids/update/index.js';
+import { DeleteGridTool } from '#tools/api/grids/delete/index.js';
+import { CloneGridTool } from '#tools/api/grids/clone/index.js';
+import { AddRowsTool } from '#tools/api/grids/rows/add/index.js';
+import { RemoveRowsTool } from '#tools/api/grids/rows/remove/index.js';
+import { MoveRowsTool } from '#tools/api/grids/rows/move/index.js';
+import { AddColumnsTool } from '#tools/api/grids/columns/add/index.js';
+import { RemoveColumnsTool } from '#tools/api/grids/columns/remove/index.js';
+import { MoveColumnsTool } from '#tools/api/grids/columns/move/index.js';
+import { UpdateCellsTool } from '#tools/api/grids/cells/update/index.js';
+
+// Resources
+import { GetResourcesTool } from '#tools/api/resources/get/index.js';
 
 /**
  * Все Tool классы для автоматической регистрации в DI
@@ -24,4 +43,21 @@ export const TOOL_CLASSES = [
   DeletePageTool,
   ClonePageTool,
   AppendContentTool,
+
+  // Grids
+  CreateGridTool,
+  GetGridTool,
+  UpdateGridTool,
+  DeleteGridTool,
+  CloneGridTool,
+  AddRowsTool,
+  RemoveRowsTool,
+  MoveRowsTool,
+  AddColumnsTool,
+  RemoveColumnsTool,
+  MoveColumnsTool,
+  UpdateCellsTool,
+
+  // Resources
+  GetResourcesTool,
 ] as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/index.ts
@@ -1,0 +1,3 @@
+export { UpdateCellsTool } from './update-cells.tool.js';
+export { UPDATE_CELLS_TOOL_METADATA } from './update-cells.metadata.js';
+export { UpdateCellsParamsSchema, type UpdateCellsParams } from './update-cells.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/update-cells.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/update-cells.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const UPDATE_CELLS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_cells', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Обновить ячейки в таблице',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'update', 'cells', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/update-cells.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/update-cells.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const CellUpdateSchema = z.object({
+  row_id: z.number().describe('ID строки'),
+  column_slug: z.string().describe('Slug колонки'),
+  value: z.unknown().describe('Новое значение ячейки'),
+});
+
+export const UpdateCellsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  cells: z.array(CellUpdateSchema).min(1).describe('Ячейки для обновления'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+});
+
+export type UpdateCellsParams = z.infer<typeof UpdateCellsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/update-cells.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/cells/update/update-cells.tool.ts
@@ -1,0 +1,38 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { UpdateCellsParamsSchema } from './update-cells.schema.js';
+import { UPDATE_CELLS_TOOL_METADATA } from './update-cells.metadata.js';
+
+export class UpdateCellsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = UPDATE_CELLS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof UpdateCellsParamsSchema {
+    return UpdateCellsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, UpdateCellsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, cells, revision } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Обновление ячеек', cells.length);
+
+      const grid = await this.facade.updateCells(idx, {
+        cells,
+        ...(revision !== undefined && { revision }),
+      });
+
+      return this.formatSuccess({
+        message: `Обновлено ${cells.length} ячеек в таблице ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при обновлении ячеек в таблице: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/clone/clone-grid.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/clone/clone-grid.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const CLONE_GRID_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('clone_grid', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Клонировать динамическую таблицу',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'clone', 'copy', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/clone/clone-grid.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/clone/clone-grid.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const CloneGridParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы для клонирования (UUID)'),
+  target: z.string().describe('Slug целевой страницы'),
+  title: z.string().min(1).max(255).optional().describe('Название копии (1-255 символов)'),
+  with_data: z.boolean().optional().describe('Копировать с данными (default: false)'),
+});
+
+export type CloneGridParams = z.infer<typeof CloneGridParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/clone/clone-grid.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/clone/clone-grid.tool.ts
@@ -1,0 +1,39 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { CloneGridParamsSchema } from './clone-grid.schema.js';
+import { CLONE_GRID_TOOL_METADATA } from './clone-grid.metadata.js';
+
+export class CloneGridTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = CLONE_GRID_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof CloneGridParamsSchema {
+    return CloneGridParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, CloneGridParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, target, title, with_data } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Клонирование таблицы', 1);
+
+      const operation = await this.facade.cloneGrid(idx, {
+        target,
+        ...(title !== undefined && { title }),
+        ...(with_data !== undefined && { with_data }),
+      });
+
+      return this.formatSuccess({
+        message: `Клонирование таблицы ${idx} запущено`,
+        status_url: operation.status_url,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при клонировании таблицы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/clone/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/clone/index.ts
@@ -1,0 +1,3 @@
+export { CloneGridTool } from './clone-grid.tool.js';
+export { CLONE_GRID_TOOL_METADATA } from './clone-grid.metadata.js';
+export { CloneGridParamsSchema, type CloneGridParams } from './clone-grid.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/add-columns.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/add-columns.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const ADD_COLUMNS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('add_columns', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Добавить колонки в таблицу',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'add', 'columns', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/add-columns.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/add-columns.schema.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const ColumnTypeSchema = z.enum([
+  'string',
+  'number',
+  'date',
+  'select',
+  'staff',
+  'checkbox',
+  'ticket',
+  'ticket_field',
+]);
+
+const BGColorSchema = z.enum([
+  'blue',
+  'yellow',
+  'pink',
+  'red',
+  'green',
+  'mint',
+  'grey',
+  'orange',
+  'magenta',
+  'purple',
+  'copper',
+  'ocean',
+]);
+
+const TextFormatSchema = z.enum(['yfm', 'wom', 'plain']);
+
+const ColumnSchema = z.object({
+  title: z.string().describe('Название колонки'),
+  slug: z.string().describe('Slug колонки'),
+  type: ColumnTypeSchema.describe('Тип колонки'),
+  required: z.boolean().describe('Обязательная колонка'),
+  color: BGColorSchema.optional().describe('Цвет фона заголовка'),
+  width: z.number().optional().describe('Ширина колонки'),
+  width_units: z.enum(['%', 'px']).optional().describe('Единицы ширины'),
+  pinned: z.enum(['left', 'right']).optional().describe('Закрепление колонки'),
+  format: TextFormatSchema.optional().describe('Формат текста'),
+  multiple: z.boolean().optional().describe('Множественный выбор (для select)'),
+  select_options: z.array(z.string()).optional().describe('Опции для select'),
+  description: z.string().optional().describe('Описание колонки'),
+});
+
+export const AddColumnsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  columns: z.array(ColumnSchema).min(1).describe('Колонки для добавления'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+  position: z.number().int().min(0).optional().describe('Позиция вставки (0 - в начало)'),
+});
+
+export type AddColumnsParams = z.infer<typeof AddColumnsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/add-columns.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/add-columns.tool.ts
@@ -1,0 +1,39 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { AddColumnsParamsSchema } from './add-columns.schema.js';
+import { ADD_COLUMNS_TOOL_METADATA } from './add-columns.metadata.js';
+
+export class AddColumnsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = ADD_COLUMNS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof AddColumnsParamsSchema {
+    return AddColumnsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, AddColumnsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, columns, revision, position } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Добавление колонок', columns.length);
+
+      const grid = await this.facade.addColumns(idx, {
+        columns,
+        ...(revision !== undefined && { revision }),
+        ...(position !== undefined && { position }),
+      });
+
+      return this.formatSuccess({
+        message: `Добавлено ${columns.length} колонок в таблицу ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при добавлении колонок в таблицу: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/add/index.ts
@@ -1,0 +1,3 @@
+export { AddColumnsTool } from './add-columns.tool.js';
+export { ADD_COLUMNS_TOOL_METADATA } from './add-columns.metadata.js';
+export { AddColumnsParamsSchema, type AddColumnsParams } from './add-columns.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/index.ts
@@ -1,0 +1,3 @@
+export { MoveColumnsTool } from './move-columns.tool.js';
+export { MOVE_COLUMNS_TOOL_METADATA } from './move-columns.metadata.js';
+export { MoveColumnsParamsSchema, type MoveColumnsParams } from './move-columns.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/move-columns.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/move-columns.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const MOVE_COLUMNS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('move_columns', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Переместить колонки в таблице',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.LOW,
+  tags: ['write', 'move', 'columns', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/move-columns.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/move-columns.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const MoveColumnsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  column_slug: z.string().describe('Slug колонки для перемещения'),
+  position: z.number().int().min(0).describe('Целевая позиция'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+  columns_count: z.number().int().min(1).optional().describe('Количество колонок для перемещения'),
+});
+
+export type MoveColumnsParams = z.infer<typeof MoveColumnsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/move-columns.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/move/move-columns.tool.ts
@@ -1,0 +1,40 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { MoveColumnsParamsSchema } from './move-columns.schema.js';
+import { MOVE_COLUMNS_TOOL_METADATA } from './move-columns.metadata.js';
+
+export class MoveColumnsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = MOVE_COLUMNS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof MoveColumnsParamsSchema {
+    return MoveColumnsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, MoveColumnsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, column_slug, position, revision, columns_count } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Перемещение колонок', 1);
+
+      const grid = await this.facade.moveColumns(idx, {
+        column_slug,
+        position,
+        ...(revision !== undefined && { revision }),
+        ...(columns_count !== undefined && { columns_count }),
+      });
+
+      return this.formatSuccess({
+        message: `Колонка ${column_slug} перемещена в позицию ${position} в таблице ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при перемещении колонок в таблице: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/index.ts
@@ -1,0 +1,3 @@
+export { RemoveColumnsTool } from './remove-columns.tool.js';
+export { REMOVE_COLUMNS_TOOL_METADATA } from './remove-columns.metadata.js';
+export { RemoveColumnsParamsSchema, type RemoveColumnsParams } from './remove-columns.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/remove-columns.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/remove-columns.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const REMOVE_COLUMNS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('remove_columns', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Удалить колонки из таблицы',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'remove', 'delete', 'columns', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/remove-columns.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/remove-columns.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const RemoveColumnsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  column_slugs: z.array(z.string()).min(1).describe('Slugs колонок для удаления'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+});
+
+export type RemoveColumnsParams = z.infer<typeof RemoveColumnsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/remove-columns.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/columns/remove/remove-columns.tool.ts
@@ -1,0 +1,38 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { RemoveColumnsParamsSchema } from './remove-columns.schema.js';
+import { REMOVE_COLUMNS_TOOL_METADATA } from './remove-columns.metadata.js';
+
+export class RemoveColumnsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = REMOVE_COLUMNS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof RemoveColumnsParamsSchema {
+    return RemoveColumnsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, RemoveColumnsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, column_slugs, revision } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Удаление колонок', column_slugs.length);
+
+      const grid = await this.facade.removeColumns(idx, {
+        column_slugs,
+        ...(revision !== undefined && { revision }),
+      });
+
+      return this.formatSuccess({
+        message: `Удалено ${column_slugs.length} колонок из таблицы ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при удалении колонок из таблицы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/create/create-grid.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/create/create-grid.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const CREATE_GRID_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('create_grid', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Создать динамическую таблицу',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.HIGH,
+  tags: ['write', 'create', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/create/create-grid.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/create/create-grid.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { PageIdSchema } from '#common/schemas/index.js';
+
+export const CreateGridParamsSchema = z.object({
+  title: z.string().min(1).max(255).describe('Название таблицы (1-255 символов)'),
+  page_id: PageIdSchema.optional().describe('ID страницы для таблицы'),
+  page_slug: z.string().optional().describe('Slug страницы для таблицы'),
+});
+
+export type CreateGridParams = z.infer<typeof CreateGridParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/create/create-grid.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/create/create-grid.tool.ts
@@ -1,0 +1,45 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { CreateGridParamsSchema } from './create-grid.schema.js';
+import { CREATE_GRID_TOOL_METADATA } from './create-grid.metadata.js';
+
+export class CreateGridTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = CREATE_GRID_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof CreateGridParamsSchema {
+    return CreateGridParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, CreateGridParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { title, page_id, page_slug } = validation.data;
+
+    if (!page_id && !page_slug) {
+      return this.formatError('Необходимо указать page_id или page_slug');
+    }
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Создание таблицы', 1);
+
+      const grid = await this.facade.createGrid({
+        title,
+        page: {
+          ...(page_id !== undefined && { id: page_id }),
+          ...(page_slug !== undefined && { slug: page_slug }),
+        },
+      });
+
+      return this.formatSuccess({
+        message: `Таблица "${title}" успешно создана`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при создании таблицы: ${title}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/create/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/create/index.ts
@@ -1,0 +1,3 @@
+export { CreateGridTool } from './create-grid.tool.js';
+export { CREATE_GRID_TOOL_METADATA } from './create-grid.metadata.js';
+export { CreateGridParamsSchema, type CreateGridParams } from './create-grid.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/delete/delete-grid.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/delete/delete-grid.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const DELETE_GRID_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('delete_grid', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Удалить динамическую таблицу',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'delete', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/delete/delete-grid.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/delete/delete-grid.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const DeleteGridParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+});
+
+export type DeleteGridParams = z.infer<typeof DeleteGridParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/delete/delete-grid.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/delete/delete-grid.tool.ts
@@ -1,0 +1,35 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { DeleteGridParamsSchema } from './delete-grid.schema.js';
+import { DELETE_GRID_TOOL_METADATA } from './delete-grid.metadata.js';
+
+export class DeleteGridTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = DELETE_GRID_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof DeleteGridParamsSchema {
+    return DeleteGridParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, DeleteGridParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Удаление таблицы', 1);
+
+      const result = await this.facade.deleteGrid(idx);
+
+      return this.formatSuccess({
+        message: `Таблица ${idx} успешно удалена`,
+        recovery_token: result.recovery_token,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при удалении таблицы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/delete/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/delete/index.ts
@@ -1,0 +1,3 @@
+export { DeleteGridTool } from './delete-grid.tool.js';
+export { DELETE_GRID_TOOL_METADATA } from './delete-grid.metadata.js';
+export { DeleteGridParamsSchema, type DeleteGridParams } from './delete-grid.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/get/get-grid.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/get/get-grid.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const GET_GRID_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_grid', MCP_TOOL_PREFIX),
+  description: '[Grids/Read] Получить динамическую таблицу по ID',
+  category: ToolCategory.GRIDS,
+  subcategory: 'read',
+  priority: ToolPriority.HIGH,
+  tags: ['read', 'get', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/get/get-grid.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/get/get-grid.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { WikiFieldsSchema } from '#common/schemas/index.js';
+
+export const GetGridParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  fields: WikiFieldsSchema,
+  filter: z.string().optional().describe('Фильтр строк'),
+  only_cols: z.string().optional().describe('Вернуть только указанные колонки (через запятую)'),
+  only_rows: z.string().optional().describe('Вернуть только указанные строки (ID через запятую)'),
+  sort: z.string().optional().describe('Сортировка (column_slug:asc|desc)'),
+});
+
+export type GetGridParams = z.infer<typeof GetGridParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/get/get-grid.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/get/get-grid.tool.ts
@@ -1,0 +1,42 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { GetGridParamsSchema } from './get-grid.schema.js';
+import { GET_GRID_TOOL_METADATA } from './get-grid.metadata.js';
+
+export class GetGridTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = GET_GRID_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof GetGridParamsSchema {
+    return GetGridParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, GetGridParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, fields, filter, only_cols, only_rows, sort } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Получение таблицы', 1);
+
+      const grid = await this.facade.getGrid({
+        idx,
+        ...(fields !== undefined && { fields }),
+        ...(filter !== undefined && { filter }),
+        ...(only_cols !== undefined && { only_cols }),
+        ...(only_rows !== undefined && { only_rows }),
+        ...(sort !== undefined && { sort }),
+      });
+
+      return this.formatSuccess({
+        message: `Таблица ${idx} получена`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при получении таблицы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/get/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/get/index.ts
@@ -1,0 +1,3 @@
+export { GetGridTool } from './get-grid.tool.js';
+export { GET_GRID_TOOL_METADATA } from './get-grid.metadata.js';
+export { GetGridParamsSchema, type GetGridParams } from './get-grid.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/index.ts
@@ -1,0 +1,19 @@
+// Basic CRUD
+export * from './create/index.js';
+export * from './get/index.js';
+export * from './update/index.js';
+export * from './delete/index.js';
+export * from './clone/index.js';
+
+// Rows operations
+export * from './rows/add/index.js';
+export * from './rows/remove/index.js';
+export * from './rows/move/index.js';
+
+// Columns operations
+export * from './columns/add/index.js';
+export * from './columns/remove/index.js';
+export * from './columns/move/index.js';
+
+// Cells operations
+export * from './cells/update/index.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/add-rows.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/add-rows.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const ADD_ROWS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('add_rows', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Добавить строки в таблицу',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'add', 'rows', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/add-rows.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/add-rows.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+const BGColorSchema = z.enum([
+  'blue',
+  'yellow',
+  'pink',
+  'red',
+  'green',
+  'mint',
+  'grey',
+  'orange',
+  'magenta',
+  'purple',
+  'copper',
+  'ocean',
+]);
+
+const RowDataSchema = z.object({
+  row: z.array(z.unknown()).describe('Значения ячеек строки'),
+  pinned: z.boolean().optional().describe('Закрепить строку'),
+  color: BGColorSchema.optional().describe('Цвет фона строки'),
+});
+
+export const AddRowsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  rows: z.array(RowDataSchema).min(1).describe('Данные строк для добавления'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+  position: z.number().int().min(0).optional().describe('Позиция вставки (0 - в начало)'),
+  after_row_id: z.string().optional().describe('ID строки, после которой вставить'),
+});
+
+export type AddRowsParams = z.infer<typeof AddRowsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/add-rows.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/add-rows.tool.ts
@@ -1,0 +1,40 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { AddRowsParamsSchema } from './add-rows.schema.js';
+import { ADD_ROWS_TOOL_METADATA } from './add-rows.metadata.js';
+
+export class AddRowsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = ADD_ROWS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof AddRowsParamsSchema {
+    return AddRowsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, AddRowsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, rows, revision, position, after_row_id } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Добавление строк', rows.length);
+
+      const grid = await this.facade.addRows(idx, {
+        rows,
+        ...(revision !== undefined && { revision }),
+        ...(position !== undefined && { position }),
+        ...(after_row_id !== undefined && { after_row_id }),
+      });
+
+      return this.formatSuccess({
+        message: `Добавлено ${rows.length} строк в таблицу ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при добавлении строк в таблицу: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/add/index.ts
@@ -1,0 +1,3 @@
+export { AddRowsTool } from './add-rows.tool.js';
+export { ADD_ROWS_TOOL_METADATA } from './add-rows.metadata.js';
+export { AddRowsParamsSchema, type AddRowsParams } from './add-rows.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/index.ts
@@ -1,0 +1,3 @@
+export { MoveRowsTool } from './move-rows.tool.js';
+export { MOVE_ROWS_TOOL_METADATA } from './move-rows.metadata.js';
+export { MoveRowsParamsSchema, type MoveRowsParams } from './move-rows.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/move-rows.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/move-rows.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const MOVE_ROWS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('move_rows', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Переместить строки в таблице',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.LOW,
+  tags: ['write', 'move', 'rows', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/move-rows.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/move-rows.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const MoveRowsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  row_id: z.string().describe('ID строки для перемещения'),
+  after_row_id: z.string().optional().describe('ID строки, после которой переместить'),
+  position: z.number().int().min(0).optional().describe('Целевая позиция'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+  rows_count: z.number().int().min(1).optional().describe('Количество строк для перемещения'),
+});
+
+export type MoveRowsParams = z.infer<typeof MoveRowsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/move-rows.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/move/move-rows.tool.ts
@@ -1,0 +1,41 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { MoveRowsParamsSchema } from './move-rows.schema.js';
+import { MOVE_ROWS_TOOL_METADATA } from './move-rows.metadata.js';
+
+export class MoveRowsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = MOVE_ROWS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof MoveRowsParamsSchema {
+    return MoveRowsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, MoveRowsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, row_id, after_row_id, position, revision, rows_count } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Перемещение строк', 1);
+
+      const grid = await this.facade.moveRows(idx, {
+        row_id,
+        ...(after_row_id !== undefined && { after_row_id }),
+        ...(position !== undefined && { position }),
+        ...(revision !== undefined && { revision }),
+        ...(rows_count !== undefined && { rows_count }),
+      });
+
+      return this.formatSuccess({
+        message: `Строка ${row_id} перемещена в таблице ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при перемещении строк в таблице: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/index.ts
@@ -1,0 +1,3 @@
+export { RemoveRowsTool } from './remove-rows.tool.js';
+export { REMOVE_ROWS_TOOL_METADATA } from './remove-rows.metadata.js';
+export { RemoveRowsParamsSchema, type RemoveRowsParams } from './remove-rows.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/remove-rows.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/remove-rows.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const REMOVE_ROWS_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('remove_rows', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Удалить строки из таблицы',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'remove', 'delete', 'rows', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/remove-rows.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/remove-rows.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const RemoveRowsParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  row_ids: z.array(z.string()).min(1).describe('ID строк для удаления'),
+  revision: z.string().optional().describe('Ревизия таблицы'),
+});
+
+export type RemoveRowsParams = z.infer<typeof RemoveRowsParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/remove-rows.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/rows/remove/remove-rows.tool.ts
@@ -1,0 +1,38 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { RemoveRowsParamsSchema } from './remove-rows.schema.js';
+import { REMOVE_ROWS_TOOL_METADATA } from './remove-rows.metadata.js';
+
+export class RemoveRowsTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = REMOVE_ROWS_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof RemoveRowsParamsSchema {
+    return RemoveRowsParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, RemoveRowsParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, row_ids, revision } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Удаление строк', row_ids.length);
+
+      const grid = await this.facade.removeRows(idx, {
+        row_ids,
+        ...(revision !== undefined && { revision }),
+      });
+
+      return this.formatSuccess({
+        message: `Удалено ${row_ids.length} строк из таблицы ${idx}`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при удалении строк из таблицы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/grids/update/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/update/index.ts
@@ -1,0 +1,3 @@
+export { UpdateGridTool } from './update-grid.tool.js';
+export { UPDATE_GRID_TOOL_METADATA } from './update-grid.metadata.js';
+export { UpdateGridParamsSchema, type UpdateGridParams } from './update-grid.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/grids/update/update-grid.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/update/update-grid.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const UPDATE_GRID_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('update_grid', MCP_TOOL_PREFIX),
+  description: '[Grids/Write] Обновить динамическую таблицу',
+  category: ToolCategory.GRIDS,
+  subcategory: 'write',
+  priority: ToolPriority.NORMAL,
+  tags: ['write', 'update', 'grid', 'table'],
+  isHelper: false,
+  requiresExplicitUserConsent: true,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/update/update-grid.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/update/update-grid.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const SortConfigSchema = z.object({
+  column_slug: z.string().describe('Slug колонки для сортировки'),
+  direction: z.enum(['asc', 'desc']).describe('Направление сортировки'),
+});
+
+export const UpdateGridParamsSchema = z.object({
+  idx: z.string().uuid().describe('ID таблицы (UUID)'),
+  revision: z.string().describe('Текущая ревизия таблицы'),
+  title: z.string().min(1).max(255).optional().describe('Новое название таблицы'),
+  default_sort: z.array(SortConfigSchema).optional().describe('Сортировка по умолчанию'),
+});
+
+export type UpdateGridParams = z.infer<typeof UpdateGridParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/grids/update/update-grid.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/grids/update/update-grid.tool.ts
@@ -1,0 +1,39 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { UpdateGridParamsSchema } from './update-grid.schema.js';
+import { UPDATE_GRID_TOOL_METADATA } from './update-grid.metadata.js';
+
+export class UpdateGridTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = UPDATE_GRID_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof UpdateGridParamsSchema {
+    return UpdateGridParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, UpdateGridParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, revision, title, default_sort } = validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Обновление таблицы', 1);
+
+      const grid = await this.facade.updateGrid(idx, {
+        revision,
+        ...(title !== undefined && { title }),
+        ...(default_sort !== undefined && { default_sort }),
+      });
+
+      return this.formatSuccess({
+        message: `Таблица ${idx} успешно обновлена`,
+        grid,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при обновлении таблицы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/index.ts
@@ -1,1 +1,3 @@
 export * from './pages/index.js';
+export * from './grids/index.js';
+export * from './resources/index.js';

--- a/packages/servers/yandex-wiki/src/tools/api/resources/get/get-resources.metadata.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/resources/get/get-resources.metadata.ts
@@ -1,0 +1,14 @@
+import { buildToolName, ToolCategory, ToolPriority } from '@mcp-framework/core';
+import type { StaticToolMetadata } from '@mcp-framework/core';
+import { MCP_TOOL_PREFIX } from '#constants';
+
+export const GET_RESOURCES_TOOL_METADATA: StaticToolMetadata = {
+  name: buildToolName('get_resources', MCP_TOOL_PREFIX),
+  description: '[Resources/Read] Получить ресурсы страницы (вложения, таблицы)',
+  category: ToolCategory.RESOURCES,
+  subcategory: 'read',
+  priority: ToolPriority.NORMAL,
+  tags: ['read', 'get', 'resources', 'attachments', 'grids'],
+  isHelper: false,
+  requiresExplicitUserConsent: false,
+} as const;

--- a/packages/servers/yandex-wiki/src/tools/api/resources/get/get-resources.schema.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/resources/get/get-resources.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { PageIdSchema } from '#common/schemas/index.js';
+
+const ResourceTypeSchema = z.enum(['attachment', 'grid', 'sharepoint_resource']);
+
+export const GetResourcesParamsSchema = z.object({
+  idx: PageIdSchema.describe('ID страницы'),
+  cursor: z.string().optional().describe('Курсор для пагинации'),
+  order_by: z.enum(['name_title', 'created_at']).optional().describe('Поле сортировки'),
+  order_direction: z.enum(['asc', 'desc']).optional().describe('Направление сортировки'),
+  page_id: z.number().int().min(1).optional().describe('Номер страницы (default: 1)'),
+  page_size: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe('Размер страницы (default: 25, max: 50)'),
+  q: z.string().optional().describe('Поиск по названию'),
+  types: z.array(ResourceTypeSchema).optional().describe('Типы ресурсов'),
+});
+
+export type GetResourcesParams = z.infer<typeof GetResourcesParamsSchema>;

--- a/packages/servers/yandex-wiki/src/tools/api/resources/get/get-resources.tool.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/resources/get/get-resources.tool.ts
@@ -1,0 +1,47 @@
+import { BaseTool, ResultLogger } from '@mcp-framework/core';
+import type { YandexWikiFacade } from '#wiki_api/facade/index.js';
+import type { ToolCallParams, ToolResult } from '@mcp-framework/infrastructure';
+import { GetResourcesParamsSchema } from './get-resources.schema.js';
+import { GET_RESOURCES_TOOL_METADATA } from './get-resources.metadata.js';
+
+export class GetResourcesTool extends BaseTool<YandexWikiFacade> {
+  static override readonly METADATA = GET_RESOURCES_TOOL_METADATA;
+
+  protected override getParamsSchema(): typeof GetResourcesParamsSchema {
+    return GetResourcesParamsSchema;
+  }
+
+  async execute(params: ToolCallParams): Promise<ToolResult> {
+    const validation = this.validateParams(params, GetResourcesParamsSchema);
+    if (!validation.success) {
+      return validation.error;
+    }
+
+    const { idx, cursor, order_by, order_direction, page_id, page_size, q, types } =
+      validation.data;
+
+    try {
+      ResultLogger.logOperationStart(this.logger, 'Получение ресурсов страницы', 1);
+
+      const response = await this.facade.getResources({
+        idx,
+        ...(cursor !== undefined && { cursor }),
+        ...(order_by !== undefined && { order_by }),
+        ...(order_direction !== undefined && { order_direction }),
+        ...(page_id !== undefined && { page_id }),
+        ...(page_size !== undefined && { page_size }),
+        ...(q !== undefined && { q }),
+        ...(types !== undefined && { types }),
+      });
+
+      return this.formatSuccess({
+        message: `Получено ${response.results.length} ресурсов для страницы ${idx}`,
+        results: response.results,
+        next_cursor: response.next_cursor,
+        prev_cursor: response.prev_cursor,
+      });
+    } catch (error: unknown) {
+      return this.formatError(`Ошибка при получении ресурсов страницы: ${idx}`, error);
+    }
+  }
+}

--- a/packages/servers/yandex-wiki/src/tools/api/resources/get/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/resources/get/index.ts
@@ -1,0 +1,3 @@
+export { GetResourcesTool } from './get-resources.tool.js';
+export { GET_RESOURCES_TOOL_METADATA } from './get-resources.metadata.js';
+export { GetResourcesParamsSchema, type GetResourcesParams } from './get-resources.schema.js';

--- a/packages/servers/yandex-wiki/src/tools/api/resources/index.ts
+++ b/packages/servers/yandex-wiki/src/tools/api/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './get/index.js';

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/add-columns.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/add-columns.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { AddColumnsDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class AddColumnsOperation extends BaseOperation {
+  async execute(idx: string, data: AddColumnsDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Adding columns to grid: ${idx}`);
+
+    return this.httpClient.post<GridWithUnknownFields>(`/v1/grids/${idx}/columns`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/add-rows.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/add-rows.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { AddRowsDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class AddRowsOperation extends BaseOperation {
+  async execute(idx: string, data: AddRowsDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Adding rows to grid: ${idx}`);
+
+    return this.httpClient.post<GridWithUnknownFields>(`/v1/grids/${idx}/rows`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/clone-grid.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/clone-grid.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { CloneGridDto } from '#wiki_api/dto/index.js';
+import type { AsyncOperation } from '#wiki_api/entities/index.js';
+
+export class CloneGridOperation extends BaseOperation {
+  async execute(idx: string, data: CloneGridDto): Promise<AsyncOperation> {
+    this.logger.info(`Cloning grid ${idx} to ${data.target}`);
+
+    return this.httpClient.post<AsyncOperation>(`/v1/grids/${idx}/clone`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/create-grid.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/create-grid.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { CreateGridDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class CreateGridOperation extends BaseOperation {
+  async execute(data: CreateGridDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Creating grid: ${data.title}`);
+
+    return this.httpClient.post<GridWithUnknownFields>('/v1/grids', data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/delete-grid.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/delete-grid.operation.ts
@@ -1,0 +1,13 @@
+import { BaseOperation } from '../base-operation.js';
+
+export interface DeleteGridResult {
+  recovery_token: string;
+}
+
+export class DeleteGridOperation extends BaseOperation {
+  async execute(idx: string): Promise<DeleteGridResult> {
+    this.logger.info(`Deleting grid: ${idx}`);
+
+    return this.deleteRequest<DeleteGridResult>(`/v1/grids/${idx}`);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/get-grid.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/get-grid.operation.ts
@@ -1,0 +1,33 @@
+import { BaseOperation } from '../base-operation.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export interface GetGridParams {
+  /** Grid ID (UUID) */
+  idx: string;
+  /** Fields to return */
+  fields?: string;
+  /** Filter expression */
+  filter?: string;
+  /** Only specific columns */
+  only_cols?: string;
+  /** Only specific rows */
+  only_rows?: string;
+  /** Sort configuration */
+  sort?: string;
+}
+
+export class GetGridOperation extends BaseOperation {
+  async execute(params: GetGridParams): Promise<GridWithUnknownFields> {
+    const queryParams: Record<string, string> = {};
+
+    if (params.fields !== undefined) queryParams['fields'] = params.fields;
+    if (params.filter !== undefined) queryParams['filter'] = params.filter;
+    if (params.only_cols !== undefined) queryParams['only_cols'] = params.only_cols;
+    if (params.only_rows !== undefined) queryParams['only_rows'] = params.only_rows;
+    if (params.sort !== undefined) queryParams['sort'] = params.sort;
+
+    this.logger.info(`Getting grid: ${params.idx}`);
+
+    return this.httpClient.get<GridWithUnknownFields>(`/v1/grids/${params.idx}`, queryParams);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/index.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/index.ts
@@ -1,0 +1,25 @@
+export { CreateGridOperation } from './create-grid.operation.js';
+
+export { GetGridOperation } from './get-grid.operation.js';
+export type { GetGridParams } from './get-grid.operation.js';
+
+export { UpdateGridOperation } from './update-grid.operation.js';
+
+export { DeleteGridOperation } from './delete-grid.operation.js';
+export type { DeleteGridResult } from './delete-grid.operation.js';
+
+export { AddRowsOperation } from './add-rows.operation.js';
+
+export { RemoveRowsOperation } from './remove-rows.operation.js';
+
+export { AddColumnsOperation } from './add-columns.operation.js';
+
+export { RemoveColumnsOperation } from './remove-columns.operation.js';
+
+export { UpdateCellsOperation } from './update-cells.operation.js';
+
+export { MoveRowsOperation } from './move-rows.operation.js';
+
+export { MoveColumnsOperation } from './move-columns.operation.js';
+
+export { CloneGridOperation } from './clone-grid.operation.js';

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/move-columns.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/move-columns.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { MoveColumnDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class MoveColumnsOperation extends BaseOperation {
+  async execute(idx: string, data: MoveColumnDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Moving columns in grid: ${idx}`);
+
+    return this.httpClient.post<GridWithUnknownFields>(`/v1/grids/${idx}/columns/move`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/move-rows.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/move-rows.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { MoveRowDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class MoveRowsOperation extends BaseOperation {
+  async execute(idx: string, data: MoveRowDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Moving rows in grid: ${idx}`);
+
+    return this.httpClient.post<GridWithUnknownFields>(`/v1/grids/${idx}/rows/move`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/remove-columns.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/remove-columns.operation.ts
@@ -1,0 +1,12 @@
+import { BaseOperation } from '../base-operation.js';
+import type { RemoveColumnsDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class RemoveColumnsOperation extends BaseOperation {
+  async execute(idx: string, data: RemoveColumnsDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Removing columns from grid: ${idx}`);
+
+    // DELETE with body
+    return this.httpClient.delete<GridWithUnknownFields>(`/v1/grids/${idx}/columns`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/remove-rows.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/remove-rows.operation.ts
@@ -1,0 +1,12 @@
+import { BaseOperation } from '../base-operation.js';
+import type { RemoveRowsDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class RemoveRowsOperation extends BaseOperation {
+  async execute(idx: string, data: RemoveRowsDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Removing rows from grid: ${idx}`);
+
+    // DELETE with body - need to use httpClient appropriately
+    return this.httpClient.delete<GridWithUnknownFields>(`/v1/grids/${idx}/rows`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/update-cells.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/update-cells.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { UpdateCellsDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class UpdateCellsOperation extends BaseOperation {
+  async execute(idx: string, data: UpdateCellsDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Updating cells in grid: ${idx}`);
+
+    return this.httpClient.post<GridWithUnknownFields>(`/v1/grids/${idx}/cells`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/update-grid.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/grid/update-grid.operation.ts
@@ -1,0 +1,11 @@
+import { BaseOperation } from '../base-operation.js';
+import type { UpdateGridDto } from '#wiki_api/dto/index.js';
+import type { GridWithUnknownFields } from '#wiki_api/entities/index.js';
+
+export class UpdateGridOperation extends BaseOperation {
+  async execute(idx: string, data: UpdateGridDto): Promise<GridWithUnknownFields> {
+    this.logger.info(`Updating grid: ${idx}`);
+
+    return this.httpClient.post<GridWithUnknownFields>(`/v1/grids/${idx}`, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/index.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/index.ts
@@ -1,2 +1,4 @@
 export { BaseOperation } from './base-operation.js';
 export * from './page/index.js';
+export * from './grid/index.js';
+export * from './resource/index.js';

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/resource/get-resources.operation.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/resource/get-resources.operation.ts
@@ -1,0 +1,42 @@
+import { BaseOperation } from '../base-operation.js';
+import type { ResourcesResponse, ResourceType } from '#wiki_api/entities/index.js';
+
+export interface GetResourcesParams {
+  /** Page ID (integer) */
+  idx: number;
+  /** Cursor for pagination */
+  cursor?: string;
+  /** Sort field: name_title, created_at */
+  order_by?: 'name_title' | 'created_at';
+  /** Sort direction */
+  order_direction?: 'asc' | 'desc';
+  /** Page number (default: 1) */
+  page_id?: number;
+  /** Page size (default: 25, max: 50) */
+  page_size?: number;
+  /** Search query */
+  q?: string;
+  /** Resource types filter */
+  types?: ResourceType[];
+}
+
+export class GetResourcesOperation extends BaseOperation {
+  async execute(params: GetResourcesParams): Promise<ResourcesResponse> {
+    const queryParams: Record<string, string | number> = {};
+
+    if (params.cursor !== undefined) queryParams['cursor'] = params.cursor;
+    if (params.order_by !== undefined) queryParams['order_by'] = params.order_by;
+    if (params.order_direction !== undefined)
+      queryParams['order_direction'] = params.order_direction;
+    if (params.page_id !== undefined) queryParams['page_id'] = params.page_id;
+    if (params.page_size !== undefined) queryParams['page_size'] = params.page_size;
+    if (params.q !== undefined) queryParams['q'] = params.q;
+    if (params.types !== undefined && params.types.length > 0) {
+      queryParams['types'] = params.types.join(',');
+    }
+
+    this.logger.info(`Getting resources for page: ${params.idx}`);
+
+    return this.httpClient.get<ResourcesResponse>(`/v1/pages/${params.idx}/resources`, queryParams);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/api_operations/resource/index.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/api_operations/resource/index.ts
@@ -1,0 +1,2 @@
+export { GetResourcesOperation } from './get-resources.operation.js';
+export type { GetResourcesParams } from './get-resources.operation.js';

--- a/packages/servers/yandex-wiki/src/wiki_api/dto/grid/columns.dto.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/dto/grid/columns.dto.ts
@@ -1,4 +1,4 @@
-import type { GridColumn } from '#wiki_api/entities/index.js';
+import type { InputGridColumn } from '#wiki_api/entities/index.js';
 
 /**
  * DTO для добавления колонок
@@ -11,7 +11,7 @@ export interface AddColumnsDto {
   position?: number;
 
   /** Колонки (обязательно) */
-  columns: Omit<GridColumn, 'id'>[];
+  columns: InputGridColumn[];
 }
 
 /**

--- a/packages/servers/yandex-wiki/src/wiki_api/dto/grid/rows.dto.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/dto/grid/rows.dto.ts
@@ -16,8 +16,8 @@ export interface AddRowsDto {
   /** Данные строк (обязательно) */
   rows: Array<{
     row: unknown[];
-    pinned?: boolean;
-    color?: BGColor;
+    pinned?: boolean | undefined;
+    color?: BGColor | undefined;
   }>;
 }
 

--- a/packages/servers/yandex-wiki/src/wiki_api/entities/grid.entity.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/entities/grid.entity.ts
@@ -36,7 +36,7 @@ export type BGColor =
   | 'ocean';
 
 /**
- * Колонка таблицы
+ * Колонка таблицы (response)
  */
 export interface GridColumn {
   readonly id?: string;
@@ -52,6 +52,24 @@ export interface GridColumn {
   readonly multiple?: boolean;
   readonly select_options?: string[];
   readonly description?: string;
+}
+
+/**
+ * Колонка таблицы для ввода (request) - поддерживает undefined для zod schemas
+ */
+export interface InputGridColumn {
+  readonly title: string;
+  readonly slug: string;
+  readonly type: ColumnType;
+  readonly required: boolean;
+  readonly color?: BGColor | undefined;
+  readonly width?: number | undefined;
+  readonly width_units?: '%' | 'px' | undefined;
+  readonly pinned?: 'left' | 'right' | undefined;
+  readonly format?: TextFormat | undefined;
+  readonly multiple?: boolean | undefined;
+  readonly select_options?: string[] | undefined;
+  readonly description?: string | undefined;
 }
 
 /**

--- a/packages/servers/yandex-wiki/src/wiki_api/entities/index.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/entities/index.ts
@@ -14,6 +14,7 @@ export type {
   TextFormat,
   BGColor,
   GridColumn,
+  InputGridColumn,
   GridRow,
   SortConfig,
   GridStructure,

--- a/packages/servers/yandex-wiki/src/wiki_api/facade/services/grid.service.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/facade/services/grid.service.ts
@@ -1,0 +1,95 @@
+import { injectable, inject } from 'inversify';
+import {
+  CreateGridOperation,
+  GetGridOperation,
+  UpdateGridOperation,
+  DeleteGridOperation,
+  AddRowsOperation,
+  RemoveRowsOperation,
+  AddColumnsOperation,
+  RemoveColumnsOperation,
+  UpdateCellsOperation,
+  MoveRowsOperation,
+  MoveColumnsOperation,
+  CloneGridOperation,
+} from '#wiki_api/api_operations/index.js';
+import type { GetGridParams, DeleteGridResult } from '#wiki_api/api_operations/index.js';
+import type { GridWithUnknownFields, AsyncOperation } from '#wiki_api/entities/index.js';
+import type {
+  CreateGridDto,
+  UpdateGridDto,
+  AddRowsDto,
+  RemoveRowsDto,
+  AddColumnsDto,
+  RemoveColumnsDto,
+  UpdateCellsDto,
+  MoveRowDto,
+  MoveColumnDto,
+  CloneGridDto,
+} from '#wiki_api/dto/index.js';
+
+@injectable()
+export class GridService {
+  constructor(
+    @inject(CreateGridOperation) private readonly createGridOp: CreateGridOperation,
+    @inject(GetGridOperation) private readonly getGridOp: GetGridOperation,
+    @inject(UpdateGridOperation) private readonly updateGridOp: UpdateGridOperation,
+    @inject(DeleteGridOperation) private readonly deleteGridOp: DeleteGridOperation,
+    @inject(AddRowsOperation) private readonly addRowsOp: AddRowsOperation,
+    @inject(RemoveRowsOperation) private readonly removeRowsOp: RemoveRowsOperation,
+    @inject(AddColumnsOperation) private readonly addColumnsOp: AddColumnsOperation,
+    @inject(RemoveColumnsOperation) private readonly removeColumnsOp: RemoveColumnsOperation,
+    @inject(UpdateCellsOperation) private readonly updateCellsOp: UpdateCellsOperation,
+    @inject(MoveRowsOperation) private readonly moveRowsOp: MoveRowsOperation,
+    @inject(MoveColumnsOperation) private readonly moveColumnsOp: MoveColumnsOperation,
+    @inject(CloneGridOperation) private readonly cloneGridOp: CloneGridOperation
+  ) {}
+
+  async createGrid(data: CreateGridDto): Promise<GridWithUnknownFields> {
+    return this.createGridOp.execute(data);
+  }
+
+  async getGrid(params: GetGridParams): Promise<GridWithUnknownFields> {
+    return this.getGridOp.execute(params);
+  }
+
+  async updateGrid(idx: string, data: UpdateGridDto): Promise<GridWithUnknownFields> {
+    return this.updateGridOp.execute(idx, data);
+  }
+
+  async deleteGrid(idx: string): Promise<DeleteGridResult> {
+    return this.deleteGridOp.execute(idx);
+  }
+
+  async addRows(idx: string, data: AddRowsDto): Promise<GridWithUnknownFields> {
+    return this.addRowsOp.execute(idx, data);
+  }
+
+  async removeRows(idx: string, data: RemoveRowsDto): Promise<GridWithUnknownFields> {
+    return this.removeRowsOp.execute(idx, data);
+  }
+
+  async addColumns(idx: string, data: AddColumnsDto): Promise<GridWithUnknownFields> {
+    return this.addColumnsOp.execute(idx, data);
+  }
+
+  async removeColumns(idx: string, data: RemoveColumnsDto): Promise<GridWithUnknownFields> {
+    return this.removeColumnsOp.execute(idx, data);
+  }
+
+  async updateCells(idx: string, data: UpdateCellsDto): Promise<GridWithUnknownFields> {
+    return this.updateCellsOp.execute(idx, data);
+  }
+
+  async moveRows(idx: string, data: MoveRowDto): Promise<GridWithUnknownFields> {
+    return this.moveRowsOp.execute(idx, data);
+  }
+
+  async moveColumns(idx: string, data: MoveColumnDto): Promise<GridWithUnknownFields> {
+    return this.moveColumnsOp.execute(idx, data);
+  }
+
+  async cloneGrid(idx: string, data: CloneGridDto): Promise<AsyncOperation> {
+    return this.cloneGridOp.execute(idx, data);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/facade/services/index.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/facade/services/index.ts
@@ -1,1 +1,3 @@
 export { PageService } from './page.service.js';
+export { GridService } from './grid.service.js';
+export { ResourceService } from './resource.service.js';

--- a/packages/servers/yandex-wiki/src/wiki_api/facade/services/resource.service.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/facade/services/resource.service.ts
@@ -1,0 +1,15 @@
+import { injectable, inject } from 'inversify';
+import { GetResourcesOperation } from '#wiki_api/api_operations/index.js';
+import type { GetResourcesParams } from '#wiki_api/api_operations/index.js';
+import type { ResourcesResponse } from '#wiki_api/entities/index.js';
+
+@injectable()
+export class ResourceService {
+  constructor(
+    @inject(GetResourcesOperation) private readonly getResourcesOp: GetResourcesOperation
+  ) {}
+
+  async getResources(params: GetResourcesParams): Promise<ResourcesResponse> {
+    return this.getResourcesOp.execute(params);
+  }
+}

--- a/packages/servers/yandex-wiki/src/wiki_api/facade/yandex-wiki.facade.ts
+++ b/packages/servers/yandex-wiki/src/wiki_api/facade/yandex-wiki.facade.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from 'inversify';
-import { PageService } from './services/index.js';
+import { PageService, GridService, ResourceService } from './services/index.js';
 import type {
   GetPageParams,
   GetPageByIdParams,
@@ -7,9 +7,29 @@ import type {
   UpdatePageParams,
   AppendContentParams,
   DeletePageResult,
+  GetGridParams,
+  DeleteGridResult,
+  GetResourcesParams,
 } from '#wiki_api/api_operations/index.js';
-import type { PageWithUnknownFields, AsyncOperation } from '#wiki_api/entities/index.js';
-import type { ClonePageDto } from '#wiki_api/dto/index.js';
+import type {
+  PageWithUnknownFields,
+  GridWithUnknownFields,
+  AsyncOperation,
+  ResourcesResponse,
+} from '#wiki_api/entities/index.js';
+import type {
+  ClonePageDto,
+  CreateGridDto,
+  UpdateGridDto,
+  AddRowsDto,
+  RemoveRowsDto,
+  AddColumnsDto,
+  RemoveColumnsDto,
+  UpdateCellsDto,
+  MoveRowDto,
+  MoveColumnDto,
+  CloneGridDto,
+} from '#wiki_api/dto/index.js';
 
 /**
  * Фасад для работы с API Yandex Wiki
@@ -20,7 +40,11 @@ import type { ClonePageDto } from '#wiki_api/dto/index.js';
  */
 @injectable()
 export class YandexWikiFacade {
-  constructor(@inject(PageService) private readonly pageService: PageService) {}
+  constructor(
+    @inject(PageService) private readonly pageService: PageService,
+    @inject(GridService) private readonly gridService: GridService,
+    @inject(ResourceService) private readonly resourceService: ResourceService
+  ) {}
 
   // === Page Methods ===
 
@@ -73,5 +97,102 @@ export class YandexWikiFacade {
    */
   async appendContent(params: AppendContentParams): Promise<PageWithUnknownFields> {
     return this.pageService.appendContent(params);
+  }
+
+  // === Grid Methods ===
+
+  /**
+   * Создает динамическую таблицу
+   */
+  async createGrid(data: CreateGridDto): Promise<GridWithUnknownFields> {
+    return this.gridService.createGrid(data);
+  }
+
+  /**
+   * Получает динамическую таблицу
+   */
+  async getGrid(params: GetGridParams): Promise<GridWithUnknownFields> {
+    return this.gridService.getGrid(params);
+  }
+
+  /**
+   * Обновляет динамическую таблицу
+   */
+  async updateGrid(idx: string, data: UpdateGridDto): Promise<GridWithUnknownFields> {
+    return this.gridService.updateGrid(idx, data);
+  }
+
+  /**
+   * Удаляет динамическую таблицу
+   * @returns recovery_token для восстановления
+   */
+  async deleteGrid(idx: string): Promise<DeleteGridResult> {
+    return this.gridService.deleteGrid(idx);
+  }
+
+  /**
+   * Добавляет строки в таблицу
+   */
+  async addRows(idx: string, data: AddRowsDto): Promise<GridWithUnknownFields> {
+    return this.gridService.addRows(idx, data);
+  }
+
+  /**
+   * Удаляет строки из таблицы
+   */
+  async removeRows(idx: string, data: RemoveRowsDto): Promise<GridWithUnknownFields> {
+    return this.gridService.removeRows(idx, data);
+  }
+
+  /**
+   * Добавляет колонки в таблицу
+   */
+  async addColumns(idx: string, data: AddColumnsDto): Promise<GridWithUnknownFields> {
+    return this.gridService.addColumns(idx, data);
+  }
+
+  /**
+   * Удаляет колонки из таблицы
+   */
+  async removeColumns(idx: string, data: RemoveColumnsDto): Promise<GridWithUnknownFields> {
+    return this.gridService.removeColumns(idx, data);
+  }
+
+  /**
+   * Обновляет ячейки в таблице
+   */
+  async updateCells(idx: string, data: UpdateCellsDto): Promise<GridWithUnknownFields> {
+    return this.gridService.updateCells(idx, data);
+  }
+
+  /**
+   * Перемещает строки в таблице
+   */
+  async moveRows(idx: string, data: MoveRowDto): Promise<GridWithUnknownFields> {
+    return this.gridService.moveRows(idx, data);
+  }
+
+  /**
+   * Перемещает колонки в таблице
+   */
+  async moveColumns(idx: string, data: MoveColumnDto): Promise<GridWithUnknownFields> {
+    return this.gridService.moveColumns(idx, data);
+  }
+
+  /**
+   * Клонирует динамическую таблицу
+   * @returns AsyncOperation с status_url для отслеживания
+   */
+  async cloneGrid(idx: string, data: CloneGridDto): Promise<AsyncOperation> {
+    return this.gridService.cloneGrid(idx, data);
+  }
+
+  // === Resource Methods ===
+
+  /**
+   * Получает ресурсы страницы (вложения, таблицы, SharePoint ресурсы)
+   */
+  async getResources(params: GetResourcesParams): Promise<ResourcesResponse> {
+    return this.resourceService.getResources(params);
   }
 }


### PR DESCRIPTION
Реализована полная поддержка Grids API (12 методов) и Resources API (1 метод):

Grid Operations:
- CreateGrid, GetGrid, UpdateGrid, DeleteGrid
- AddRows, RemoveRows, MoveRows
- AddColumns, RemoveColumns, MoveColumns
- UpdateCells, CloneGrid

Grid Tools:
- yw_create_grid, yw_get_grid, yw_update_grid, yw_delete_grid
- yw_add_rows, yw_remove_rows, yw_move_rows
- yw_add_columns, yw_remove_columns, yw_move_columns
- yw_update_cells, yw_clone_grid

Resources API:
- GetResourcesOperation, ResourceService, yw_get_resources

Infrastructure:
- Добавлен RESOURCES в ToolCategory
- Добавлена поддержка body в httpClient.delete()
- Добавлен InputGridColumn для exactOptionalPropertyTypes

🤖 Generated with Claude Code